### PR TITLE
[Do not merge] Add static 'breadcrumbs' data to travel advice...

### DIFF
--- a/app/presenters/breadcrumbs_presenter.rb
+++ b/app/presenters/breadcrumbs_presenter.rb
@@ -1,0 +1,29 @@
+class BreadcrumbsPresenter
+  def self.present
+    {
+      web_url: "/foreign-travel-advice",
+      title: "Foreign travel advice",
+      parent: {
+        web_url: "/browse/abroad/travel-abroad",
+        title: "Travel abroad",
+        parent: {
+          web_url: "/browse/abroad",
+          title: "Passports, travel and living abroad",
+          parent: nil
+        }
+      }
+    }.as_json
+  end
+
+  def self.present_for_index
+    {
+      web_url: "/browse/abroad/travel-abroad",
+      title: "Travel abroad",
+      parent: {
+        web_url: "/browse/abroad",
+        title: "Passports, travel and living abroad",
+        parent: nil
+      }
+    }.as_json
+  end
+end

--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -34,6 +34,7 @@ class EditionPresenter
       "public_updated_at" => public_updated_at.iso8601,
       "update_type" => update_type,
       "details" => details,
+      "links" => { "parent" => breadcrumbs }
     }
   end
 
@@ -98,5 +99,9 @@ private
 
   def document
     @document ||= AssetPresenter.present(edition.document)
+  end
+
+  def breadcrumbs
+    @breadcrumbs ||= BreadcrumbsPresenter.present
   end
 end

--- a/app/presenters/index_presenter.rb
+++ b/app/presenters/index_presenter.rb
@@ -27,6 +27,9 @@ class IndexPresenter
       "details" => {
         "email_signup_link" => TravelAdvicePublisher::EMAIL_SIGNUP_URL,
         "countries" => countries,
+      },
+      "links" => {
+        "parent" => breadcrumbs,
       }
     }
   end
@@ -46,6 +49,10 @@ private
         "synonyms" => edition.synonyms,
       }
     end.compact
+  end
+
+  def breadcrumbs
+    BreadcrumbsPresenter.present_for_index
   end
 
   def public_updated_at(edition)

--- a/spec/presenters/breadcrumbs_presenter_spec.rb
+++ b/spec/presenters/breadcrumbs_presenter_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+
+RSpec.describe BreadcrumbsPresenter, ".present" do
+  it "presents ancestry for breadcrumbs" do
+    expect(described_class.present).to eq(
+      {
+        "web_url" => "/foreign-travel-advice",
+        "title" => "Foreign travel advice",
+        "parent" => {
+          "web_url" => "/browse/abroad/travel-abroad",
+          "title" => "Travel abroad",
+          "parent" => {
+            "web_url" => "/browse/abroad",
+            "title" => "Passports, travel and living abroad",
+            "parent" => nil
+          }
+        }
+      }
+    )
+  end
+
+  it "presents ancestry for index breadcrumbs" do
+    expect(described_class.present_for_index).to eq(
+      {
+        "web_url" => "/browse/abroad/travel-abroad",
+        "title" => "Travel abroad",
+        "parent" => {
+          "web_url" => "/browse/abroad",
+          "title" => "Passports, travel and living abroad",
+          "parent" => nil
+        }
+      }
+    )
+  end
+end

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -58,6 +58,8 @@ describe EditionPresenter do
       expect(presented_data["format"]).to eq("placeholder_travel_advice")
 
       presented_data["format"] = "travel_advice"
+      presented_data.delete("links")
+
       expect(presented_data).to be_valid_against_schema('travel_advice')
     end
 
@@ -109,6 +111,21 @@ describe EditionPresenter do
             }
           ],
           "alert_status" => ["avoid_all_but_essential_travel_to_parts"],
+        },
+        "links" => {
+          "parent" => {
+            "web_url" => "/foreign-travel-advice",
+            "title" => "Foreign travel advice",
+            "parent" => {
+              "web_url" => "/browse/abroad/travel-abroad",
+              "title" => "Travel abroad",
+              "parent" => {
+                "web_url" => "/browse/abroad",
+                "title" => "Passports, travel and living abroad",
+                "parent" => nil
+              }
+            }
+          },
         }
       )
     end

--- a/spec/presenters/index_presenter_spec.rb
+++ b/spec/presenters/index_presenter_spec.rb
@@ -42,6 +42,8 @@ describe IndexPresenter do
       expect(presented_data["format"]).to eq("placeholder_travel_advice_index")
 
       presented_data["format"] = "travel_advice_index"
+      presented_data.delete("links")
+
       expect(presented_data).to be_valid_against_schema('travel_advice_index')
     end
 
@@ -82,8 +84,19 @@ describe IndexPresenter do
                 "change_description" => "Stuff changed",
                 "synonyms" => ["foo", "bar"],
               },
-            ],
+            ]
           },
+          "links" => {
+            "parent" => {
+              "web_url" => "/browse/abroad/travel-abroad",
+              "title" => "Travel abroad",
+              "parent" => {
+                "web_url" => "/browse/abroad",
+                "title" => "Passports, travel and living abroad",
+                "parent" => nil
+              }
+            }
+          }
         )
       end
     end


### PR DESCRIPTION
https://trello.com/c/vm54jvVo/477-send-hard-coded-breadcrumbs-to-publishing-api
Static breadcrumbs for travel advice country and index representations.

This expands breadcrumbs in the links hash, please don't merge yet as this PR depends on these: https://github.com/alphagov/publishing-api/pull/193 and  https://github.com/alphagov/content-store/pull/182