### PR TITLE
Bump therubyracer to match static

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ else
   gem 'gds-api-adapters', '5.3.0'
 end
 
-gem 'therubyracer'
+gem 'therubyracer', '0.12.0'
 gem 'jquery-rails', '2.0.2' # TODO: Newer versions break publisher sortable parts. Will need attention.
 gem 'less-rails-bootstrap'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,7 +136,7 @@ GEM
       less (~> 2.2.0)
     less-rails-bootstrap (2.2.0)
       less-rails (~> 2.2.0)
-    libv8 (3.3.10.4)
+    libv8 (3.16.14.3)
     libwebsocket (0.1.7.1)
       addressable
       websocket
@@ -216,6 +216,7 @@ GEM
     rake (10.1.0)
     rdoc (3.12.2)
       json (~> 1.4)
+    ref (1.0.5)
     rest-client (1.6.7)
       mime-types (>= 1.16)
     rspec-core (2.12.1)
@@ -249,8 +250,9 @@ GEM
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
     state_machine (1.2.0)
-    therubyracer (0.10.2)
-      libv8 (~> 3.3.10)
+    therubyracer (0.12.0)
+      libv8 (~> 3.16.14.0)
+      ref
     thor (0.18.1)
     tilt (1.4.1)
     timecop (0.5.9.2)
@@ -303,7 +305,7 @@ DEPENDENCIES
   rails (= 3.2.16)
   rspec-rails (= 2.12.0)
   simplecov-rcov (= 0.2.3)
-  therubyracer
+  therubyracer (= 0.12.0)
   timecop (= 0.5.9.2)
   uglifier (>= 1.0.3)
   unicorn


### PR DESCRIPTION
Bump to 0.12.0 which is compilable with Mavericks and matches the version used in `static`.
