### PR TITLE
Revert "Use country slug in EmailAlertPresenter"

### DIFF
--- a/app/presenters/email_alert_presenter.rb
+++ b/app/presenters/email_alert_presenter.rb
@@ -29,7 +29,7 @@ private
   end
 
   def links
-    { countries: [country.slug] }
+    { countries: [content_id] }
   end
 
   def document_type

--- a/spec/presenters/email_alert_presenter_spec.rb
+++ b/spec/presenters/email_alert_presenter_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe EmailAlertPresenter do
   it "formats the message to include the parent link" do
     expect(email_alert["subject"]).to eq("Algeria travel advice")
     expect(email_alert["tags"]).to eq({})
-    expect(email_alert["links"]).to eq(countries: ["algeria"])
+    expect(email_alert["links"]).to eq(countries: ["b5c8e64b-3461-4447-9144-1588e4a84fe6"])
     expect(email_alert["document_type"]).to eq("travel_advice")
 
     body = email_alert["body"]


### PR DESCRIPTION
Reverts alphagov/travel-advice-publisher#113

To be merged after https://github.com/alphagov/email-alert-api/pull/101 (see there for reasoning)