### PR TITLE
Update schemas to use the new subscriber_list details format

### DIFF
--- a/app/presenters/email_alert_signup/edition_presenter.rb
+++ b/app/presenters/email_alert_signup/edition_presenter.rb
@@ -51,15 +51,17 @@ module EmailAlertSignup
 
     def details
       {
-        subscriber_list_document_type: "travel_advice",
-        signup_tags: tags,
+        subscriber_list: {
+          document_type: "travel_advice",
+          links: subscriber_list_links,
+        },
         summary: summary,
         breadcrumbs: breadcrumbs,
         govdelivery_title: edition.title,
       }
     end
 
-    def tags
+    def subscriber_list_links
       { countries: [country.content_id] }
     end
 

--- a/app/presenters/email_alert_signup/index_presenter.rb
+++ b/app/presenters/email_alert_signup/index_presenter.rb
@@ -45,8 +45,9 @@ module EmailAlertSignup
 
     def details
       {
-        subscriber_list_document_type: "travel_advice",
-        signup_tags: {},
+        subscriber_list: {
+          document_type: "travel_advice",
+        },
         summary: summary,
         breadcrumbs: breadcrumbs,
         govdelivery_title: "Foreign travel advice",

--- a/spec/presenters/email_alert_signup/edition_presenter_spec.rb
+++ b/spec/presenters/email_alert_signup/edition_presenter_spec.rb
@@ -44,9 +44,11 @@ RSpec.describe EmailAlertSignup::EditionPresenter do
       details: {
         summary: "You'll get an email each time Aruba Travel Advice is updated.",
         govdelivery_title: "Aruba Travel Advice",
-        subscriber_list_document_type: "travel_advice",
-        signup_tags: {
-          countries: [edition_content_id],
+        subscriber_list: {
+          document_type: "travel_advice",
+          links: {
+            countries: [edition_content_id],
+          },
         },
         breadcrumbs: [
           {

--- a/spec/presenters/email_alert_signup/index_presenter_spec.rb
+++ b/spec/presenters/email_alert_signup/index_presenter_spec.rb
@@ -31,8 +31,9 @@ RSpec.describe EmailAlertSignup::IndexPresenter do
       details: {
         summary: "You'll get an email each time a country is updated.",
         govdelivery_title: "Foreign travel advice",
-        subscriber_list_document_type: "travel_advice",
-        signup_tags: {},
+        subscriber_list: {
+          document_type: "travel_advice",
+        },
         breadcrumbs: [
           {
             title: "Foreign travel advice",


### PR DESCRIPTION
**We will merge the pull requests ourselves in the Publishing Platform team when everyone's happy.**

https://trello.com/c/oqGCU2XP/525-add-email-signup-links-to-travel-advice-on-frontend

We've been migrating travel advice over to use the new email-alert-frontend workflow rather than the old pagewatch workflow.

Whilst doing this work, we noticed that policy publisher passes through subscriber list information as implicit links on the signup content item (which should really be reserved for more general associations with other content items). After talking with @tijmenb and @mobaig in Finding Things we concluded that the details hash is the best place for that information.

Therefore, this work consists of four parts:

1) An update to travel advice publisher to create the new email alert signup forms
https://github.com/alphagov/travel-advice-publisher/pull/123

2) An update to policy publisher to change the structure of the subscriber list data
https://github.com/alphagov/policy-publisher/pull/129

3) An update the email-alert-frontend to support searching by document_type (required for travel index)
https://github.com/alphagov/email-alert-frontend/pull/25

4) An update to the content schemas to reflect the new subscriber list data structure
https://github.com/alphagov/govuk-content-schemas/pull/261

We'd like to merge and deploy all four pull requests at (roughly) the same time. Please could comment as usual and state whether you are happy for the pull requests to be merged.