### PR TITLE
Change edition rendering app to multipage-frontend

### DIFF
--- a/app/observers/panopticon_registration_observer.rb
+++ b/app/observers/panopticon_registration_observer.rb
@@ -16,7 +16,7 @@ class PanopticonRegistrationObserver < Mongoid::Observer
 
   def register_with_panopticon(edition)
     details = RegisterableTravelAdviceEdition.new(edition)
-    registerer = GdsApi::Panopticon::Registerer.new(owning_app: 'travel-advice-publisher', rendering_app: "frontend", kind: 'travel-advice')
+    registerer = GdsApi::Panopticon::Registerer.new(owning_app: 'travel-advice-publisher', rendering_app: "multipage-frontend", kind: 'travel-advice')
     registerer.register(details)
   end
 end

--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -29,7 +29,7 @@ class EditionPresenter
       "description" => edition.overview,
       "locale" => "en",
       "publishing_app" => "travel-advice-publisher",
-      "rendering_app" => "frontend",
+      "rendering_app" => "multipage-frontend",
       "routes" => routes,
       "public_updated_at" => public_updated_at.iso8601,
       "update_type" => update_type,

--- a/lib/tasks/panopticon.rake
+++ b/lib/tasks/panopticon.rake
@@ -33,7 +33,7 @@ namespace :panopticon do
     logger = GdsApi::Base.logger = Logger.new(STDERR).tap { |l| l.level = Logger::INFO }
     logger.info "Registering with panopticon..."
 
-    registerer = GdsApi::Panopticon::Registerer.new(:owning_app => "travel-advice-publisher", :rendering_app => "frontend", :kind => 'travel-advice')
+    registerer = GdsApi::Panopticon::Registerer.new(:owning_app => "travel-advice-publisher", :rendering_app => "multipage-frontend", :kind => 'travel-advice')
 
     TravelAdviceEdition.published.each do |edition|
       details = RegisterableTravelAdviceEdition.new(edition)

--- a/spec/features/edition_edit_spec.rb
+++ b/spec/features/edition_edit_spec.rb
@@ -56,7 +56,7 @@ feature "Edit Edition page", :js => true do
           'name' => 'Aruba travel advice',
           'kind' => 'travel-advice',
           'owning_app' => 'travel-advice-publisher',
-          'rendering_app' => 'frontend',
+          'rendering_app' => 'multipage-frontend',
           'state' => 'draft'
       ))
     end
@@ -396,7 +396,7 @@ feature "Edit Edition page", :js => true do
         'indexable_content' => 'Summary Part One Body text',
         'kind' => 'travel-advice',
         'owning_app' => 'travel-advice-publisher',
-        'rendering_app' => 'frontend',
+        'rendering_app' => 'multipage-frontend',
         'state' => 'live'
     ))
 

--- a/spec/models/travel_advice_edition_spec.rb
+++ b/spec/models/travel_advice_edition_spec.rb
@@ -65,7 +65,7 @@ describe TravelAdviceEdition do
       RegisterableTravelAdviceEdition.should_receive(:new).with(ed).and_return(registerable_edition)
       GdsApi::Panopticon::Registerer.should_receive(:new).with(
         :owning_app => 'travel-advice-publisher',
-        :rendering_app => 'frontend',
+        :rendering_app => 'multipage-frontend',
         :kind => 'travel-advice'
       ).and_return(registerer)
       registerer.should_receive(:register).with(registerable_edition)
@@ -106,7 +106,7 @@ describe TravelAdviceEdition do
       RegisterableTravelAdviceEdition.should_receive(:new).with(ed).and_return(registerable_edition)
       GdsApi::Panopticon::Registerer.should_receive(:new).with(
         :owning_app => 'travel-advice-publisher',
-        :rendering_app => 'frontend',
+        :rendering_app => 'multipage-frontend',
         :kind => 'travel-advice'
       ).and_return(registerer)
       registerer.should_receive(:register).with(registerable_edition)

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -68,7 +68,7 @@ describe EditionPresenter do
         "description" => "Something something",
         "locale" => "en",
         "publishing_app" => "travel-advice-publisher",
-        "rendering_app" => "frontend",
+        "rendering_app" => "multipage-frontend",
         "public_updated_at" => edition.published_at.iso8601,
         "update_type" => "major",
         "routes" => [

--- a/spec/presenters/index_presenter_spec.rb
+++ b/spec/presenters/index_presenter_spec.rb
@@ -43,7 +43,7 @@ describe IndexPresenter do
       expect(presented_data).to be_valid_against_schema('travel_advice_index')
     end
 
-    it "returns a placeholder item" do
+    it "returns a presented index item" do
       Timecop.freeze do
         expect(presented_data).to eq(
           "content_id" => TravelAdvicePublisher::INDEX_CONTENT_ID,


### PR DESCRIPTION
Without this `rendering_app` change, routes for new/changed editions will still point at the `frontend` app.