### PR TITLE
Add static 'breadcrumbs' data to travel advice...

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -14,6 +14,7 @@ class Admin::EditionsController < ApplicationController
 
     if edition.save
       PublishingApiNotifier.put_content(edition)
+      PublishingApiNotifier.put_links(edition)
       redirect_to edit_admin_edition_path(edition)
     else
       redirect_to admin_country_path(@country.slug), :alert => "Failed to create new edition"
@@ -76,6 +77,7 @@ class Admin::EditionsController < ApplicationController
   def save_and_publish
     if @edition.update_attributes(params[:edition]) && @edition.publish_as(current_user)
       PublishingApiNotifier.put_content(@edition)
+      PublishingApiNotifier.put_links(@edition)
       PublishingApiNotifier.publish(@edition)
       PublishingApiNotifier.publish_index
 

--- a/app/notifiers/publishing_api_notifier.rb
+++ b/app/notifiers/publishing_api_notifier.rb
@@ -6,6 +6,12 @@ module PublishingApiNotifier
       api.put_content(presenter.content_id, presenter.render_for_publishing_api)
     end
 
+    def put_links(edition)
+      presenter = LinksPresenter.new(edition)
+
+      api.put_links(presenter.content_id, presenter.present)
+    end
+
     def publish(edition)
       presenter = EditionPresenter.new(edition)
 
@@ -16,6 +22,7 @@ module PublishingApiNotifier
       presenter = IndexPresenter.new
 
       api.put_content(presenter.content_id, presenter.render_for_publishing_api)
+      api.put_links(TravelAdvicePublisher::INDEX_CONTENT_ID, IndexLinksPresenter.present)
       api.publish(presenter.content_id, presenter.update_type)
     end
 

--- a/app/presenters/breadcrumbs_presenter.rb
+++ b/app/presenters/breadcrumbs_presenter.rb
@@ -1,0 +1,39 @@
+class BreadcrumbsPresenter
+  def self.present
+    [
+      {
+        "content_id" => "08d48cdd-6b50-43ff-a53b-beab47f4aab0",
+        "base_path" => "/foreign-travel-advice",
+        "title" => "Foreign travel advice",
+        "links" => { "parent" => ["b9849cd6-61a7-42dc-8124-362d2c7d48b0"] },
+      },
+      {
+        "content_id" => "b9849cd6-61a7-42dc-8124-362d2c7d48b0",
+        "base_path" => "/browse/abroad/travel-abroad",
+        "title" => "Travel abroad",
+        "links" => { "parent" => ["86eb717a-fb40-42e7-83fa-d031a03880fb"] },
+      },
+      {
+        "content_id" => "86eb717a-fb40-42e7-83fa-d031a03880fb",
+        "base_path" => "/browse/abroad",
+        "title" => "Passports, travel and living abroad",
+      }
+    ]
+  end
+
+  def self.present_for_index
+    [
+     {
+        "content_id" => "b9849cd6-61a7-42dc-8124-362d2c7d48b0",
+        "base_path" => "/browse/abroad/travel-abroad",
+        "title" => "Travel abroad",
+        "links" => { "parent" => ["86eb717a-fb40-42e7-83fa-d031a03880fb"] },
+      },
+      {
+        "content_id" => "86eb717a-fb40-42e7-83fa-d031a03880fb",
+        "base_path" => "/browse/abroad",
+        "title" => "Passports, travel and living abroad",
+      }
+    ]
+  end
+end

--- a/app/presenters/index_links_presenter.rb
+++ b/app/presenters/index_links_presenter.rb
@@ -1,0 +1,9 @@
+class IndexLinksPresenter
+  def self.present
+    {
+      :links => {
+        "parent" => BreadcrumbsPresenter.present_for_index
+      }
+    }
+  end
+end

--- a/app/presenters/links_presenter.rb
+++ b/app/presenters/links_presenter.rb
@@ -1,0 +1,26 @@
+class LinksPresenter
+
+  def initialize(edition)
+    @edition = edition
+  end
+
+  def present
+    {
+      :links => {
+        "parent" => BreadcrumbsPresenter.present
+      }
+    }
+  end
+
+  def content_id
+    country.content_id
+  end
+
+private
+
+  attr_reader :edition
+
+  def country
+    @country ||= Country.find_by_slug(edition.country_slug)
+  end
+end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -8,6 +8,7 @@ namespace :publishing_api do
     presenter = IndexPresenter.new
 
     api_v2.put_content(presenter.content_id, presenter.render_for_publishing_api)
+    api_v2.put_links(TravelAdvicePublisher::INDEX_CONTENT_ID, IndexLinksPresenter.present)
     api_v2.publish(presenter.content_id, presenter.update_type)
   end
 
@@ -15,8 +16,10 @@ namespace :publishing_api do
   task :republish_editions => :environment do
     TravelAdviceEdition.published.each do |edition|
       presenter = EditionPresenter.new(edition, republish: true)
+      links_presenter = LinksPresenter.new(edition)
 
       api_v2.put_content(presenter.content_id, presenter.render_for_publishing_api)
+      api_v2.put_links(links_presenter.content_id, links_presenter.present)
       api_v2.publish(presenter.content_id, presenter.update_type)
 
       print "."

--- a/spec/presenters/breadcrumbs_presenter_spec.rb
+++ b/spec/presenters/breadcrumbs_presenter_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+
+RSpec.describe BreadcrumbsPresenter, ".present" do
+  it "presents ancestry for breadcrumbs" do
+    expect(described_class.present).to eq(
+      [
+        {
+          "content_id" => "08d48cdd-6b50-43ff-a53b-beab47f4aab0",
+          "base_path" => "/foreign-travel-advice",
+          "title" => "Foreign travel advice",
+          "links" => {
+            "parent" => ["b9849cd6-61a7-42dc-8124-362d2c7d48b0"]
+          }
+        },
+        {
+          "content_id" => "b9849cd6-61a7-42dc-8124-362d2c7d48b0",
+          "base_path" => "/browse/abroad/travel-abroad",
+          "title" => "Travel abroad",
+          "links" => {
+            "parent" => ["86eb717a-fb40-42e7-83fa-d031a03880fb"]
+          }
+        },
+        {
+          "content_id" => "86eb717a-fb40-42e7-83fa-d031a03880fb",
+          "base_path" => "/browse/abroad",
+          "title" => "Passports, travel and living abroad"
+        },
+      ]
+    )
+  end
+
+  it "presents ancestry for index breadcrumbs" do
+    expect(described_class.present_for_index).to eq(
+      [
+        {
+          "content_id" => "b9849cd6-61a7-42dc-8124-362d2c7d48b0",
+          "base_path" => "/browse/abroad/travel-abroad",
+          "title" => "Travel abroad",
+          "links" => {
+            "parent" => ["86eb717a-fb40-42e7-83fa-d031a03880fb"]
+          }
+        },
+        {
+          "content_id" => "86eb717a-fb40-42e7-83fa-d031a03880fb",
+          "base_path" => "/browse/abroad",
+          "title" => "Passports, travel and living abroad"
+        },
+      ]
+    )
+  end
+end

--- a/spec/presenters/index_links_presenter_spec.rb
+++ b/spec/presenters/index_links_presenter_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+RSpec.describe IndexLinksPresenter, ".present" do
+  it "renders index links" do
+    expect(described_class.present).to eq(
+      :links => {
+        "parent" => [
+          {
+            "content_id" => "b9849cd6-61a7-42dc-8124-362d2c7d48b0",
+            "base_path" => "/browse/abroad/travel-abroad",
+            "title" => "Travel abroad",
+            "links" => {
+              "parent" => ["86eb717a-fb40-42e7-83fa-d031a03880fb"]
+            }
+          },
+          {
+            "content_id" => "86eb717a-fb40-42e7-83fa-d031a03880fb",
+            "base_path" => "/browse/abroad",
+            "title" => "Passports, travel and living abroad"
+          },
+        ]
+      }
+    )
+  end
+end

--- a/spec/presenters/index_presenter_spec.rb
+++ b/spec/presenters/index_presenter_spec.rb
@@ -42,6 +42,7 @@ describe IndexPresenter do
       expect(presented_data["format"]).to eq("placeholder_travel_advice_index")
 
       presented_data["format"] = "travel_advice_index"
+
       expect(presented_data).to be_valid_against_schema('travel_advice_index')
     end
 

--- a/spec/presenters/links_presenter_spec.rb
+++ b/spec/presenters/links_presenter_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+
+RSpec.describe LinksPresenter do
+  let(:edition) { FactoryGirl.build(:travel_advice_edition, country_slug: 'aruba') }
+
+  subject { described_class.new(edition) }
+
+  describe "#content_id" do
+    it "renders the content_id of the edition" do
+      expect(subject.content_id).to eq("56bae85b-a57c-4ca2-9dbd-68361a086bb3")
+    end
+  end
+
+  describe "present" do
+    let(:presented_data) { subject.present }
+
+    it "returns travel advice breadcrumbs data" do
+      expect(presented_data).to eq(
+        :links => {
+          "parent" => [
+            {
+              "content_id" => "08d48cdd-6b50-43ff-a53b-beab47f4aab0",
+              "base_path" => "/foreign-travel-advice",
+              "title" => "Foreign travel advice",
+              "links" => {
+                "parent" => ["b9849cd6-61a7-42dc-8124-362d2c7d48b0"]
+              }
+            },
+            {
+              "content_id" => "b9849cd6-61a7-42dc-8124-362d2c7d48b0",
+              "base_path" => "/browse/abroad/travel-abroad",
+              "title" => "Travel abroad",
+              "links" => {
+                "parent" => ["86eb717a-fb40-42e7-83fa-d031a03880fb"]
+              }
+            },
+            {
+              "content_id" => "86eb717a-fb40-42e7-83fa-d031a03880fb",
+              "base_path" => "/browse/abroad",
+              "title" => "Passports, travel and living abroad"
+            }
+          ]
+        }
+      )
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/vm54jvVo/477-send-hard-coded-breadcrumbs-to-publishing-api
Static breadcrumbs for travel advice country and index representations sent to the publishing api in the links hash.
