### PR TITLE
Trigger pub API index update in separate worker.

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -97,9 +97,13 @@ class Admin::EditionsController < ApplicationController
       notifier.put_content(@edition)
       notifier.put_links(@edition)
       notifier.publish(@edition)
-      notifier.publish_index
       notifier.enqueue
+
       EmailAlertApiNotifier.send_alert(@edition)
+
+      index_notifier = PublishingApiNotifier.new
+      index_notifier.publish_index
+      index_notifier.enqueue
 
       # catch any upload errors
       if @edition.errors.any?


### PR DESCRIPTION
This should prevent the (less important) update of
the travel advice index page from affecting updates
to the individual travel advice pages if the index
page update fails or conflicts.