### PR TITLE
Make the SEND_EMAIL_ALERTS flag Hieradata friendly

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,5 +68,5 @@ TravelAdvicePublisher::Application.configure do
   config.logstasher.supress_app_log = true
 
   # Feature flag to enable the sending of email alerts
-  config.send_email_alerts = (ENV["SEND_EMAIL_ALERTS"] == "true")
+  config.send_email_alerts = (ENV["SEND_EMAIL_ALERTS"] == "1")
 end


### PR DESCRIPTION
`"true"` is a quoted boolean value in Hiera, which is against our style.

Making this a '1' gets around this and still conveys intent.