### PR TITLE
Send rendered html

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ end
 
 gem 'logstasher', '0.4.8'
 gem 'airbrake', '~> 4.0.0'
+gem 'govspeak', '~> 3.1.1'
 
 # Gems used only for assets and not required in production
 # environments by default.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -300,6 +300,7 @@ DEPENDENCIES
   formtastic-bootstrap (= 3.0.0)
   gds-api-adapters (~> 26.4.0)
   gds-sso (= 10.0.0)
+  govspeak (~> 3.1.1)
   govuk-content-schema-test-helpers (~> 1.3.0)
   govuk_admin_template (= 3.0.0)
   govuk_content_models (= 27.1.0)

--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -40,7 +40,7 @@ class EditionPresenter
 private
   def details
     details = {
-      "summary" => edition.summary,
+      "summary" => GovspeakPresenter.present(edition.summary),
       "country" => {
         "slug" => country.slug,
         "name" => country.name,

--- a/app/presenters/govspeak_presenter.rb
+++ b/app/presenters/govspeak_presenter.rb
@@ -1,0 +1,15 @@
+module GovspeakPresenter
+  class << self
+    def present(govspeak)
+      [
+        { "content_type" => "text/govspeak", "content" => govspeak },
+        { "content_type" => "text/html", "content" => html(govspeak) }
+      ]
+    end
+
+  private
+    def html(govspeak)
+      Govspeak::Document.new(govspeak).to_html
+    end
+  end
+end

--- a/app/presenters/part_presenter.rb
+++ b/app/presenters/part_presenter.rb
@@ -11,7 +11,7 @@ class PartPresenter
     {
       "slug" => part.slug,
       "title" => part.title,
-      "body" => part.body,
+      "body" => GovspeakPresenter.present(part.body),
     }
   end
 

--- a/spec/features/edition_edit_spec.rb
+++ b/spec/features/edition_edit_spec.rb
@@ -272,11 +272,17 @@ feature "Edit Edition page", :js => true do
 
     @edition.parts.build
     p1 = @edition.parts.first.update_attributes(
-      :title => 'Part One', :body => 'Body text', :slug => 'part-one')
+      title: 'Part One',
+      slug: 'part-one',
+      body: 'Body text',
+    )
 
     @edition.parts.build
     p2 = @edition.parts.second.update_attributes(
-      :title => 'Part Two', :body => 'Body text', :slug => 'part-two')
+      title: 'Part Two',
+      slug: 'part-two',
+      body: 'Body text',
+    )
 
     visit "/admin/editions/#{@edition._id}/edit"
 
@@ -298,12 +304,18 @@ feature "Edit Edition page", :js => true do
       {
         "slug" => "part-one",
         "title" => "Part One",
-        "body" => "Body text",
+        "body" => [
+          { "content_type" => "text/govspeak", "content" => "Body text" },
+          { "content_type" => "text/html", "content" => "<p>Body text</p>\n" },
+        ],
       },
       {
         "slug" => "part-two",
         "title" => "Part Two",
-        "body" => "Body text",
+        "body" => [
+          { "content_type" => "text/govspeak", "content" => "Body text" },
+          { "content_type" => "text/html", "content" => "<p>Body text</p>\n" },
+        ],
       },
     ])
 

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -10,14 +10,14 @@ describe EditionPresenter do
       :title => "Aruba travel advice",
       :overview => "Something something",
       :published_at => 5.minutes.ago,
-      :summary => "Edition summary",
+      :summary => "### Summary",
       :alert_status => [TravelAdviceEdition::ALERT_STATUSES.first],
     )
 
     edition.parts.build(
       slug: "terrorism",
       title: "Terrorism",
-      body: "<p>There is an underlying threat from ...</p>",
+      body: "There is an underlying threat from ...",
     )
 
     edition.actions.build(
@@ -70,7 +70,10 @@ describe EditionPresenter do
           {"path" => "/foreign-travel-advice/aruba.atom", "type" => "exact"}
         ],
         "details" => {
-          "summary" => "Edition summary",
+          "summary" => [
+            { "content_type" => "text/govspeak", "content" => "### Summary" },
+            { "content_type" => "text/html", "content" => "<h3 id=\"summary\">Summary</h3>\n" },
+          ],
           "country" => {
             "slug" => "aruba",
             "name" => "Aruba",
@@ -82,7 +85,10 @@ describe EditionPresenter do
             {
               "slug" => "terrorism",
               "title" => "Terrorism",
-              "body" => "<p>There is an underlying threat from ...</p>",
+              "body" => [
+                { "content_type" => "text/govspeak", "content" => "There is an underlying threat from ..." },
+                { "content_type" => "text/html", "content" => "<p>There is an underlying threat from &hellip;</p>\n" },
+              ],
             }
           ],
           "alert_status" => ["avoid_all_but_essential_travel_to_parts"],

--- a/spec/presenters/govspeak_presenter_spec.rb
+++ b/spec/presenters/govspeak_presenter_spec.rb
@@ -1,0 +1,12 @@
+require "spec_helper"
+
+RSpec.describe GovspeakPresenter do
+  it "presents the given govspeak as multiple content types" do
+    result = subject.present("### Title\r\nParagraph")
+
+    expect(result).to eq [
+      { "content_type" => "text/govspeak", "content" => "### Title\r\nParagraph" },
+      { "content_type" => "text/html", "content" => "<h3 id=\"title\">Title</h3>\n<p>Paragraph</p>\n" },
+    ]
+  end
+end

--- a/spec/presenters/part_presenter_spec.rb
+++ b/spec/presenters/part_presenter_spec.rb
@@ -18,7 +18,10 @@ RSpec.describe PartPresenter do
     expect(presented).to eq(
       "slug" => "part-one",
       "title" => "Part One",
-      "body" => "Body text",
+      "body" => [
+        { "content_type" => "text/govspeak", "content" => "Body text" },
+        { "content_type" => "text/html", "content" => "<p>Body text</p>\n" },
+      ],
     )
   end
 end


### PR DESCRIPTION
Schema change: https://github.com/alphagov/govuk-content-schemas/pull/188

https://trello.com/c/L6gBHNFN/471-make-travel-advice-publisher-send-both-govspeak-and-html-to-the-publishing-api