### PR TITLE
Send content_ids to panopticon.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '20.1.1'
+  gem 'gds-api-adapters', '~> 24.2.0'
 end
 
 gem 'therubyracer', '0.12.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ GEM
       actionpack (>= 3.0)
     formtastic-bootstrap (3.0.0)
       formtastic (>= 2.2)
-    gds-api-adapters (20.1.1)
+    gds-api-adapters (24.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -287,7 +287,7 @@ DEPENDENCIES
   factory_girl_rails
   formtastic (= 2.3.0)
   formtastic-bootstrap (= 3.0.0)
-  gds-api-adapters (= 20.1.1)
+  gds-api-adapters (~> 24.2.0)
   gds-sso (= 10.0.0)
   govuk_admin_template (= 2.3.1)
   govuk_content_models (= 27.1.0)

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -1,10 +1,11 @@
 class Country
 
-  attr_reader :name, :slug
+  attr_reader :name, :slug, :content_id
 
   def initialize(attrs)
     @name = attrs['name']
     @slug = attrs['slug']
+    @content_id = attrs['content_id']
   end
 
   def editions

--- a/lib/data/countries.yml
+++ b/lib/data/countries.yml
@@ -1,455 +1,682 @@
 ---
 - name: Afghanistan
   slug: afghanistan
+  content_id: 5a292f20-a9b6-46ea-b35f-584f8b3d7392
 - name: Albania
   slug: albania
+  content_id: 2a3938e1-d588-45fc-8c8f-0f51814d5409
 - name: Algeria
   slug: algeria
+  content_id: b5c8e64b-3461-4447-9144-1588e4a84fe6
 - name: American Samoa
   slug: american-samoa
+  content_id: 3b54054f-c22a-4e3a-8c10-19d0667b5718
 - name: Andorra
   slug: andorra
+  content_id: 196a0c49-e844-4246-ab7c-a5c4197dfdad
 - name: Angola
   slug: angola
+  content_id: 9738a4db-236d-4116-8d19-1373987b7889
 - name: Anguilla
   slug: anguilla
+  content_id: fb061c13-3130-4338-b4c3-df3a2ab4c112
 - name: Antigua and Barbuda
   slug: antigua-and-barbuda
+  content_id: 269db8e5-9fef-4840-aca4-4896c66b8329
 - name: Argentina
   slug: argentina
+  content_id: 5393a385-63f9-466f-a851-422f249d06f8
 - name: Armenia
   slug: armenia
+  content_id: a306037b-bed2-4607-aab6-eb5a8fa51882
 - name: Aruba
   slug: aruba
+  content_id: 56bae85b-a57c-4ca2-9dbd-68361a086bb3
 - name: Australia
   slug: australia
+  content_id: 48baf826-7d71-4fea-a9c4-9730fd30eb9e
 - name: Austria
   slug: austria
+  content_id: b662d0a3-c20d-4167-8056-b9c7d058d860
 - name: Azerbaijan
   slug: azerbaijan
+  content_id: f68b6778-cb3b-4c0b-82a0-b90613fdda26
 - name: Bahamas
   slug: bahamas
+  content_id: ac5f0376-62ef-4f8f-8fbe-6dc6c2e4a671
 - name: Bahrain
   slug: bahrain
+  content_id: 66c3e499-0a63-42e0-833d-8b847e70e229
 - name: Bangladesh
   slug: bangladesh
+  content_id: 266ca3b6-752f-400b-91c0-8b9c3c433d2d
 - name: Barbados
   slug: barbados
+  content_id: d37300da-5fca-4247-b9fc-7ae770ee992b
 - name: Belarus
   slug: belarus
+  content_id: a73a1811-a1a0-474c-ad2c-30dc0ab74495
 - name: Belgium
   slug: belgium
+  content_id: 7631e836-3295-403d-b031-09d563322511
 - name: Belize
   slug: belize
+  content_id: 7e521913-0947-4c45-afc0-9ee91efd9434
 - name: Benin
   slug: benin
+  content_id: 9ce921df-748d-4efe-99b0-fc5bcd2ec045
 - name: Bermuda
   slug: bermuda
+  content_id: 186abab7-2e5c-40cd-a4f2-e3f5cfcdbde9
 - name: Bhutan
   slug: bhutan
+  content_id: f53a97fb-4bc3-46d2-898b-d2a1e460cd0e
 - name: Bolivia
   slug: bolivia
+  content_id: 2f6708c2-9a26-4949-8eb7-824e601ee377
 - name: Bonaire/St Eustatius/Saba
   slug: bonaire-st-eustatius-saba
+  content_id: a33df5a7-34ec-4ff1-ad23-656f3d7d0331
 - name: Bosnia and Herzegovina
   slug: bosnia-and-herzegovina
+  content_id: 49bcb1b3-69b8-4351-84af-adb907ce3d2b
 - name: Botswana
   slug: botswana
+  content_id: 72181a48-c553-45e4-aa5a-ebe232acea00
 - name: Brazil
   slug: brazil
+  content_id: eaec959e-d3e2-4e69-9caa-a5fbf117c790
 - name: British Antarctic Territory
   slug: british-antarctic-territory
+  content_id: 7a2554bd-9dc5-4a2e-953c-263c65ced66b
 - name: British Indian Ocean Territory
   slug: british-indian-ocean-territory
+  content_id: 081268be-3cc3-4ced-9488-066532b7dea1
 - name: British Virgin Islands
   slug: british-virgin-islands
+  content_id: 59bfd21e-90ee-414f-acc8-696b641d4363
 - name: Brunei
   slug: brunei
+  content_id: 65a38090-2d1c-4e45-9ebd-8638085933f1
 - name: Bulgaria
   slug: bulgaria
+  content_id: 94aa06ba-2d58-4299-88ba-8861acc18729
 - name: Burkina Faso
   slug: burkina-faso
+  content_id: 9ac225d7-ea48-401b-b255-7f281d2c4168
 - name: Burma
   slug: burma
+  content_id: ed343e59-83ca-496b-84b1-8f85c71a747d
 - name: Burundi
   slug: burundi
+  content_id: d13008f0-a794-47e2-a9fe-773ffe6bc0b5
 - name: Cambodia
   slug: cambodia
+  content_id: 8f98f704-65d6-44bc-8047-915066809df5
 - name: Cameroon
   slug: cameroon
+  content_id: 677b18e8-cec2-4d2b-b978-708d14565c94
 - name: Canada
   slug: canada
+  content_id: f402b8de-2e99-4ff3-949f-31fe65796cae
 - name: Cape Verde
   slug: cape-verde
+  content_id: a9296394-be3d-4bf2-a443-20d09a628bce
 - name: Cayman Islands
   slug: cayman-islands
+  content_id: 317ef779-a84c-422f-9497-ccd0bf3174ef
 - name: Central African Republic
   slug: central-african-republic
+  content_id: f52ed25a-1c8f-497b-938e-066d008d5d73
 - name: Chad
   slug: chad
+  content_id: 5b3924c1-2907-4549-9fea-499ca43e66b4
 - name: Chile
   slug: chile
+  content_id: 09921127-6706-4893-874f-5c943b3f1c38
 - name: China
   slug: china
+  content_id: cb91b5b1-d4af-43d6-a9ea-48d56fe03300
 - name: Colombia
   slug: colombia
+  content_id: 8c40f35a-ff29-4d28-93cf-90e4432de4e5
 - name: Comoros
   slug: comoros
+  content_id: 8236701c-0e96-4cfe-b315-2bd6b3e3b028
 - name: Congo
   slug: congo
+  content_id: 438a3cd3-5936-462d-b7ed-fff0ea485af1
 - name: Costa Rica
   slug: costa-rica
+  content_id: f47beb28-e218-4b1a-bd4b-3c4165d056b5
 - name: "Côte d'Ivoire"
   slug: cote-d-ivoire
+  content_id: 9652542c-e5bd-4416-bbbd-5e3e19609863
 - name: Croatia
   slug: croatia
+  content_id: f531e87f-78f5-4d67-9515-79c7cedbd5c4
 - name: Cuba
   slug: cuba
+  content_id: d1055857-ece4-4862-9fe1-493545e9fede
 - name: "Curaçao"
   slug: curacao
+  content_id: 60f02e47-4f6b-4873-8819-1dd913cd5df2
 - name: Cyprus
   slug: cyprus
+  content_id: d35026df-3ea6-452e-870b-71bdfb7cf73e
 - name: Czech Republic
   slug: czech-republic
+  content_id: b5e5c48e-dac9-4443-a7cc-8042ccdf8404
 - name: Democratic Republic of Congo
   slug: democratic-republic-of-congo
+  content_id: 88122213-1a2f-420f-94f9-c622147d4300
 - name: Denmark
   slug: denmark
+  content_id: 8d0d439c-dcf3-4239-8049-4a7c465baad6
 - name: Djibouti
   slug: djibouti
+  content_id: 0b95dd6d-7234-4d04-a7a6-b412447cc2d5
 - name: Dominica
   slug: dominica
+  content_id: f0615634-9fbf-46f5-8435-5ae2d23698b6
 - name: Dominican Republic
   slug: dominican-republic
+  content_id: 38051402-bf94-47ab-9ad7-a468280f3d9e
 - name: Ecuador
   slug: ecuador
+  content_id: aa3bb093-06ac-4423-b242-e62ba4a4cf7d
 - name: Egypt
   slug: egypt
+  content_id: 52e41c89-6f2c-4db6-9370-6d41fb44fd0f
 - name: El Salvador
   slug: el-salvador
+  content_id: 68964c7a-351f-41ae-a7f1-ecfa94263c56
 - name: Equatorial Guinea
   slug: equatorial-guinea
+  content_id: 1907e0cd-778e-49d6-95f1-1d9b3e790c2e
 - name: Eritrea
   slug: eritrea
+  content_id: 6b47e9b9-0942-48b5-8ee1-778699ac95f0
 - name: Estonia
   slug: estonia
+  content_id: 16ae2d80-d6e0-4380-a358-ccd03c2bd7f7
 - name: Ethiopia
   slug: ethiopia
+  content_id: d36e7377-4160-4e4d-a103-83980eaf9dc9
 - name: Falkland Islands
   slug: falkland-islands
+  content_id: 61a1542f-d196-42a0-9605-ad667b60504e
 - name: Fiji
   slug: fiji
+  content_id: 4b79ee8f-0217-486b-bcc9-5f0ef9c16b54
 - name: Finland
   slug: finland
+  content_id: f14f4107-1731-4dd8-a890-8defe459e15a
 - name: France
   slug: france
+  content_id: 05a8e85c-5a65-406e-923d-79c04a4433f6
 - name: French Guiana
   slug: french-guiana
+  content_id: 020d58a7-f069-4eb8-bdf2-9979e7196ba4
 - name: French Polynesia
   slug: french-polynesia
+  content_id: 8dae3061-8bc3-4deb-8ac5-723957597716
 - name: Gabon
   slug: gabon
+  content_id: fe2044fc-4201-4116-89fd-126aaff9a987
 - name: Gambia
   slug: gambia
+  content_id: 35007dbc-65c9-418b-9ce8-3d28832eb8ee
 - name: Georgia
   slug: georgia
+  content_id: 05b21330-97be-45f0-9ddf-778c722bd116
 - name: Germany
   slug: germany
+  content_id: c3d72e08-e00f-4b62-98d5-010ea1520e50
 - name: Ghana
   slug: ghana
+  content_id: eca820fa-0cb2-4d26-a642-be0c041da22d
 - name: Gibraltar
   slug: gibraltar
+  content_id: 726afbd8-e8d1-4ef8-a3a8-9d0a4c467014
 - name: Greece
   slug: greece
+  content_id: c5018a34-3aaa-40e4-b90f-cf73539a0978
 - name: Grenada
   slug: grenada
+  content_id: 674324d7-8cb1-4a4d-8480-112b0ab776c9
 - name: Guadeloupe
   slug: guadeloupe
+  content_id: faad8241-f19d-4762-ba38-3b8871b5b10b
 - name: Guatemala
   slug: guatemala
+  content_id: 4c5a2c31-5e39-413b-ba7c-b87e86f8b2b4
 - name: Guinea
   slug: guinea
+  content_id: 1986f9ec-a8dc-4e07-8f93-cd10d65a3e10
 - name: Guinea-Bissau
   slug: guinea-bissau
+  content_id: b9f2cdf8-140e-4c97-9fcf-2e308798a294
 - name: Guyana
   slug: guyana
+  content_id: b2e8eed8-96d7-45e4-8c7b-20d263e6487e
 - name: Haiti
   slug: haiti
+  content_id: a6d54a9d-12f7-49e4-84bc-3b5167489ce5
 - name: Holy See
   slug: holy-see
+  content_id: 2b2966b7-dbff-44b0-80e3-e3f6013e19e0
 - name: Honduras
   slug: honduras
+  content_id: 80d80224-d917-4d7a-881e-1122fe1e7799
 - name: Hong Kong
   slug: hong-kong
+  content_id: 78fe3dfe-d561-434d-9db6-970c70597b3d
 - name: Hungary
   slug: hungary
+  content_id: 715dc6fa-15fe-40fc-a4ba-f5274142d921
 - name: Iceland
   slug: iceland
+  content_id: 0e0f3be9-5805-43c5-9535-b42a88219ea6
 - name: India
   slug: india
+  content_id: ea7e300b-24dd-40af-afde-fd690a2df678
 - name: Indonesia
   slug: indonesia
+  content_id: e2c44bf1-0b96-4034-9ac8-96f6e0181a80
 - name: Iran
   slug: iran
+  content_id: 05bc5265-c585-4b5c-b813-c8f245ddfc7f
 - name: Iraq
   slug: iraq
+  content_id: bba7f111-b07f-461d-9bab-8a7366aabd40
 - name: Ireland
   slug: ireland
+  content_id: 9affaaf6-e7b5-416d-b806-d8e7c0cb0cbf
 - name: Israel
   slug: israel
+  content_id: 250a060b-d764-4e0c-b131-dc2d10c3160e
 - name: Italy
   slug: italy
+  content_id: 00a2d263-f4cc-4ed1-9ae8-ce5e73ce4d30
 - name: Jamaica
   slug: jamaica
+  content_id: 1def455a-6ee1-4235-b109-3b485a208b84
 - name: Japan
   slug: japan
+  content_id: 8a8de3c7-0b94-4670-87a7-f110d789d3d3
 - name: Jerusalem
   slug: jerusalem
+  content_id: ed9e128f-2672-463b-bd24-f7dee3ddfe10
 - name: Jordan
   slug: jordan
+  content_id: a03f9a35-51a9-47a8-95b5-2e4bcdaa5dd8
 - name: Kazakhstan
   slug: kazakhstan
+  content_id: 172402e4-e1c9-4739-bae5-80bf1d1005c3
 - name: Kenya
   slug: kenya
+  content_id: 47d7619a-8621-49bc-8e67-75e06b3fb610
 - name: Kiribati
   slug: kiribati
+  content_id: d68b6113-2270-41a2-85cc-97b494d65cb6
 - name: Kosovo
   slug: kosovo
+  content_id: 261a33bd-bf2f-401e-b5e1-31d0b085f4ae
 - name: Kuwait
   slug: kuwait
+  content_id: bb97fe15-ec47-4968-a2e8-1922e5916cb4
 - name: Kyrgyzstan
   slug: kyrgyzstan
+  content_id: 6cd1bdd0-0afc-492f-bae9-6cc219213b87
 - name: Laos
   slug: laos
+  content_id: 602e34bf-8222-4391-96d9-548dbe1e1799
 - name: Latvia
   slug: latvia
+  content_id: ba3b46db-c2eb-404d-bcdd-63ccd956cebc
 - name: Lebanon
   slug: lebanon
+  content_id: d1ee9570-46b5-421f-a36c-68b5f30b9742
 - name: Lesotho
   slug: lesotho
+  content_id: 1bda9310-85a5-491b-8d33-fc494daeb83e
 - name: Liberia
   slug: liberia
+  content_id: 2bb95e1c-fdf2-4210-8047-210d5c0d6044
 - name: Libya
   slug: libya
+  content_id: 83ed7690-9249-41c3-8525-12a15e46f6ba
 - name: Liechtenstein
   slug: liechtenstein
+  content_id: c8a0bcf9-ddf9-4906-9457-cd179d70ed57
 - name: Lithuania
   slug: lithuania
+  content_id: b6321337-80c2-4f1b-910a-aad4852dc7d7
 - name: Luxembourg
   slug: luxembourg
+  content_id: bfff46a6-c3d8-4881-af8e-e62af3f5a03a
 - name: Macao
   slug: macao
+  content_id: c442b539-cc27-4637-af33-c5d51e0727a8
 - name: Macedonia
   slug: macedonia
+  content_id: 269306a3-45ab-4d96-a004-9abfcb7f7972
 - name: Madagascar
   slug: madagascar
+  content_id: ee0ba11b-98de-4dd5-b66a-b54dfe55cde6
 - name: Malawi
   slug: malawi
+  content_id: 5911a0b5-1d96-49c5-9e83-3ed20a815995
 - name: Malaysia
   slug: malaysia
+  content_id: 126d47f7-5fd2-41ff-af17-b23564355e03
 - name: Maldives
   slug: maldives
+  content_id: 99e0a892-9daa-443c-b96c-97ba9e28a2c8
 - name: Mali
   slug: mali
+  content_id: 19793ecb-fdaf-4b00-a3b8-bab6805c5205
 - name: Malta
   slug: malta
+  content_id: 0b04ef72-ed4f-427c-82fb-851004d9a4d9
 - name: Marshall Islands
   slug: marshall-islands
+  content_id: d8aaa1cd-85d2-4ba6-a825-b13319efa4d8
 - name: Martinique
   slug: martinique
+  content_id: 21c92da9-777e-4dcd-a6fc-dc73b6bb0099
 - name: Mauritania
   slug: mauritania
+  content_id: 15469fdc-d0d1-4a9f-a59e-b3d3acdea226
 - name: Mauritius
   slug: mauritius
+  content_id: 51cc8ddf-0dc6-453a-b721-940068671aff
 - name: Mayotte
   slug: mayotte
+  content_id: 61c6b7aa-a4d1-43a6-8f69-99dd9596ab2d
 - name: Mexico
   slug: mexico
+  content_id: 34dafa2b-24e5-4625-b542-bf5e0bb8cd80
 - name: Micronesia
   slug: micronesia
+  content_id: d010fd00-bf63-42f0-ba7b-0982f49cb3d4
 - name: Moldova
   slug: moldova
+  content_id: 4064154c-ef7e-4edf-9f98-8f747ce39471
 - name: Monaco
   slug: monaco
+  content_id: 09c1d197-d95b-44ea-bc64-489b126c2246
 - name: Mongolia
   slug: mongolia
+  content_id: c5501de2-f581-450d-bdb9-0cfda75b7502
 - name: Montenegro
   slug: montenegro
+  content_id: ec6dceb9-de27-496d-be5d-da7f1dfc25bb
 - name: Montserrat
   slug: montserrat
+  content_id: 03a790cd-d685-4569-a1c6-bf4157f4777d
 - name: Morocco
   slug: morocco
+  content_id: 7584a0dd-accf-4901-a8a6-bc964dc1412f
 - name: Mozambique
   slug: mozambique
+  content_id: eb77a950-bd40-4a8d-8f3b-1f92d126930d
 - name: Namibia
   slug: namibia
+  content_id: 5a2d153e-efc6-4dbc-b3ac-d81e51e4f1f7
 - name: Nauru
   slug: nauru
+  content_id: 6f2af041-91cb-408a-8377-1b41c9d59f23
 - name: Nepal
   slug: nepal
+  content_id: d2ac8d41-054a-4a47-a8f5-9f9a5bb37ad9
 - name: Netherlands
   slug: netherlands
+  content_id: 98641f11-0391-4679-a033-6d79db918d05
 - name: New Caledonia
   slug: new-caledonia
+  content_id: a6b88bf7-e78f-4c0e-9de6-e291ee8a5305
 - name: New Zealand
   slug: new-zealand
+  content_id: 9221e19e-95ea-4045-bafa-1b22671e227c
 - name: Nicaragua
   slug: nicaragua
+  content_id: 864d9605-b3f8-4ed4-a846-0cf948cfea44
 - name: Niger
   slug: niger
+  content_id: 06c5b994-2e2e-41d8-bf14-75885e3887fb
 - name: Nigeria
   slug: nigeria
+  content_id: 7ba86fb6-c102-4d5f-bdcd-39f7702ae0cc
 - name: North Korea
   slug: north-korea
+  content_id: 277fdb72-8046-490f-8076-b3203e20c467
 - name: Norway
   slug: norway
+  content_id: 5db38510-b08a-4e4c-b84f-ca2d62353ab6
 - name: The Occupied Palestinian Territories
   slug: the-occupied-palestinian-territories
+  content_id: 1db59f95-ea74-4cb0-b5c3-9b0724001e17
 - name: Oman
   slug: oman
+  content_id: aa62bc84-6fd0-4665-8b9a-4c4ab5977e8a
 - name: Pakistan
   slug: pakistan
+  content_id: ea339677-8843-4a8a-b5ad-dff327d70ce3
 - name: Palau
   slug: palau
+  content_id: fb9351aa-1fc4-4df1-8d9f-504a89ea5856
 - name: Panama
   slug: panama
+  content_id: a15edf3a-5af1-45b3-8a10-31fcf4bfdbea
 - name: Papua New Guinea
   slug: papua-new-guinea
+  content_id: a55aacc4-9c01-4257-8a72-4cd5c972dceb
 - name: Paraguay
   slug: paraguay
+  content_id: 4a24839c-226b-4f19-8026-c88c4fca3988
 - name: Peru
   slug: peru
+  content_id: a1c8c919-6d66-41cf-ba90-5f51a0b0eb3f
 - name: Philippines
   slug: philippines
+  content_id: 9a7fcd1d-1be5-4342-89ff-a4bd8ecf93e3
 - name: Pitcairn Island
   slug: pitcairn-island
+  content_id: c925efa1-bbda-455a-b45b-7109ab384247
 - name: Poland
   slug: poland
+  content_id: 5931cad1-dc75-4c21-b84e-c176441e0190
 - name: Portugal
   slug: portugal
+  content_id: 84647e7e-66d3-4b91-b562-b2a65c3c0be6
 - name: Qatar
   slug: qatar
+  content_id: 3d94082a-6e41-4c09-ba52-1b282943caae
 - name: "Réunion"
   slug: reunion
+  content_id: 150b2c9a-8958-43a8-a9e8-a24045071289
 - name: Romania
   slug: romania
+  content_id: ddf42429-0853-4737-b75d-2aeaf16b30a0
 - name: Russia
   slug: russia
+  content_id: 821537bc-8189-4347-b04d-3c3029f8c947
 - name: Rwanda
   slug: rwanda
+  content_id: 25d2eeab-5494-4fe7-b558-b478c873923d
 - name: Samoa
   slug: samoa
+  content_id: c3c1f5ef-9041-46ab-a8e2-400d183e8c59
 - name: San Marino
   slug: san-marino
+  content_id: b2967d73-df09-43db-bc64-9d90e468c6b5
 - name: "São Tomé and Principe"
   slug: sao-tome-and-principe
+  content_id: a3605d0c-bf86-41f9-9f50-7bd577052c4c
 - name: Saudi Arabia
   slug: saudi-arabia
+  content_id: a83fb6ba-7c3c-4e32-afe0-d7dce1ea5e6b
 - name: Senegal
   slug: senegal
+  content_id: 4ac15add-d794-4b65-9dfe-3488dcc04fa1
 - name: Serbia
   slug: serbia
+  content_id: e21957c3-680e-4b4a-bc04-589abc3a2b60
 - name: Seychelles
   slug: seychelles
+  content_id: 969f0558-e381-4a34-a8a5-91d106d89050
 - name: Sierra Leone
   slug: sierra-leone
+  content_id: b53b8c14-ae32-46ed-af66-04a6eb350c7a
 - name: Singapore
   slug: singapore
+  content_id: 06ffd544-1097-41b1-90b6-b9a74f78669e
 - name: Slovakia
   slug: slovakia
+  content_id: 9ae32c04-25b7-4627-8ddc-5d5dc7746825
 - name: Slovenia
   slug: slovenia
+  content_id: e380b607-2886-4103-90b8-a044af29772e
 - name: Solomon Islands
   slug: solomon-islands
+  content_id: 44e13401-96f0-4ac1-bfdd-9f0cc0111b40
 - name: Somalia
   slug: somalia
+  content_id: 992befc4-32a3-4a1a-a034-c9cb2ff42bad
 - name: South Africa
   slug: south-africa
+  content_id: e4649806-d58a-40f7-b86d-09a4376c25a0
 - name: South Georgia and the South Sandwich Islands
   slug: south-georgia-and-south-sandwich-islands
+  content_id: 4b0ade17-81e9-4ab2-af5c-c33df84fc0dd
 - name: South Korea
   slug: south-korea
+  content_id: 78f22c79-1f19-4ce2-ab69-2a221c770e52
 - name: South Sudan
   slug: south-sudan
+  content_id: 86224eb2-3686-4558-8405-491d544be4db
 - name: Spain
   slug: spain
+  content_id: 24df0bb1-0ca1-4675-9237-528ecd3d17a5
 - name: Sri Lanka
   slug: sri-lanka
+  content_id: c90dd329-ea2a-413a-b927-a67bd3cbbb84
 - name: St Helena, Ascension and Tristan da Cunha
   slug: st-helena-ascension-and-tristan-da-cunha
+  content_id: ab5bb8cb-92d9-440d-90dc-889d301675af
 - name: St Kitts and Nevis
   slug: st-kitts-and-nevis
+  content_id: e07d2af5-f1a8-47e9-b4ff-33d7ff1178ef
 - name: St Lucia
   slug: st-lucia
+  content_id: 5a9e154c-e1dc-4fde-8182-58c5b6e69efa
 - name: St Maarten
   slug: st-maarten
+  content_id: f752255c-de89-4b61-af7a-6233dd44a58a
 - name: St Pierre & Miquelon
   slug: st-pierre-and-miquelon
+  content_id: 31b8bebb-c8a6-4634-acd7-4e073e23826b
 - name: St Vincent and the Grenadines
   slug: st-vincent-and-the-grenadines
+  content_id: c04c4008-678c-43c0-b4f6-bd542f77fda8
 - name: Sudan
   slug: sudan
+  content_id: deee5c29-5006-4280-bb46-44c0bd7a6a11
 - name: Suriname
   slug: suriname
+  content_id: 0e50ddd6-ee02-4d1c-815b-7f35a8777f72
 - name: Swaziland
   slug: swaziland
+  content_id: cb0448b6-91b4-44fd-b54f-508b554971d1
 - name: Sweden
   slug: sweden
+  content_id: 9772ac3f-b0ea-4787-b859-9a091e1f8af6
 - name: Switzerland
   slug: switzerland
+  content_id: 3985ac9b-d0c0-423b-9936-94a3ac3bed62
 - name: Syria
   slug: syria
+  content_id: 85c16f75-3380-497e-a915-4d77256cde37
 - name: Taiwan
   slug: taiwan
+  content_id: b486e8b6-fbe2-443d-acaa-cc0c5a8b4cfe
 - name: Tajikistan
   slug: tajikistan
+  content_id: 1a06c5d2-9457-477a-a3ea-1ce3b8b44fc1
 - name: Tanzania
   slug: tanzania
+  content_id: 203432b1-e296-4ffe-9fc9-dcfe110c0d67
 - name: Thailand
   slug: thailand
+  content_id: 724a37c1-2f81-40b2-8640-d3d06e74d2bb
 - name: Timor-Leste
   slug: timor-leste
+  content_id: 0b059300-5933-4123-a27a-af603904c8be
 - name: Togo
   slug: togo
+  content_id: 68ee5e60-28d7-40ae-90eb-3d917ece53de
 - name: Tonga
   slug: tonga
+  content_id: 96f71287-395b-435b-94ef-855b0f14e2c6
 - name: Trinidad and Tobago
   slug: trinidad-and-tobago
+  content_id: 2cacdc4c-913b-463a-b29e-4a5f45b67e4e
 - name: Tunisia
   slug: tunisia
+  content_id: 29351cb7-7523-4ab7-8adf-8d2e2c8768b1
 - name: Turkey
   slug: turkey
+  content_id: 385d62b6-1fb3-4b29-80f3-cef2efa73cce
 - name: Turkmenistan
   slug: turkmenistan
+  content_id: ac173bb7-97ce-4dc3-b8a9-dae920d595db
 - name: Turks and Caicos Islands
   slug: turks-and-caicos-islands
+  content_id: f931c121-e8be-4b50-ab51-762e9741834e
 - name: Tuvalu
   slug: tuvalu
+  content_id: b60c33a7-0d98-4d98-a79d-fe48735a2116
 - name: Uganda
   slug: uganda
+  content_id: 77488676-da3d-4752-a6b2-f99c7691bf67
 - name: Ukraine
   slug: ukraine
+  content_id: ed654721-0bf5-415e-ad51-4fe93e6b3a0b
 - name: United Arab Emirates
   slug: united-arab-emirates
+  content_id: 753268f3-f9fb-44bb-bcb2-84a570ea637e
 - name: USA
   slug: usa
+  content_id: f2cecaae-77ce-4df3-bf27-7783c3975706
 - name: Uruguay
   slug: uruguay
+  content_id: 67ab9201-cd93-4ebe-bc2b-085f540705f7
 - name: Uzbekistan
   slug: uzbekistan
+  content_id: 2f79a772-583b-4f01-adc1-5dc832eddcec
 - name: Vanuatu
   slug: vanuatu
+  content_id: 89ce38b7-40fa-46e6-9073-235ac6923425
 - name: Venezuela
   slug: venezuela
+  content_id: ca3a5c2c-1c6a-483d-88a1-5feb813ba4f3
 - name: Vietnam
   slug: vietnam
+  content_id: 8f6e7323-3d10-46da-a1a7-c50b5fc5a5ea
 - name: Wallis and Futuna
   slug: wallis-and-futuna
+  content_id: 714e5775-6655-449e-ac16-2897f8a14f73
 - name: Western Sahara
   slug: western-sahara
+  content_id: 18d6ade3-900d-44ab-b251-ee5f791ba4b4
 - name: Yemen
   slug: yemen
+  content_id: 73891fe3-3a92-4c2e-a1a6-b63f00186ce8
 - name: Zambia
   slug: zambia
+  content_id: 7e2beff5-a1ee-4ed4-ad63-c9a72bb0dc17
 - name: Zimbabwe
   slug: zimbabwe
+  content_id: d38db404-4291-4088-951a-1b8d5b696f1e

--- a/lib/registerable_travel_advice_edition.rb
+++ b/lib/registerable_travel_advice_edition.rb
@@ -23,6 +23,10 @@ class RegisterableTravelAdviceEdition
     "foreign-travel-advice/#{@edition.country_slug}"
   end
 
+  def content_id
+    country.try(:content_id)
+  end
+
   def need_ids
     [TravelAdvicePublisher::NEED_ID]
   end
@@ -33,5 +37,11 @@ class RegisterableTravelAdviceEdition
 
   def prefixes
     ["/#{slug}"]
+  end
+
+  private
+
+  def country
+    Country.find_by_slug(@edition.country_slug)
   end
 end

--- a/lib/tasks/panopticon.rake
+++ b/lib/tasks/panopticon.rake
@@ -14,6 +14,7 @@ namespace :panopticon do
     slug = "foreign-travel-advice"
     record = OpenStruct.new(
       slug: slug,
+      content_id: "08d48cdd-6b50-43ff-a53b-beab47f4aab0",
       title: "Foreign travel advice",
       need_ids: [TravelAdvicePublisher::NEED_ID],
       paths: ["/#{slug}", "/#{slug}.json", "/#{slug}.atom"],

--- a/spec/features/country_index_spec.rb
+++ b/spec/features/country_index_spec.rb
@@ -37,9 +37,9 @@ feature "Country Index" do
       ["Argentina",           "no advice published"],
       ["Armenia",             "no advice published"],
       ["Aruba",               "advice published"],
-      ["Ascension Island",    "no advice published"],
       ["Australia",           "no advice published"],
       ["Austria",             "advice published"],
+      ["Azerbaijan",          "no advice published"],
     ]
   end
 end

--- a/spec/features/edition_edit_spec.rb
+++ b/spec/features/edition_edit_spec.rb
@@ -28,6 +28,17 @@ feature "Edit Edition page", :js => true do
       within(:css, "#history") do
         page.should have_content("New version by Joe Bloggs")
       end
+
+      WebMock.should have_requested(:put, "#{GdsApi::TestHelpers::Panopticon::PANOPTICON_ENDPOINT}/artefacts/foreign-travel-advice/aruba.json").
+        with(:body => hash_including(
+          'slug' => 'foreign-travel-advice/aruba',
+          'content_id' => '56bae85b-a57c-4ca2-9dbd-68361a086bb3', # from countries.yml fixture
+          'name' => 'Aruba travel advice',
+          'kind' => 'travel-advice',
+          'owning_app' => 'travel-advice-publisher',
+          'rendering_app' => 'frontend',
+          'state' => 'draft'
+      ))
     end
 
     scenario "create an edition from an archived edition" do
@@ -335,6 +346,7 @@ feature "Edit Edition page", :js => true do
     WebMock.should have_requested(:put, "#{GdsApi::TestHelpers::Panopticon::PANOPTICON_ENDPOINT}/artefacts/foreign-travel-advice/albania.json").
       with(:body => hash_including(
         'slug' => 'foreign-travel-advice/albania',
+        'content_id' => '2a3938e1-d588-45fc-8c8f-0f51814d5409', # from countries.yml fixture
         'name' => 'Albania travel advice',
         'description' => 'The overview',
         'indexable_content' => 'Summary Part One Body text',

--- a/spec/fixtures/data/countries.yml
+++ b/spec/fixtures/data/countries.yml
@@ -1,29 +1,43 @@
---- 
+---
 - name: Afghanistan
   slug: afghanistan
+  content_id: 5a292f20-a9b6-46ea-b35f-584f8b3d7392
 - name: Albania
   slug: albania
+  content_id: 2a3938e1-d588-45fc-8c8f-0f51814d5409
 - name: Algeria
   slug: algeria
+  content_id: b5c8e64b-3461-4447-9144-1588e4a84fe6
 - name: American Samoa
   slug: american-samoa
+  content_id: 3b54054f-c22a-4e3a-8c10-19d0667b5718
 - name: Andorra
   slug: andorra
+  content_id: 196a0c49-e844-4246-ab7c-a5c4197dfdad
 - name: Angola
   slug: angola
+  content_id: 9738a4db-236d-4116-8d19-1373987b7889
 - name: Anguilla
   slug: anguilla
+  content_id: fb061c13-3130-4338-b4c3-df3a2ab4c112
 - name: Antigua and Barbuda
   slug: antigua-and-barbuda
+  content_id: 269db8e5-9fef-4840-aca4-4896c66b8329
 - name: Argentina
   slug: argentina
+  content_id: 5393a385-63f9-466f-a851-422f249d06f8
 - name: Armenia
   slug: armenia
+  content_id: a306037b-bed2-4607-aab6-eb5a8fa51882
 - name: Aruba
   slug: aruba
-- name: Ascension Island
-  slug: ascension-island
+  content_id: 56bae85b-a57c-4ca2-9dbd-68361a086bb3
 - name: Australia
   slug: australia
+  content_id: 48baf826-7d71-4fea-a9c4-9730fd30eb9e
 - name: Austria
   slug: austria
+  content_id: b662d0a3-c20d-4167-8056-b9c7d058d860
+- name: Azerbaijan
+  slug: azerbaijan
+  content_id: f68b6778-cb3b-4c0b-82a0-b90613fdda26

--- a/spec/lib/registerable_travel_advice_edition_spec.rb
+++ b/spec/lib/registerable_travel_advice_edition_spec.rb
@@ -60,4 +60,21 @@ describe RegisterableTravelAdviceEdition do
       @registerable.prefixes.should == ["/foreign-travel-advice/#{@edition.country_slug}"]
     end
   end
+
+  describe "content_id" do
+    before :each do
+      @edition = FactoryGirl.build(:travel_advice_edition)
+      @registerable = RegisterableTravelAdviceEdition.new(@edition)
+    end
+
+    it "should return the content_id of the corresponding country" do
+      @edition.country_slug = 'albania'
+      @registerable.content_id.should == Country.find_by_slug('albania').content_id
+    end
+
+    it "should return nil if there is no corresponding country" do
+      @edition.country_slug = 'non-existent'
+      @registerable.content_id.should be_nil
+    end
+  end
 end


### PR DESCRIPTION
This adds content_ids, and includes them in the data sent to Panopticon.

Sending these to publishing-api will be done in a follow-up PR.