### PR TITLE
Update travel advice index when countries are published...

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -77,6 +77,7 @@ class Admin::EditionsController < ApplicationController
     if @edition.update_attributes(params[:edition]) && @edition.publish_as(current_user)
       PublishingApiNotifier.put_content(@edition)
       PublishingApiNotifier.publish(@edition)
+      PublishingApiNotifier.publish_index
 
       # catch any upload errors
       if @edition.errors.any?

--- a/app/notifiers/publishing_api_notifier.rb
+++ b/app/notifiers/publishing_api_notifier.rb
@@ -2,16 +2,27 @@ module PublishingApiNotifier
   class << self
     def put_content(edition)
       presenter = EditionPresenter.new(edition)
-      api = TravelAdvicePublisher.publishing_api_v2
 
       api.put_content(presenter.content_id, presenter.render_for_publishing_api)
     end
 
     def publish(edition)
       presenter = EditionPresenter.new(edition)
-      api = TravelAdvicePublisher.publishing_api_v2
 
       api.publish(presenter.content_id, presenter.update_type)
+    end
+
+    def publish_index
+      presenter = IndexPresenter.new
+
+      api.put_content(presenter.content_id, presenter.render_for_publishing_api)
+      api.publish(presenter.content_id, presenter.update_type)
+    end
+
+  private
+
+    def api
+      TravelAdvicePublisher.publishing_api_v2
     end
   end
 end

--- a/spec/features/edition_edit_spec.rb
+++ b/spec/features/edition_edit_spec.rb
@@ -416,6 +416,10 @@ feature "Edit Edition page", :js => true do
     assert_publishing_api_publish("2a3938e1-d588-45fc-8c8f-0f51814d5409", {
       update_type: "major"
     })
+
+    assert_publishing_api_publish(TravelAdvicePublisher::INDEX_CONTENT_ID, {
+      update_type: "minor"
+    })
   end
 
   scenario "save and publish a minor update to an edition" do


### PR DESCRIPTION
The travel advice index is sorted by country update time and should be updated whenever advice for a country is published.
https://trello.com/c/KxOmVc1J/498-save-and-publish-index-content-item-not-just-manually