### PR TITLE
Fix connections to asset-manager in development.

### DIFF
--- a/config/initializers/asset_manager.rb
+++ b/config/initializers/asset_manager.rb
@@ -1,4 +1,6 @@
+# This file is overwritten on deploy
+
 require 'gds_api/asset_manager'
 require 'plek'
 
-TravelAdvicePublisher.asset_api = GdsApi::AssetManager.new(Plek.current.find('asset-manager'))
+TravelAdvicePublisher.asset_api = GdsApi::AssetManager.new(Plek.current.find('asset-manager'), :bearer_token => "12345678")


### PR DESCRIPTION
With the changes to gds-sso in #68, the dummy mode bearer token auth
only works if a token is given (it doesn't matter what it is, only that
one is sent).
