### PR TITLE
Improve error messages when Sidekiq jobs fails

### DIFF
--- a/app/workers/publishing_api_worker.rb
+++ b/app/workers/publishing_api_worker.rb
@@ -5,7 +5,11 @@ class PublishingApiWorker
     jobs.each do |endpoint, content_id, payload|
       payload.symbolize_keys! if payload.is_a?(Hash)
 
-      api.public_send(endpoint, content_id, payload)
+      begin
+        api.public_send(endpoint, content_id, payload)
+      rescue => e
+        raise_helpful_error(e, jobs, endpoint, content_id, payload)
+      end
     end
   end
 
@@ -14,4 +18,40 @@ private
   def api
     TravelAdvicePublisher.publishing_api_v2
   end
+
+  def raise_helpful_error(e, jobs, endpoint, content_id, payload)
+    message = "Sidekiq job failed in #{self.class.name}."
+
+    message += "\n\n=== Job details ==="
+    jobs.each { |j| message += "\n#{j.inspect}" }
+
+    message += "\n\n=== Failed request details ==="
+    message += "\n#{endpoint}, #{content_id}"
+    message += "\n#{payload}"
+
+    message += "\n\n=== Error details ==="
+    message += "\n#{e.message}"
+    message += "\n#{filter_backtrace(e.backtrace).join("\n")}"
+
+    message += "\n\n=== Sidekiq queue details ==="
+    message += "\nItems on queue: #{queue_size}"
+    message += "\nItems in retry set: #{retry_set_size}"
+
+    raise Error, message
+  end
+
+  def filter_backtrace(backtrace)
+    backtrace.select { |l| l.include?("travel-advice-publisher") }
+  end
+
+  def queue_size
+    queue = Sidekiq::Queue.all.first
+    queue ? queue.size : "No queue found"
+  end
+
+  def retry_set_size
+    Sidekiq::RetrySet.new.size
+  end
+
+  class Error < StandardError; end
 end


### PR DESCRIPTION
Example error output:

```
PublishingApiWorker::Error:
  Sidekiq job failed in PublishingApiWorker.

  === Job details ===
  [:put_content, "30dcf739-2920-49a9-83f0-b6a987827231", {:details=>{"foo"=>"bar"}}]

  === Failed request details ===
  put_content, 30dcf739-2920-49a9-83f0-b6a987827231
  {:details=>{"foo"=>"bar"}}

  === Error details ===
  GdsApi::TimedOutException
  /var/govuk/travel-advice-publisher/app/workers/publishing_api_worker.rb:9:in `public_send'
  /var/govuk/travel-advice-publisher/app/workers/publishing_api_worker.rb:9:in `block in perform'
  /var/govuk/travel-advice-publisher/app/workers/publishing_api_worker.rb:5:in `each'
  /var/govuk/travel-advice-publisher/app/workers/publishing_api_worker.rb:5:in `perform'
  /var/govuk/travel-advice-publisher/spec/workers/publishing_api_worker_spec.rb:30:in `block (3 levels) in <top (required)>'

  === Sidekiq queue details ===
  Items on queue: 8
  Items in retry set: 0
```