### PR TITLE
Cache travel advice content for a maximum of 10 seconds

### DIFF
--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -51,6 +51,7 @@ private
       "email_signup_link" => "#{base_path}/email-signup",
       "parts" => parts,
       "alert_status" => edition.alert_status,
+      "max_cache_time" => 10,
     }
 
     details.merge!("image" => image) if image

--- a/app/presenters/index_presenter.rb
+++ b/app/presenters/index_presenter.rb
@@ -27,6 +27,7 @@ class IndexPresenter
       "details" => {
         "email_signup_link" => "#{base_path}/email-signup",
         "countries" => countries,
+        "max_cache_time" => 10,
       }
     }
   end

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -107,6 +107,7 @@ describe EditionPresenter do
             }
           ],
           "alert_status" => ["avoid_all_but_essential_travel_to_parts"],
+          "max_cache_time" => 10
         },
       )
     end

--- a/spec/presenters/index_presenter_spec.rb
+++ b/spec/presenters/index_presenter_spec.rb
@@ -81,6 +81,7 @@ describe IndexPresenter do
                 "synonyms" => ["foo", "bar"],
               },
             ],
+            "max_cache_time" => 10,
           },
         )
       end


### PR DESCRIPTION
These tests are failing because of the schemas, which are updated here:
https://github.com/alphagov/govuk-content-schemas/pull/273