### PR TITLE
Add delay to ensure the cache is expired

### DIFF
--- a/app/workers/publishing_api_worker.rb
+++ b/app/workers/publishing_api_worker.rb
@@ -9,7 +9,7 @@ class PublishingApiWorker
 
       begin
         if endpoint == "send_alert"
-          EmailAlertApiWorker.perform_async(payload, request_id: params["request_id"])
+          EmailAlertApiWorker.perform_in(CACHE_EXPIRES_IN, payload, request_id: params["request_id"])
         else
           api.public_send(endpoint, content_id, payload)
         end
@@ -20,6 +20,8 @@ class PublishingApiWorker
   end
 
 private
+
+  CACHE_EXPIRES_IN = 10.seconds
 
   def api
     TravelAdvicePublisher.publishing_api_v2


### PR DESCRIPTION
This PR addresses an issue when a user opens an email with a travel advice update, clicks the link and does not get the latest information. 

## Description
The email has a link to published content. This content has a TTL of 10 seconds as per commits:

- [Setting TTL in multipage frontend](https://github.com/alphagov/multipage-frontend/blob/master/app/controllers/travel_advice_controller.rb#L3-3)
- [Setting TTL in Travel Advice Publisher for content store](https://github.com/alphagov/travel-advice-publisher/blob/master/app/presenters/edition_presenter.rb#L54)

By postponing sending the email `10 seconds`, we intend to cover situations where a user receives the email, clicks on it immediately, and get old content. This is not very likely to happen due to latency among [email-alert-api](https://github.com/alphagov/email-alert-api), [gov delivery](https://github.com/govdelivery) and the user, but something we would like to cover.

## Note
This is not a final solution, as a better caching mechanism is planned to be built for the [content store](https://github.com/alphagov/content-store). This is a temporary solution to prevent unexpected results.