### PR TITLE
Remove Analytics due to gem bump

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,17 +2,6 @@
   <%= stylesheet_link_tag "application", :media => "all" %>
   <%= javascript_include_tag 'application' %>
   <%= csrf_meta_tags %>
-  <% if Rails.env.production? %>
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-      ga('create', 'UA-26179049-6', 'alphagov.co.uk');
-      ga('send', 'pageview');
-    </script>
-  <% end %>
 <% end %>
 
 <% content_for :favicon do %>


### PR DESCRIPTION
govuk-admin-template was bumped to 2.3.1, which now handles google
analytics; therefore analytics code in application.html.erb can be removed.