### PR TITLE
Bump content models to 4.15.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'reverse_markdown' # TODO: Used by FCOTravelAdviceScraper. Safe to remove th
 if ENV['CONTENT_MODELS_DEV']
   gem 'govuk_content_models', :path => '../govuk_content_models'
 else
-  gem "govuk_content_models", "4.14.0"
+  gem "govuk_content_models", "4.15.0"
 end
 
 if ENV['API_DEV']

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
       htmlentities (~> 4)
       kramdown (~> 0.13.3)
       sanitize (= 2.0.3)
-    govuk_content_models (4.14.0)
+    govuk_content_models (4.15.0)
       bson_ext
       differ
       gds-api-adapters
@@ -286,7 +286,7 @@ DEPENDENCIES
   formtastic-bootstrap!
   gds-api-adapters (= 5.3.0)
   gds-sso (= 3.0.0)
-  govuk_content_models (= 4.14.0)
+  govuk_content_models (= 4.15.0)
   jquery-rails (= 2.0.2)
   less-rails-bootstrap
   mongo (= 1.6.2)


### PR DESCRIPTION
This fixes the issue where parts were not being saved in the correct
order when an edition was saved.
