### PR TITLE
Ensure parts are presented in order

### DIFF
--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -87,7 +87,7 @@ private
   end
 
   def parts
-    edition.parts.map do |part|
+    edition.order_parts.map do |part|
       PartPresenter.present(part)
     end
   end

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -18,6 +18,14 @@ describe EditionPresenter do
       slug: "terrorism",
       title: "Terrorism",
       body: "There is an underlying threat from ...",
+      order: 2,
+    )
+
+    edition.parts.build(
+      slug: "safety-and-security",
+      title: "Safety and security",
+      body: "Keep your valuables safely stored ...",
+      order: 1,
     )
 
     edition.actions.build(
@@ -83,6 +91,14 @@ describe EditionPresenter do
           "change_description" => "Stuff changed",
           "email_signup_link" => TravelAdvicePublisher::EMAIL_SIGNUP_URL,
           "parts" => [
+            {
+              "slug" => "safety-and-security",
+              "title" => "Safety and security",
+              "body" => [
+                { "content_type" => "text/govspeak", "content" => "Keep your valuables safely stored ..." },
+                { "content_type" => "text/html", "content" => "<p>Keep your valuables safely stored &hellip;</p>\n" },
+              ],
+            },
             {
               "slug" => "terrorism",
               "title" => "Terrorism",


### PR DESCRIPTION
[Content API orders parts](https://github.com/alphagov/govuk_content_api/blob/master/lib/presenters/artefact_presenter.rb#L127) when presenting them to the frontend, so do the same before sending to the Publishing API.

https://trello.com/c/uwYsVFbe/491-support-part-ordering-for-multipage-content-items