### PR TITLE
Add GOVUK request id to payload details...

### DIFF
--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -52,6 +52,7 @@ private
       "parts" => parts,
       "alert_status" => edition.alert_status,
       "max_cache_time" => 10,
+      "publishing_request_id" => publishing_request_id,
     }
 
     details.merge!("image" => image) if image
@@ -99,5 +100,9 @@ private
 
   def document
     @document ||= AssetPresenter.present(edition.document)
+  end
+
+  def publishing_request_id
+    GdsApi::GovukHeaders.headers[:govuk_request_id]
   end
 end

--- a/spec/features/edition_edit_spec.rb
+++ b/spec/features/edition_edit_spec.rb
@@ -373,6 +373,9 @@ feature "Edit Edition page", js: true do
   end
 
   scenario "save and publish an edition" do
+    allow(GdsApi::GovukHeaders).to receive(:headers)
+      .and_return(govuk_request_id: "25108-1461151489.528-10.3.3.1-1066")
+
     @old_edition = FactoryGirl.create(:published_travel_advice_edition, country_slug: 'albania')
     @edition = FactoryGirl.create(:draft_travel_advice_edition, country_slug: 'albania', title: 'Albania travel advice',
                                   alert_status: TravelAdviceEdition::ALERT_STATUSES[1..0],
@@ -426,6 +429,9 @@ feature "Edit Edition page", js: true do
     assert_publishing_api_publish(TravelAdvicePublisher::INDEX_CONTENT_ID, {
       update_type: "minor"
     })
+
+    assert_details_contains("2a3938e1-d588-45fc-8c8f-0f51814d5409",
+                            "publishing_request_id", "25108-1461151489.528-10.3.3.1-1066")
 
     assert_email_alert_sent("subject" => "Albania travel advice")
   end

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -37,6 +37,11 @@ describe EditionPresenter do
     edition
   }
 
+  before do
+    allow(GdsApi::GovukHeaders).to receive(:headers)
+      .and_return(govuk_request_id: "25108-1461151489.528-10.3.3.1-1066")
+  end
+
   subject { described_class.new(edition) }
 
   describe "#content_id" do
@@ -111,7 +116,8 @@ describe EditionPresenter do
             }
           ],
           "alert_status" => ["avoid_all_but_essential_travel_to_parts"],
-          "max_cache_time" => 10
+          "max_cache_time" => 10,
+          "publishing_request_id" => "25108-1461151489.528-10.3.3.1-1066"
         },
       )
     end


### PR DESCRIPTION
https://trello.com/c/Io2JYTFv/27-ensure-request-id-is-available-to-multipage-frontend-and-frontend-apps

Pass the govuk request id generated at the load balancer into
the [payload details as 'publishing_request_id'](https://github.com/alphagov/govuk-content-schemas/commit/eb4f5df8b2bbdc72cbf24c8ccb490cf509e44f47), this will be
then be present in the downstream apps and availble to the
frontend apps for rendering in govuk:publishing-request-id
meta tags. (see https://github.com/alphagov/frontend/pull/941 and https://github.com/alphagov/multipage-frontend/pull/36)
This end-to-end identifier will be the basis for feedback and
monitoring mechanisms to ensure content gets published and
delivered by email.