### PR TITLE
Add static related links to travel advice.

### DIFF
--- a/app/presenters/links_presenter.rb
+++ b/app/presenters/links_presenter.rb
@@ -7,7 +7,8 @@ class LinksPresenter
   def present
     {
       :links => {
-        "parent" => BreadcrumbsPresenter.present
+        "parent" => BreadcrumbsPresenter.present,
+        "related" => RelatedLinksPresenter.present
       }
     }
   end

--- a/app/presenters/related_links_presenter.rb
+++ b/app/presenters/related_links_presenter.rb
@@ -1,0 +1,40 @@
+class RelatedLinksPresenter
+  def self.present
+    [
+      {
+        "content_id" => "b9849cd6-61a7-42dc-8124-362d2c7d48b0",
+        "title" => "Travel abroad",
+        "base_path" => "/browse/abroad/travel-abroad",
+      },
+      {
+        "content_id" => "95f9c380-30bc-44c7-86b4-e9c9ef0fc272",
+        "title" => "Hand luggage restrictions at UK airports",
+        "base_path" => "/hand-luggage-restrictions",
+        "links" => {
+          "parent" => ["b9849cd6-61a7-42dc-8124-362d2c7d48b0"]
+        }
+      },
+      {
+        "content_id" => "e4d06cb9-9e2e-4e82-b802-0aad013ae16c",
+        "title" => "Driving abroad",
+        "base_path" => "/driving-abroad",
+        "links" => {
+          "parent" => ["b9849cd6-61a7-42dc-8124-362d2c7d48b0"]
+        }
+      },
+      {
+        "content_id" => "86eb717a-fb40-42e7-83fa-d031a03880fb",
+        "title" => "Passports, travel and living abroad",
+        "base_path" => "/browse/abroad",
+      },
+      {
+        "content_id" => "82248bb1-c4d6-41e0-9494-d98123475626",
+        "title" => "Renew or replace your adult passport",
+        "base_path" => "/renew-adult-passport",
+        "links" => {
+          "parent" => ["86eb717a-fb40-42e7-83fa-d031a03880fb"]
+        }
+      },
+    ]
+  end
+end

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -109,7 +109,7 @@ describe EditionPresenter do
             }
           ],
           "alert_status" => ["avoid_all_but_essential_travel_to_parts"],
-        }
+        },
       )
     end
 

--- a/spec/presenters/links_presenter_spec.rb
+++ b/spec/presenters/links_presenter_spec.rb
@@ -39,6 +39,42 @@ RSpec.describe LinksPresenter do
               "base_path" => "/browse/abroad",
               "title" => "Passports, travel and living abroad"
             }
+          ],
+          "related" => [
+            {
+              "content_id" => "b9849cd6-61a7-42dc-8124-362d2c7d48b0",
+              "title" => "Travel abroad",
+              "base_path" => "/browse/abroad/travel-abroad"
+            },
+            {
+              "content_id" => "95f9c380-30bc-44c7-86b4-e9c9ef0fc272",
+              "title" => "Hand luggage restrictions at UK airports",
+              "base_path" => "/hand-luggage-restrictions",
+              "links" => {
+                "parent" => ["b9849cd6-61a7-42dc-8124-362d2c7d48b0"]
+              }
+            },
+            {
+              "content_id" => "e4d06cb9-9e2e-4e82-b802-0aad013ae16c",
+              "title" => "Driving abroad",
+              "base_path" => "/driving-abroad",
+              "links" => {
+                "parent" => ["b9849cd6-61a7-42dc-8124-362d2c7d48b0"]
+              }
+            },
+            {
+              "content_id" => "86eb717a-fb40-42e7-83fa-d031a03880fb",
+              "title" => "Passports, travel and living abroad",
+              "base_path" => "/browse/abroad"
+            },
+            {
+              "content_id" => "82248bb1-c4d6-41e0-9494-d98123475626",
+              "title" => "Renew or replace your adult passport",
+              "base_path" => "/renew-adult-passport",
+              "links" => {
+                "parent" => ["86eb717a-fb40-42e7-83fa-d031a03880fb"]
+              }
+            }
           ]
         }
       )

--- a/spec/presenters/related_links_presenter_spec.rb
+++ b/spec/presenters/related_links_presenter_spec.rb
@@ -1,0 +1,44 @@
+require "spec_helper"
+
+RSpec.describe RelatedLinksPresenter, ".present" do
+  it "presents related links by section" do
+    expect(described_class.present).to eq(
+      [
+        {
+          "content_id" => "b9849cd6-61a7-42dc-8124-362d2c7d48b0",
+          "title" => "Travel abroad",
+          "base_path" => "/browse/abroad/travel-abroad"
+        },
+        {
+          "content_id" => "95f9c380-30bc-44c7-86b4-e9c9ef0fc272",
+          "title" => "Hand luggage restrictions at UK airports",
+          "base_path" => "/hand-luggage-restrictions",
+          "links" => {
+            "parent" => ["b9849cd6-61a7-42dc-8124-362d2c7d48b0"]
+          }
+        },
+        {
+          "content_id" => "e4d06cb9-9e2e-4e82-b802-0aad013ae16c",
+          "title" => "Driving abroad",
+          "base_path" => "/driving-abroad",
+          "links" => {
+            "parent" => ["b9849cd6-61a7-42dc-8124-362d2c7d48b0"]
+          }
+        },
+        {
+          "content_id" => "86eb717a-fb40-42e7-83fa-d031a03880fb",
+          "title" => "Passports, travel and living abroad",
+          "base_path" => "/browse/abroad"
+        },
+        {
+          "content_id" => "82248bb1-c4d6-41e0-9494-d98123475626",
+          "title" => "Renew or replace your adult passport",
+          "base_path" => "/renew-adult-passport",
+          "links" => {
+            "parent" => ["86eb717a-fb40-42e7-83fa-d031a03880fb"]
+          }
+        }
+      ]
+    )
+  end
+end


### PR DESCRIPTION
https://trello.com/c/B0Q5jszW/478-send-hard-coded-related-links-to-publishing-api
Adds static related links in a structure compatible with the respective
govuk component used to render related links.
Please do not merge, depends on https://github.com/alphagov/travel-advice-publisher/pull/106