### PR TITLE
Add the EmailAlertPresenter…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'mongoid_rails_migrations', '1.0.1'
 
 gem 'diffy', '3.0.7'
 
-gem 'plek', '1.8.1'
+gem 'plek', '~> 1.9.0'
 gem 'gds-sso', '10.0.0'
 
 gem 'govuk_admin_template', '3.0.0'
@@ -26,7 +26,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 26.4.0'
+  gem 'gds-api-adapters', '~> 27.2.0'
 end
 
 gem 'logstasher', '0.4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,11 +75,11 @@ GEM
       actionpack (>= 3.0)
     formtastic-bootstrap (3.0.0)
       formtastic (>= 2.2)
-    gds-api-adapters (26.4.0)
+    gds-api-adapters (27.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
-      plek
+      plek (>= 1.9.0)
       rack-cache
       rest-client (~> 1.8.0)
     gds-sso (10.0.0)
@@ -178,7 +178,7 @@ GEM
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
     phantomjs (1.9.7.1)
-    plek (1.8.1)
+    plek (1.9.0)
     poltergeist (1.8.1)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -302,7 +302,7 @@ DEPENDENCIES
   factory_girl_rails
   formtastic (= 2.3.0)
   formtastic-bootstrap (= 3.0.0)
-  gds-api-adapters (~> 26.4.0)
+  gds-api-adapters (~> 27.2.0)
   gds-sso (= 10.0.0)
   govspeak (~> 3.1.1)
   govuk-content-schema-test-helpers (~> 1.3.0)
@@ -312,7 +312,7 @@ DEPENDENCIES
   logstasher (= 0.4.8)
   mongoid (= 2.6)
   mongoid_rails_migrations (= 1.0.1)
-  plek (= 1.8.1)
+  plek (~> 1.9.0)
   poltergeist (= 1.8.1)
   pry-rails
   rails (= 3.2.22)

--- a/app/notifiers/email_alert_api_notifier.rb
+++ b/app/notifiers/email_alert_api_notifier.rb
@@ -1,0 +1,21 @@
+require "gds_api/email_alert_api"
+
+module EmailAlertApiNotifier
+  class << self
+    def send_alert(edition)
+      return unless send_alert?(edition)
+
+      payload = EmailAlertPresenter.present(edition)
+      api.send_alert(payload)
+    end
+
+  private
+    def send_alert?(edition)
+      edition.state == "published" && !edition.minor_update
+    end
+
+    def api
+      TravelAdvicePublisher.email_alert_api
+    end
+  end
+end

--- a/app/presenters/email_alert_presenter.rb
+++ b/app/presenters/email_alert_presenter.rb
@@ -1,0 +1,75 @@
+class EmailAlertPresenter
+  def self.present(edition)
+    new(edition).present
+  end
+
+  def initialize(edition)
+    self.edition = edition
+  end
+
+  def present
+    {
+      "subject" => subject,
+      "tags" => tags,
+      "links" => links,
+      "body" => body,
+    }
+  end
+
+private
+  attr_accessor :edition
+
+  def subject
+    edition.title
+  end
+
+  def tags
+    { countries: [edition.country_slug] }
+  end
+
+  def links
+    :TODO
+  end
+
+  def body
+    <<-HTML
+      <div class="rss_item" data-message-id="#{message_identifier}" style="margin-bottom: 2em;">
+        <div class="rss_title" style="font-size: 120%; margin: 0 0 0.3em; padding: 0;">
+          <a href="#{absolute_path}" style="font-weight: bold; ">#{link_text}</a>
+        </div>
+        #{formatted_published_at}
+        #{change_description}
+        <br />
+        <div class="rss_description" style="margin: 0 0 0.3em; padding: 0;">#{description}</div>
+      </div>
+    HTML
+  end
+
+  def message_identifier
+    Digest::SHA1.hexdigest(edition.title + formatted_published_at)
+  end
+
+  def link_text
+    edition.title
+  end
+
+  def change_description
+    edition.change_description
+  end
+
+  def description
+    edition.summary
+  end
+
+  def formatted_published_at
+    edition.published_at.strftime("%l:%M%P, %-d %B %Y")
+  end
+
+  def absolute_path
+    Plek.new.website_root + base_path
+  end
+
+  def base_path
+    "/foreign-travel-advice/#{edition.country_slug}"
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,7 @@ end
 module TravelAdvicePublisher
   mattr_accessor :asset_api
   mattr_accessor :publishing_api_v2
+  mattr_accessor :email_alert_api
 
   # Maslow need ID for Travel Advice Publisher
   NEED_ID = '101191'

--- a/config/initializers/email_alert_api.rb
+++ b/config/initializers/email_alert_api.rb
@@ -1,0 +1,6 @@
+require "gds_api/email_alert_api"
+require "plek"
+
+TravelAdvicePublisher.email_alert_api = GdsApi::EmailAlertApi.new(
+  Plek.current.find("email-alert-api")
+)

--- a/spec/features/edition_edit_spec.rb
+++ b/spec/features/edition_edit_spec.rb
@@ -73,11 +73,11 @@ feature "Edit Edition page", :js => true do
       page.should have_field("Search title", :with => @edition.title)
       current_path.should_not == "/admin/editions/#{@edition._id}/edit"
 
-      assert_publishing_api_put_content("2a3938e1-d588-45fc-8c8f-0f51814d5409", {
+      assert_publishing_api_put_content("2a3938e1-d588-45fc-8c8f-0f51814d5409", request_json_includes(
         title: "An archived title",
         format: "placeholder_travel_advice",
         content_id: '2a3938e1-d588-45fc-8c8f-0f51814d5409',
-      })
+      ))
     end
 
     scenario "create an edition from a published edition" do
@@ -207,11 +207,11 @@ feature "Edit Edition page", :js => true do
     two.body.should == 'Body text'
     two.order.should == 2
 
-    assert_publishing_api_put_content("2a3938e1-d588-45fc-8c8f-0f51814d5409", {
+    assert_publishing_api_put_content("2a3938e1-d588-45fc-8c8f-0f51814d5409", request_json_includes(
       title: "Travel advice for Albania",
       format: "placeholder_travel_advice",
       content_id: '2a3938e1-d588-45fc-8c8f-0f51814d5409',
-    })
+    ))
   end
 
   scenario "Updating the reviewed at date for a published edition" do
@@ -457,11 +457,10 @@ feature "Edit Edition page", :js => true do
     expect(action.request_type).to eq Action::PUBLISH
     expect(action.comment).to eq "Minor update"
 
-    assert_publishing_api_put_content("2a3938e1-d588-45fc-8c8f-0f51814d5409", {
+    assert_publishing_api_put_content("2a3938e1-d588-45fc-8c8f-0f51814d5409", request_json_includes(
       format: "placeholder_travel_advice",
       content_id: '2a3938e1-d588-45fc-8c8f-0f51814d5409',
-    })
-
+    ))
 
     assert_publishing_api_publish("2a3938e1-d588-45fc-8c8f-0f51814d5409", {
       update_type: "minor"

--- a/spec/notifiers/email_alert_api_notifier_spec.rb
+++ b/spec/notifiers/email_alert_api_notifier_spec.rb
@@ -1,0 +1,44 @@
+require "spec_helper"
+require "gds_api/test_helpers/email_alert_api"
+
+RSpec.describe EmailAlertApiNotifier do
+  include GdsApiHelpers
+  include GdsApi::TestHelpers::EmailAlertApi
+
+  before do
+    stub_panopticon_registration
+    stub_any_email_alert_api_call
+  end
+
+  let(:edition) do
+    FactoryGirl.create(
+      :published_travel_advice_edition,
+      country_slug: "switzerland",
+      title: "Switzerland travel advice",
+    )
+  end
+
+  it "sends a request to the email alert api" do
+    response = subject.send_alert(edition)
+    assert_email_alert_sent("subject" => "Switzerland travel advice")
+  end
+
+  context "when the edition is a draft" do
+    let(:edition) { FactoryGirl.create(:draft_travel_advice_edition) }
+
+    it "does nothing" do
+      expect(subject.send_alert(edition)).to be_nil
+    end
+  end
+
+  context "when the update_type is minor" do
+    before do
+      edition.minor_update = true
+      edition.save!(validate: false)
+    end
+
+    it "does nothing" do
+      expect(subject.send_alert(edition)).to be_nil
+    end
+  end
+end

--- a/spec/presenters/email_alert_presenter_spec.rb
+++ b/spec/presenters/email_alert_presenter_spec.rb
@@ -1,0 +1,52 @@
+require "spec_helper"
+
+RSpec.describe EmailAlertPresenter do
+  include GdsApiHelpers
+
+  before do
+    stub_panopticon_registration
+  end
+
+  let(:edition) do
+    FactoryGirl.create(
+      :published_travel_advice_edition,
+      country_slug: "algeria",
+      title: "Algeria travel advice",
+      change_description: "Updated image of regions",
+    )
+  end
+
+  let(:email_alert) { described_class.present(edition) }
+
+  around do |example|
+    january_1st = Time.local(2016, 1, 1, 1, 1, 1)
+
+    Timecop.travel(january_1st) do
+      example.run
+    end
+  end
+
+  it "formats the message to include the parent link" do
+    expect(email_alert["subject"]).to eq("Algeria travel advice")
+    expect(email_alert["tags"]).to eq(countries: ["algeria"])
+    expect(email_alert["links"]).to eq(:TODO)
+
+    body = email_alert["body"]
+
+    lines = body.split("\n")
+    lines = lines.map(&:strip)
+    lines = lines.reject(&:empty?)
+
+    expect(lines).to eq [
+      '<div class="rss_item" data-message-id="94384295a5f4b9eee7fca066304fe4c4b1f206ba" style="margin-bottom: 2em;">',
+      '<div class="rss_title" style="font-size: 120%; margin: 0 0 0.3em; padding: 0;">',
+      '<a href="http://www.dev.gov.uk/foreign-travel-advice/algeria" style="font-weight: bold; ">Algeria travel advice</a>',
+      '</div>',
+      '1:01am, 1 January 2016',
+      'Updated image of regions',
+      '<br />',
+      '<div class="rss_description" style="margin: 0 0 0.3em; padding: 0;"></div>',
+      '</div>',
+    ]
+  end
+end

--- a/spec/tasks/publishing_api_rake_spec.rb
+++ b/spec/tasks/publishing_api_rake_spec.rb
@@ -17,12 +17,12 @@ describe "publishing_api rake tasks", :type => :rake_task do
     it "sends the index item to publishing_api" do
       task.invoke
 
-      assert_publishing_api_put_content(TravelAdvicePublisher::INDEX_CONTENT_ID, {
+      assert_publishing_api_put_content(TravelAdvicePublisher::INDEX_CONTENT_ID, request_json_includes(
         base_path: "/foreign-travel-advice",
         title: "Foreign travel advice",
         format: "placeholder_travel_advice_index",
         update_type: "minor",
-      })
+      ))
 
       assert_publishing_api_publish(TravelAdvicePublisher::INDEX_CONTENT_ID, {
         update_type: "minor",
@@ -39,25 +39,25 @@ describe "publishing_api rake tasks", :type => :rake_task do
 
       task.invoke
 
-      assert_publishing_api_put_content("56bae85b-a57c-4ca2-9dbd-68361a086bb3", {
+      assert_publishing_api_put_content("56bae85b-a57c-4ca2-9dbd-68361a086bb3", request_json_includes(
         base_path: "/foreign-travel-advice/aruba",
         title: aruba.title,
         format: "placeholder_travel_advice",
         update_type: "republish",
         public_updated_at: aruba.published_at.iso8601,
-      })
+      ))
 
       assert_publishing_api_publish("56bae85b-a57c-4ca2-9dbd-68361a086bb3", {
         update_type: "republish",
       })
 
-      assert_publishing_api_put_content("b5c8e64b-3461-4447-9144-1588e4a84fe6", {
+      assert_publishing_api_put_content("b5c8e64b-3461-4447-9144-1588e4a84fe6", request_json_includes(
         base_path: "/foreign-travel-advice/algeria",
         title: algeria.title,
         format: "placeholder_travel_advice",
         update_type: "republish",
         public_updated_at: algeria.published_at.iso8601,
-      })
+      ))
 
       assert_publishing_api_publish("b5c8e64b-3461-4447-9144-1588e4a84fe6", {
         update_type: "republish",
@@ -76,8 +76,13 @@ describe "publishing_api rake tasks", :type => :rake_task do
       expect(a_request(:post, GdsApi::TestHelpers::PublishingApiV2::PUBLISHING_API_V2_ENDPOINT + "/content/56bae85b-a57c-4ca2-9dbd-68361a086bb3/publish"))
         .not_to have_been_made
 
-      assert_publishing_api_put_content("b5c8e64b-3461-4447-9144-1588e4a84fe6")
-      assert_publishing_api_publish("b5c8e64b-3461-4447-9144-1588e4a84fe6")
+      assert_publishing_api_put_content("b5c8e64b-3461-4447-9144-1588e4a84fe6", request_json_includes(
+        "base_path" => "/foreign-travel-advice/algeria"
+      ))
+
+      assert_publishing_api_publish("b5c8e64b-3461-4447-9144-1588e4a84fe6", {
+        "update_type" => "republish"
+      })
     end
   end
 end


### PR DESCRIPTION
**Work in progress, do not merge yet**

This was ported over from the EmailAlertService
and then simplified as it now only needs to
present TravelAdviceEditions rather than generic
Editions.

Currently, the “links” value is not set, pending
a discussion with the Finding Things team.