### PR TITLE
Adds static 'breadcrumbs' data for countries.

### DIFF
--- a/app/presenters/breadcrumbs_presenter.rb
+++ b/app/presenters/breadcrumbs_presenter.rb
@@ -1,0 +1,29 @@
+class BreadcrumbsPresenter
+  def self.present
+    {
+      web_url: "https://www.gov.uk/foreign-travel-advice",
+      title: "Foreign travel advice",
+      parent: {
+        web_url: "https://www.gov.uk/browse/abroad/travel-abroad",
+        title: "Travel abroad",
+        parent: {
+          web_url: "https://www.gov.uk/browse/abroad",
+          title: "Passports, travel and living abroad",
+          parent: nil
+        }
+      }
+    }.as_json
+  end
+
+  def self.present_for_index
+    {
+      web_url: "https://www.gov.uk/browse/abroad/travel-abroad",
+      title: "Travel abroad",
+      parent: {
+        web_url: "https://www.gov.uk/browse/abroad",
+        title: "Passports, travel and living abroad",
+        parent: nil
+      }
+    }.as_json
+  end
+end

--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -51,6 +51,7 @@ private
       "email_signup_link" => TravelAdvicePublisher::EMAIL_SIGNUP_URL,
       "parts" => parts,
       "alert_status" => edition.alert_status,
+      "primary_parent" => breadcrumbs,
     }
 
     details.merge!("image" => image) if image
@@ -98,5 +99,9 @@ private
 
   def document
     @document ||= AssetPresenter.present(edition.document)
+  end
+
+  def breadcrumbs
+    @breadcrumbs ||= BreadcrumbsPresenter.present
   end
 end

--- a/app/presenters/index_presenter.rb
+++ b/app/presenters/index_presenter.rb
@@ -27,6 +27,7 @@ class IndexPresenter
       "details" => {
         "email_signup_link" => TravelAdvicePublisher::EMAIL_SIGNUP_URL,
         "countries" => countries,
+        "primary_parent" => breadcrumbs,
       }
     }
   end
@@ -46,6 +47,10 @@ private
         "synonyms" => edition.synonyms,
       }
     end.compact
+  end
+
+  def breadcrumbs
+    BreadcrumbsPresenter.present_for_index
   end
 
   def public_updated_at(edition)

--- a/spec/presenters/breadcrumbs_presenter_spec.rb
+++ b/spec/presenters/breadcrumbs_presenter_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+RSpec.describe BreadcrumbsPresenter, ".present" do
+  it "presents ancestry for breadcrumbs" do
+    expect(described_class.present).to eq(
+      {
+        "web_url" => "https://www.gov.uk/foreign-travel-advice",
+        "title" => "Foreign travel advice",
+        "parent" => {
+          "web_url" => "https://www.gov.uk/browse/abroad/travel-abroad",
+          "title" => "Travel abroad",
+          "parent" => {
+            "web_url" => "https://www.gov.uk/browse/abroad",
+            "title" => "Passports, travel and living abroad",
+            "parent" => nil
+          }
+        }
+      }
+    )
+  end
+
+  it "presents ancestry for index breadcrumbs" do
+    expect(described_class.present_for_index).to eq(
+      {
+        "web_url" => "https://www.gov.uk/browse/abroad/travel-abroad",
+        "title" => "Travel abroad",
+        "parent" => {
+          "web_url" => "https://www.gov.uk/browse/abroad",
+          "title" => "Passports, travel and living abroad",
+          "parent" => nil
+        }
+      }
+    )
+  end
+end

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -109,6 +109,19 @@ describe EditionPresenter do
             }
           ],
           "alert_status" => ["avoid_all_but_essential_travel_to_parts"],
+          "primary_parent" => {
+            "web_url" => "https://www.gov.uk/foreign-travel-advice",
+            "title" => "Foreign travel advice",
+            "parent" => {
+              "web_url" => "https://www.gov.uk/browse/abroad/travel-abroad",
+              "title" => "Travel abroad",
+              "parent" => {
+                "web_url" => "https://www.gov.uk/browse/abroad",
+                "title" => "Passports, travel and living abroad",
+                "parent" => nil
+              }
+            }
+          },
         }
       )
     end

--- a/spec/presenters/index_presenter_spec.rb
+++ b/spec/presenters/index_presenter_spec.rb
@@ -83,6 +83,15 @@ describe IndexPresenter do
                 "synonyms" => ["foo", "bar"],
               },
             ],
+            "primary_parent" => {
+              "web_url" => "https://www.gov.uk/browse/abroad/travel-abroad",
+              "title" => "Travel abroad",
+              "parent" => {
+                "web_url" => "https://www.gov.uk/browse/abroad",
+                "title" => "Passports, travel and living abroad",
+                "parent" => nil
+              }
+            },
           },
         )
       end


### PR DESCRIPTION
https://trello.com/c/vm54jvVo/477-send-hard-coded-breadcrumbs-to-publishing-api

also relates to https://github.com/alphagov/govuk-content-schemas/pull/205 and the accompanying story https://trello.com/c/tomHUlp7/475-define-data-format-for-breadcrumbs