### PR TITLE
Add rake task to trigger email alerts for an edition.

### DIFF
--- a/lib/tasks/email_alerts.rake
+++ b/lib/tasks/email_alerts.rake
@@ -1,0 +1,10 @@
+namespace :email_alerts do
+  desc "Triggers an email notification for the given edition ID"
+  task :trigger, [:edition_id] => :environment do |task, args|
+    abort "Please provide an edition ID, e.g. rake #{task.name}[fedc13e231ccd7d63e1abf65]" unless args[:edition_id]
+
+    edition = TravelAdviceEdition.find(id: args[:edition_id])
+    puts "Sending an email alert for #{edition.title}"
+    EmailAlertApiNotifier.send_alert(edition)
+  end
+end

--- a/spec/tasks/email_alerts_rake_spec.rb
+++ b/spec/tasks/email_alerts_rake_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+require "rake"
+
+describe "Email alert rake tasks", type: :rake_task do
+  include GdsApi::TestHelpers::EmailAlertApi
+
+  before do
+    Rake.application = nil # Reset any previously loaded tasks
+    Rails.application.load_tasks
+    stub_any_email_alert_api_call
+  end
+
+  describe "trigger_email_alert" do
+    let(:task) { Rake::Task["email_alerts:trigger"] }
+    let(:country_slug) { "aruba" }
+
+    it "triggers an email notification for the given edition ID" do
+      edition = FactoryGirl.create(:published_travel_advice_edition, country_slug: country_slug)
+
+      task.invoke(edition.id)
+
+      assert_email_alert_sent(
+        "links" => {
+          "countries" => [Country.find_by_slug(country_slug).content_id]
+        }
+      )
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/Xr0LF1IP/653-rake-resend-alert-task-for-ta-advice

Opsmanual update: https://github.gds/gds/opsmanual/pull/659