### PR TITLE
Use the new email signup journey…

### DIFF
--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -48,7 +48,7 @@ private
       "updated_at" => updated_at.iso8601,
       "reviewed_at" => reviewed_at.iso8601,
       "change_description" => edition.change_description,
-      "email_signup_link" => TravelAdvicePublisher::EMAIL_SIGNUP_URL,
+      "email_signup_link" => "#{base_path}/email-signup",
       "parts" => parts,
       "alert_status" => edition.alert_status,
     }

--- a/app/presenters/index_presenter.rb
+++ b/app/presenters/index_presenter.rb
@@ -10,7 +10,7 @@ class IndexPresenter
   def render_for_publishing_api
     {
       "content_id" => content_id,
-      "base_path" => "/foreign-travel-advice",
+      "base_path" => base_path,
       "format" => TravelAdvicePublisher::INDEX_FORMAT,
       "title" => "Foreign travel advice",
       "description" => "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",
@@ -25,13 +25,18 @@ class IndexPresenter
       "public_updated_at" => Time.zone.now.iso8601,
       "update_type" => update_type,
       "details" => {
-        "email_signup_link" => TravelAdvicePublisher::EMAIL_SIGNUP_URL,
+        "email_signup_link" => "#{base_path}/email-signup",
         "countries" => countries,
       }
     }
   end
 
 private
+
+  def base_path
+    "/foreign-travel-advice"
+  end
+
   def countries
     Country.all.map do |country|
       edition = country.last_published_edition

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,8 +26,6 @@ module TravelAdvicePublisher
   INDEX_CONTENT_ID = "08d48cdd-6b50-43ff-a53b-beab47f4aab0"
   INDEX_EMAIL_SIGNUP_CONTENT_ID = "1aebfc97-7723-4cb6-82f4-434639efc185"
 
-  EMAIL_SIGNUP_URL = "https://public.govdelivery.com/accounts/UKGOVUK/subscriber/topics?qsp=TRAVEL"
-
   COUNTRY_FORMAT = "travel_advice"
 
   INDEX_FORMAT = "travel_advice_index"

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -87,7 +87,7 @@ describe EditionPresenter do
           "updated_at" => Time.zone.now.iso8601,
           "reviewed_at" => Time.zone.now.iso8601,
           "change_description" => "Stuff changed",
-          "email_signup_link" => TravelAdvicePublisher::EMAIL_SIGNUP_URL,
+          "email_signup_link" => "/foreign-travel-advice/aruba/email-signup",
           "parts" => [
             {
               "slug" => "safety-and-security",

--- a/spec/presenters/index_presenter_spec.rb
+++ b/spec/presenters/index_presenter_spec.rb
@@ -62,7 +62,7 @@ describe IndexPresenter do
           "public_updated_at" => Time.zone.now.iso8601,
           "update_type" => "minor",
           "details" => {
-            "email_signup_link" => TravelAdvicePublisher::EMAIL_SIGNUP_URL,
+            "email_signup_link" => "/foreign-travel-advice/email-signup",
             "countries" => [
               {
                 "name" => "Andorra",


### PR DESCRIPTION
This change points the email links on travel
advice pages to the new signup journey that uses
the email-alert-frontend.

Previously we were sending users to a generic
govdelivery page where they were prompted to check
the boxes of countries to subscribe to.

This change will require a republish of the
index and countries content items. There are rake
tasks for this.