### PR TITLE
Explicitly include test-unit Gem everywhere

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,8 +52,10 @@ group :development, :test do
   gem 'timecop', '0.5.9.2'
   gem 'jasmine', '2.1.0'
   gem 'govuk-content-schema-test-helpers', '~> 1.3.0'
-  gem 'test-unit'
   gem 'govuk-lint', '~> 0.5.3'
   gem 'pry-rails'
   gem "pry-byebug"
 end
+
+# FIXME: move back into the `test` group once we're on Rails 4
+gem 'test-unit'


### PR DESCRIPTION
ActiveSupport appears to depends on test-unit, which was removed in 2.2.0:

https://www.ruby-lang.org/en/news/2014/12/25/ruby-2-2-0-released/

Adding this back in at the top level allows us to get a Rails console again.

This should only be an issue until [we go to Rails 4](https://github.com/alphagov/travel-advice-publisher/pull/112) - it appears to be [related to `3.2.x`](https://github.com/rspec/rspec-rails/issues/1273#issuecomment-70681180).