### PR TITLE
Fix need ID related problem

### DIFF
--- a/lib/registerable_travel_advice_edition.rb
+++ b/lib/registerable_travel_advice_edition.rb
@@ -23,8 +23,8 @@ class RegisterableTravelAdviceEdition
     "foreign-travel-advice/#{@edition.country_slug}"
   end
 
-  def need_id
-    133
+  def need_ids
+    ['101191']
   end
 
   def paths

--- a/spec/lib/registerable_travel_advice_edition_spec.rb
+++ b/spec/lib/registerable_travel_advice_edition_spec.rb
@@ -48,8 +48,8 @@ describe RegisterableTravelAdviceEdition do
       @registerable.indexable_content.should == @edition.indexable_content
     end
 
-    it "should return 133 for the need_id" do
-      @registerable.need_id.should == 133
+    it "should return ['101191'] for the need_ids" do
+      @registerable.need_ids.should == ['101191']
     end
 
     it "should return /<slug>.atom for the paths" do


### PR DESCRIPTION
User of travel advice publisher were unable to publish updated country information.

Panopticon now expects Maslow need IDs and this app was sending the old Needotron need id.

https://www.pivotaltracker.com/story/show/70424796
