### PR TITLE
Old Need ID was found in a rake task.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,9 @@ end
 module TravelAdvicePublisher
   mattr_accessor :asset_api
 
+  # Maslow need ID for Travel Advice Publisher
+  NEED_ID = '101191'
+
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/lib/registerable_travel_advice_edition.rb
+++ b/lib/registerable_travel_advice_edition.rb
@@ -24,7 +24,7 @@ class RegisterableTravelAdviceEdition
   end
 
   def need_ids
-    ['101191']
+    [TravelAdvicePublisher::NEED_ID]
   end
 
   def paths

--- a/lib/tasks/panopticon.rake
+++ b/lib/tasks/panopticon.rake
@@ -15,7 +15,7 @@ namespace :panopticon do
     record = OpenStruct.new(
       slug: slug,
       title: "Foreign travel advice",
-      need_id: 133,
+      need_ids: [TravelAdvicePublisher::NEED_ID],
       paths: ["/#{slug}", "/#{slug}.json", "/#{slug}.atom"],
       prefixes: [],
       description: "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/70424796

Old Need ID was found in a Rake task that wasn't picked up in the tests, but on CI building.

Pull out application constant for the Need ID and use it in both places.
