### PR TITLE
Send GOVUK-Request-Id HTTP header downstream.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 27.2.0'
+  gem 'gds-api-adapters', '~> 30.2.0'
 end
 
 gem 'logstasher', '0.4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
     diff-lcs (1.2.5)
     diffy (3.0.7)
     docile (1.1.5)
-    domain_name (0.5.20160128)
+    domain_name (0.5.20160310)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
@@ -124,7 +124,7 @@ GEM
       actionpack (>= 3.0)
     formtastic-bootstrap (3.0.0)
       formtastic (>= 2.2)
-    gds-api-adapters (27.2.2)
+    gds-api-adapters (30.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -411,7 +411,7 @@ DEPENDENCIES
   factory_girl_rails
   formtastic (= 2.3.0)
   formtastic-bootstrap (= 3.0.0)
-  gds-api-adapters (~> 27.2.0)
+  gds-api-adapters (~> 30.2.0)
   gds-sso (~> 11.2)
   govspeak (~> 3.5.2)
   govuk-content-schema-test-helpers (~> 1.3.0)

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -154,6 +154,10 @@ class Admin::EditionsController < ApplicationController
   end
 
   def notifier
-    @notifier ||= PublishingApiNotifier.new
+    @notifier ||= PublishingApiNotifier.new(request_id: govuk_request_id)
+  end
+
+  def govuk_request_id
+    @govuk_request_id ||= GdsApi::GovukHeaders.headers[:govuk_request_id]
   end
 end

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -14,7 +14,7 @@ class Admin::EditionsController < ApplicationController
 
     if edition.save
       notifier.put_content(edition)
-      notifier.put_links(edition)
+      notifier.patch_links(edition)
       notifier.enqueue
       redirect_to edit_admin_edition_path(edition)
     else
@@ -95,12 +95,12 @@ class Admin::EditionsController < ApplicationController
   def save_and_publish
     if @edition.update_attributes(permitted_edition_attributes) && @edition.publish_as(current_user)
       notifier.put_content(@edition)
-      notifier.put_links(@edition)
+      notifier.patch_links(@edition)
       notifier.publish(@edition)
       notifier.send_alert(@edition)
       notifier.enqueue
 
-      index_notifier = PublishingApiNotifier.new
+      index_notifier = PublishingApiNotifier.new(request_id: govuk_request_id)
       index_notifier.publish_index
       index_notifier.enqueue
 

--- a/app/notifiers/publishing_api_notifier.rb
+++ b/app/notifiers/publishing_api_notifier.rb
@@ -10,10 +10,10 @@ class PublishingApiNotifier
     tasks << [:put_content, presenter.content_id, presenter.render_for_publishing_api]
   end
 
-  def put_links(edition)
+  def patch_links(edition)
     presenter = LinksPresenter.new(edition)
 
-    tasks << [:put_links, presenter.content_id, presenter.present]
+    tasks << [:patch_links, presenter.content_id, presenter.present]
   end
 
   def publish(edition, update_type: nil)
@@ -27,7 +27,7 @@ class PublishingApiNotifier
     presenter = IndexPresenter.new
 
     tasks << [:put_content, presenter.content_id, presenter.render_for_publishing_api]
-    tasks << [:put_links, presenter.content_id, IndexLinksPresenter.present]
+    tasks << [:patch_links, presenter.content_id, IndexLinksPresenter.present]
     tasks << [:publish, presenter.content_id, presenter.update_type]
   end
 

--- a/app/notifiers/publishing_api_notifier.rb
+++ b/app/notifiers/publishing_api_notifier.rb
@@ -1,5 +1,4 @@
 class PublishingApiNotifier
-
   def initialize
     self.tasks = []
   end

--- a/app/notifiers/publishing_api_notifier.rb
+++ b/app/notifiers/publishing_api_notifier.rb
@@ -1,6 +1,7 @@
 class PublishingApiNotifier
-  def initialize
+  def initialize(request_id:)
     self.tasks = []
+    self.request_id = request_id
   end
 
   def put_content(edition)
@@ -40,12 +41,12 @@ class PublishingApiNotifier
 
   def enqueue
     validate_tasks_order
-    worker.perform_async(tasks) if tasks.any?
+    worker.perform_async(tasks, request_id: request_id) if tasks.any?
   end
 
 private
 
-  attr_accessor :tasks
+  attr_accessor :tasks, :request_id
 
   def worker
     PublishingApiWorker

--- a/app/workers/email_alert_api_worker.rb
+++ b/app/workers/email_alert_api_worker.rb
@@ -1,7 +1,9 @@
 class EmailAlertApiWorker
   include Sidekiq::Worker
 
-  def perform(payload)
+  def perform(payload, params = {})
+    GdsApi::GovukHeaders.set_header(:govuk_request_id, params["request_id"])
+
     api.send_alert(payload) if send_alert?
   rescue => e
     message = "\n\n=== Failed request details ==="

--- a/app/workers/publishing_api_worker.rb
+++ b/app/workers/publishing_api_worker.rb
@@ -1,13 +1,15 @@
 class PublishingApiWorker
   include Sidekiq::Worker
 
-  def perform(jobs)
+  def perform(jobs, params = {})
+    GdsApi::GovukHeaders.set_header(:govuk_request_id, params["request_id"])
+
     jobs.each do |endpoint, content_id, payload|
       payload = payload.symbolize_keys if payload.is_a?(Hash)
 
       begin
         if endpoint == "send_alert"
-          EmailAlertApiWorker.perform_async(payload)
+          EmailAlertApiWorker.perform_async(payload, request_id: params["request_id"])
         else
           api.public_send(endpoint, content_id, payload)
         end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -8,7 +8,7 @@ namespace :publishing_api do
     presenter = IndexPresenter.new
 
     api_v2.put_content(presenter.content_id, presenter.render_for_publishing_api)
-    api_v2.put_links(TravelAdvicePublisher::INDEX_CONTENT_ID, IndexLinksPresenter.present)
+    api_v2.patch_links(TravelAdvicePublisher::INDEX_CONTENT_ID, IndexLinksPresenter.present)
     api_v2.publish(presenter.content_id, presenter.update_type)
   end
 
@@ -19,7 +19,7 @@ namespace :publishing_api do
       links_presenter = LinksPresenter.new(edition)
 
       api_v2.put_content(presenter.content_id, presenter.render_for_publishing_api)
-      api_v2.put_links(links_presenter.content_id, links_presenter.present)
+      api_v2.patch_links(links_presenter.content_id, links_presenter.present)
       api_v2.publish(presenter.content_id, presenter.update_type)
 
       print "."

--- a/spec/notifiers/publishing_api_notifier_spec.rb
+++ b/spec/notifiers/publishing_api_notifier_spec.rb
@@ -2,7 +2,6 @@ require "spec_helper"
 require "sidekiq/testing"
 
 RSpec.describe PublishingApiNotifier do
-
   before do
     Sidekiq::Worker.clear_all
     stub_request(:put, %r{#{GdsApi::TestHelpers::Panopticon::PANOPTICON_ENDPOINT}/artefacts.*})

--- a/spec/notifiers/publishing_api_notifier_spec.rb
+++ b/spec/notifiers/publishing_api_notifier_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe PublishingApiNotifier do
     end
   end
 
-  describe "put_content, put_links and enqueue" do
+  describe "put_content, patch_links and enqueue" do
     let(:content_presenter) { EditionPresenter.new(edition) }
     let(:links_presenter) { LinksPresenter.new(edition) }
 
@@ -39,7 +39,7 @@ RSpec.describe PublishingApiNotifier do
       presented_links = links_presenter.present.as_json
 
       subject.put_content(edition)
-      subject.put_links(edition)
+      subject.patch_links(edition)
       subject.enqueue
 
       expect(PublishingApiWorker.jobs.size).to eq(1)
@@ -54,7 +54,7 @@ RSpec.describe PublishingApiNotifier do
 
       endpoint, content_id, payload = tasks.second
 
-      expect(endpoint).to eq("put_links")
+      expect(endpoint).to eq("patch_links")
       expect(content_id).to eq(links_presenter.content_id)
       expect(payload).to eq(presented_links)
     end
@@ -145,11 +145,11 @@ RSpec.describe PublishingApiNotifier do
     end
 
     it "enqueues a put links job second" do
-      put_links_task = tasks.second
+      patch_links_task = tasks.second
 
-      expect(put_links_task.first).to eq("put_links")
-      expect(put_links_task.second).to eq(presenter.content_id)
-      expect(put_links_task.last).to eq(IndexLinksPresenter.present.as_json)
+      expect(patch_links_task.first).to eq("patch_links")
+      expect(patch_links_task.second).to eq(presenter.content_id)
+      expect(patch_links_task.last).to eq(IndexLinksPresenter.present.as_json)
     end
 
     it "enqueues a publish job last" do

--- a/spec/notifiers/publishing_api_notifier_spec.rb
+++ b/spec/notifiers/publishing_api_notifier_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe PublishingApiNotifier do
     stub_request(:put, %r{#{GdsApi::TestHelpers::Panopticon::PANOPTICON_ENDPOINT}/artefacts.*})
   end
 
+  subject { PublishingApiNotifier.new(request_id: "12345-54321")}
+
   let(:edition) { FactoryGirl.create(:travel_advice_edition, country_slug: "aruba", published_at: Time.zone.now) }
 
   describe "put_content and enqueue" do

--- a/spec/requests/request_tracing_spec.rb
+++ b/spec/requests/request_tracing_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+require 'sidekiq/testing'
+require "gds_api/test_helpers/email_alert_api"
+
+RSpec.describe "Request tracing", type: :request do
+  include GdsApi::TestHelpers::PublishingApiV2
+  include GdsApi::TestHelpers::EmailAlertApi
+
+  let(:govuk_request_id) { "12345-67890" }
+  let(:edition) { FactoryGirl.create(:travel_advice_edition, country_slug: "aruba") }
+
+  before do
+    FactoryGirl.create(:user)
+    stub_any_publishing_api_call
+    stub_any_email_alert_api_call
+    stub_request(:any, /panopticon/)
+  end
+
+  it "passes the govuk_request_id through all downstream workers" do
+    params = {
+      commit: "Save & Publish",
+      edition: {
+        title: "New title",
+      },
+    }
+    inbound_headers = {
+      "HTTP_GOVUK_REQUEST_ID" => govuk_request_id,
+    }
+
+    put "/admin/editions/#{edition.id}", params, inbound_headers
+    GdsApi::GovukHeaders.clear_headers # Simulate workers running in a separate thread
+    Sidekiq::Worker.drain_all # Run all workers
+
+    onward_headers = {
+      "GOVUK-Request-Id" => govuk_request_id
+    }
+    expect(WebMock).to have_requested(:put, /panopticon/).with(headers: onward_headers)
+    expect(WebMock).to have_requested(:put, /publishing-api.*content/).with(headers: onward_headers).twice
+    expect(WebMock).to have_requested(:patch, /publishing-api.*links/).with(headers: onward_headers).twice
+    expect(WebMock).to have_requested(:post, /publishing-api.*publish/).with(headers: onward_headers).twice
+    expect(WebMock).to have_requested(:post, /email-alert-api/).with(headers: onward_headers)
+  end
+end


### PR DESCRIPTION
The workers run in different threads/processes to
the webserver so HTTP headers are lost.

https://trello.com/c/Eddv2AiS/688-for-migrated-formats-update-for-request-tracing