### PR TITLE
Save `govuk_request_id` on publish

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -109,6 +109,8 @@ class Admin::EditionsController < ApplicationController
         flash[:alert] = @edition.errors.full_messages.join(", ")
       end
 
+      PublishRequest.create(request_id: govuk_request_id, edition_id: @edition.id)
+
       redirect_to admin_country_path(@edition.country_slug), :alert => "#{@edition.title} published."
     else
       flash[:alert] = "We had some problems publishing: #{@edition.errors.full_messages.join(", ")}."

--- a/app/models/publish_request.rb
+++ b/app/models/publish_request.rb
@@ -1,0 +1,7 @@
+class PublishRequest
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  field :edition_id
+  field :request_id
+end

--- a/spec/controllers/admin/editions_controller_spec.rb
+++ b/spec/controllers/admin/editions_controller_spec.rb
@@ -209,7 +209,7 @@ describe Admin::EditionsController do
       @draft = FactoryGirl.create(:draft_travel_advice_edition, country_slug: 'aruba')
     end
 
-    describe "publish" do
+    describe "Save & Publish" do
       it "should publish the edition" do
         allow(TravelAdviceEdition).to receive(:find).with(@draft.to_param).and_return(@draft)
         allow(@draft).to receive(:publish).and_return(true)
@@ -225,6 +225,15 @@ describe Admin::EditionsController do
         post :update, id: @draft.to_param, edition: {}, commit: "Save & Publish"
 
         expect(PublishingApiWorker.jobs.size).to eq(2)
+      end
+
+      it "creates a PublishRequest for that edition" do
+        request_id = '123456'
+        allow(GdsApi::GovukHeaders).to receive(:headers).and_return(govuk_request_id: request_id)
+        post :update, id: @draft.to_param, edition: {}, commit: "Save & Publish"
+        publish_request = PublishRequest.last
+        expect(publish_request.edition_id).to eq(@draft.id)
+        expect(publish_request.request_id).to eq(request_id)
       end
     end
   end


### PR DESCRIPTION
The `govuk_request_id` is set per request in the headers. Storing this value when an `Edition` is published will allow the database record to be compared with the front end representation and the alert email for monitoring purposes to ensure the publish and alert succeeded.

[Trello](https://trello.com/c/TQoOXFZ4/31-save-request-id-on-publish-in-tap)