### PR TITLE
Don't attempt to define spec:schema rake task in prod.

### DIFF
--- a/lib/tasks/rspec.rake
+++ b/lib/tasks/rspec.rake
@@ -1,8 +1,10 @@
-require 'rspec/core/rake_task'
+if Rails.env.test? || Rails.env.development?
+  require 'rspec/core/rake_task'
 
-namespace :spec do
-  desc "Run all schema specs"
-  RSpec::Core::RakeTask.new(:schema) do |t|
-    t.rspec_opts = '-t schema_test'
+  namespace :spec do
+    desc "Run all schema specs"
+    RSpec::Core::RakeTask.new(:schema) do |t|
+      t.rspec_opts = '-t schema_test'
+    end
   end
 end


### PR DESCRIPTION
the rspec gem isn't available in production, so this errors out.
Wrapping it in a conditional prevents this.

Best reviewed with `?w=1` on the URL.