### PR TITLE
Publish edition on Update review date.

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -117,6 +117,7 @@ class Admin::EditionsController < ApplicationController
 
     if @edition.save!
       PublishingApiNotifier.put_content(@edition)
+      PublishingApiNotifier.publish(@edition, update_type: "minor")
       redirect_to admin_country_path(@edition.country_slug), :alert => "Updated review date"
     else
       redirect_to edit_admin_edition_path(@edition), :alert => "Failed to update the review date"

--- a/app/notifiers/publishing_api_notifier.rb
+++ b/app/notifiers/publishing_api_notifier.rb
@@ -12,10 +12,11 @@ module PublishingApiNotifier
       api.put_links(presenter.content_id, presenter.present)
     end
 
-    def publish(edition)
+    def publish(edition, update_type: nil)
       presenter = EditionPresenter.new(edition)
 
-      api.publish(presenter.content_id, presenter.update_type)
+      update_type = update_type || presenter.update_type
+      api.publish(presenter.content_id, update_type)
     end
 
     def publish_index

--- a/spec/features/edition_edit_spec.rb
+++ b/spec/features/edition_edit_spec.rb
@@ -224,6 +224,9 @@ feature "Edit Edition page", :js => true do
 
       page.should have_content "Updated review date"
       assert_details_contains("2a3938e1-d588-45fc-8c8f-0f51814d5409", "reviewed_at", Time.now.iso8601)
+      assert_publishing_api_publish("2a3938e1-d588-45fc-8c8f-0f51814d5409", {
+        update_type: "minor"
+      })
     end
   end
 


### PR DESCRIPTION
Currently this action only calls the publishing-api put_content endpoint, which sends a new draft but does not make it live. We need to call publish as well, sending it as a minor update.