### PR TITLE
[WIP] Add publication checks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ gem 'sidekiq', '3.5.1'
 gem "sidekiq-logging-json", "0.0.14"
 gem "sidekiq-statsd", "0.1.5"
 
+gem "aws-sdk"
+
 # Gems used only for assets and not required in production
 # environments by default.
 group :assets do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,12 @@ GEM
     autoprefixer-rails (6.3.1)
       execjs
       json
+    aws-sdk (2.2.36)
+      aws-sdk-resources (= 2.2.36)
+    aws-sdk-core (2.2.36)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.2.36)
+      aws-sdk-core (= 2.2.36)
     bootstrap-sass (3.3.6)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
@@ -169,12 +175,15 @@ GEM
       rack (>= 1.2.1)
       rake
     jasmine-core (2.1.3)
+    jmespath (1.2.4)
+      json_pure (>= 1.8.1)
     jquery-rails (3.1.4)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
     json-schema (2.5.2)
       addressable (~> 2.3.8)
+    json_pure (1.8.3)
     jwt (1.5.1)
     kgio (2.10.0)
     kramdown (1.5.0)
@@ -403,6 +412,7 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake (~> 4.0.0)
+  aws-sdk
   capybara (= 2.6.2)
   ci_reporter_rspec
   database_cleaner (= 1.5.1)

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -109,7 +109,11 @@ class Admin::EditionsController < ApplicationController
         flash[:alert] = @edition.errors.full_messages.join(", ")
       end
 
-      PublishRequest.create(request_id: govuk_request_id, edition_id: @edition.id)
+      PublishRequest.create(
+        request_id: govuk_request_id,
+        edition_id: @edition.id,
+        country_slug: @edition.country_slug
+      )
 
       redirect_to admin_country_path(@edition.country_slug), :alert => "#{@edition.title} published."
     else

--- a/app/models/publish_request.rb
+++ b/app/models/publish_request.rb
@@ -4,4 +4,21 @@ class PublishRequest
 
   field :edition_id
   field :request_id
+  field :check_count, type: Integer, default: 0
+  field :succeeded, type: Boolean, default: false
+  field :checks_complete, type: Boolean, default: false
+  field :email_received, type: Boolean, default: false
+  field :frontend_updated, type: Boolean, default: false
+
+  MAX_RETRIES = 3
+
+  def register_check_attempt!
+    self.check_count = check_count + 1
+    self.checks_complete = check_count >= MAX_RETRIES
+    if(self.email_received? && self.frontend_updated?)
+      self.succeeded = true
+      self.checks_complete = true
+    end
+    save!
+  end
 end

--- a/app/models/publish_request.rb
+++ b/app/models/publish_request.rb
@@ -25,4 +25,8 @@ class PublishRequest
   def mark_email_received
     self.email_received = true
   end
+
+  def mark_frontend_updated
+    self.frontend_updated = true
+  end
 end

--- a/app/models/publish_request.rb
+++ b/app/models/publish_request.rb
@@ -21,4 +21,8 @@ class PublishRequest
     end
     save!
   end
+
+  def mark_email_received
+    self.email_received = true
+  end
 end

--- a/app/models/publish_request.rb
+++ b/app/models/publish_request.rb
@@ -9,6 +9,7 @@ class PublishRequest
   field :checks_complete, type: Boolean, default: false
   field :email_received, type: Boolean, default: false
   field :frontend_updated, type: Boolean, default: false
+  field :country_slug, type: String
 
   MAX_RETRIES = 3
 

--- a/lib/publication_check/content_store_check.rb
+++ b/lib/publication_check/content_store_check.rb
@@ -1,0 +1,36 @@
+module PublicationCheck
+  class ContentStoreCheck
+    attr_reader :request_id, :publish_request
+
+    def run(publish_request)
+      @publish_request = publish_request
+      @request_id = publish_request.request_id
+      page_has_request_id?
+    end
+
+  private
+
+    def content_store_url
+      "#{Plek.find('www-origin')}/api/content/foreign-travel-advice/#{country_slug}"
+    end
+
+    def edition
+      @edition ||= TravelAdviceEdition.find(publish_request.edition_id)
+    end
+
+    def country_slug
+      edition.country_slug
+    end
+
+    def page_response
+      Net::HTTP.get_response(URI(content_store_url))
+    end
+
+    def page_has_request_id?
+      response_json = JSON.parse(page_response.body)
+      content_store_request_id = response_json["details"]["publishing_request_id"]
+      content_store_request_id.present? &&
+        content_store_request_id == request_id
+    end
+  end
+end

--- a/lib/publication_check/content_store_check.rb
+++ b/lib/publication_check/content_store_check.rb
@@ -5,7 +5,9 @@ module PublicationCheck
     def run(publish_request)
       @publish_request = publish_request
       @request_id = publish_request.request_id
-      page_has_request_id?
+      result = page_has_request_id?
+      publish_request.mark_frontend_updated if result
+      result
     end
 
   private

--- a/lib/publication_check/email_alert_check.rb
+++ b/lib/publication_check/email_alert_check.rb
@@ -1,8 +1,9 @@
 module PublicationCheck
   class EmailAlertCheck
-    attr_reader :govuk_request_id
+    attr_reader :govuk_request_id, :publish_request
 
     def run(publish_request)
+      @publish_request = publish_request
       @govuk_request_id = publish_request.request_id
       run_check
     end
@@ -12,6 +13,7 @@ module PublicationCheck
     def run_check
       begin
         get_object
+        publish_request.mark_email_received
         return true
       rescue Aws::S3::Errors::NoSuchKey
         return false

--- a/lib/publication_check/email_alert_check.rb
+++ b/lib/publication_check/email_alert_check.rb
@@ -1,0 +1,40 @@
+module PublicationCheck
+  class EmailAlertCheck
+    attr_reader :govuk_request_id
+
+    def run(publish_request)
+      @govuk_request_id = publish_request.request_id
+      run_check
+    end
+
+  private
+
+    def run_check
+      begin
+        get_object
+        return true
+      rescue Aws::S3::Errors::NoSuchKey
+        return false
+      end
+    end
+
+    def get_object
+      s3.get_object(
+        bucket: bucket,
+        key: object_key
+      )
+    end
+
+    def bucket
+      "govuk-email-alert-notifications"
+    end
+
+    def object_key
+      "travel-advice-alerts/#{govuk_request_id}.msg"
+    end
+
+    def s3
+      @s3 ||= Aws::S3::Client.new
+    end
+  end
+end

--- a/lib/publication_check/result.rb
+++ b/lib/publication_check/result.rb
@@ -1,0 +1,17 @@
+module PublicationCheck
+  class Result
+    def initialize
+      @publish_requests = []
+    end
+
+    def add_checked_request(publish_request)
+      @publish_requests << publish_request
+    end
+
+    def success?
+      #TODO check the state of the publish requests and return
+      #based on if any have failed all retries
+      true
+    end
+  end
+end

--- a/lib/publication_check/runner.rb
+++ b/lib/publication_check/runner.rb
@@ -1,0 +1,22 @@
+module PublicationCheck
+  class Runner
+    DEFAULT_CHECKS = [
+      EmailAlertCheck,
+      ContentStoreCheck
+    ]
+
+    def self.run_check(publish_requests, checks = DEFAULT_CHECKS)
+      Result.new.tap do |result|
+        publish_requests.each do |publish_request|
+          checks.map(&:new).each do |check|
+            check.run(publish_request)
+          end
+          result.add_checked_request(publish_request)
+          #TODO update publish_request state eg. publish_request.mark_checked
+          #which would either increment the checked count for retry attempts (if all checks haven't passed)
+          #or else set a successfully checked flag
+        end
+      end
+    end
+  end
+end

--- a/lib/publication_check/runner.rb
+++ b/lib/publication_check/runner.rb
@@ -11,10 +11,8 @@ module PublicationCheck
           checks.map(&:new).each do |check|
             check.run(publish_request)
           end
+          publish_request.register_check_attempt!
           result.add_checked_request(publish_request)
-          #TODO update publish_request state eg. publish_request.mark_checked
-          #which would either increment the checked count for retry attempts (if all checks haven't passed)
-          #or else set a successfully checked flag
         end
       end
     end

--- a/spec/lib/publication_check/content_store_check_spec.rb
+++ b/spec/lib/publication_check/content_store_check_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+module PublicationCheck
+  describe ContentStoreCheck do
+    let(:edition){
+      FactoryGirl.create(
+        :published_travel_advice_edition,
+        country_slug: "andorra",
+        version_number: 2)
+    }
+    let(:publish_request){
+      PublishRequest.new(
+        request_id: "25107-1461581820.634-185.22.224.96-13641",
+        edition_id: edition.id
+      )
+    }
+    let(:content_store_check){ ContentStoreCheck.new }
+    let(:content_store_url){
+      "#{Plek.find('www-origin')}/api/content/foreign-travel-advice/#{edition.country_slug}"
+      # "https://www.gov.uk/api/content/foreign-travel-advice/#{edition.country_slug}"
+    }
+    let(:content_store_response){
+      double(status: 200, body: response_body)
+    }
+    let(:response_publishing_request_id){
+      "25107-1461581820.634-185.22.224.96-13641"
+    }
+    let(:response_body){
+      <<-JSON
+        {
+          "base_path": "test/base/path",
+          "content_id": "7a2554bd-9dc5-4a2e-953c-263c65ced66b",
+          "details": {
+            "publishing_request_id": "#{response_publishing_request_id}"
+          }
+        }
+      JSON
+    }
+
+    before do
+      allow(Net::HTTP).to receive(:get_response)
+        .with(URI(content_store_url))
+        .and_return(content_store_response)
+    end
+
+    it "requests the correct page" do
+      expect(Net::HTTP).to receive(:get_response).with(
+        URI(content_store_url)
+      ).and_return(content_store_response)
+      content_store_check.run(publish_request)
+    end
+
+    context "a response containing the request id" do
+      before do
+        allow(Net::HTTP).to receive(:get_response)
+          .with(URI(content_store_url))
+          .and_return(content_store_response)
+      end
+
+      it "returns true" do
+        expect(content_store_check.run(publish_request))
+          .to be(true)
+      end
+    end
+
+    context "a response containing a different request id" do
+      let(:response_publishing_request_id){
+        "25107-1461581820.634-185.22.224.96-1234"
+      }
+
+      it "returns false" do
+        expect(content_store_check.run(publish_request))
+          .to be(false)
+      end
+    end
+
+    context "the response contains no request_id" do
+      let(:response_body){
+        <<-JSON
+          {
+            "base_path": "test/base/path",
+            "content_id": "7a2554bd-9dc5-4a2e-953c-263c65ced66b",
+            "details": {}
+          }
+        JSON
+      }
+
+      it "returns false" do
+        expect(content_store_check.run(publish_request))
+          .to be(false)
+      end
+    end
+  end
+end

--- a/spec/lib/publication_check/content_store_check_spec.rb
+++ b/spec/lib/publication_check/content_store_check_spec.rb
@@ -61,6 +61,11 @@ module PublicationCheck
         expect(content_store_check.run(publish_request))
           .to be(true)
       end
+
+      it "marks the publish request as frontend updated" do
+        expect(publish_request).to receive(:mark_frontend_updated)
+        content_store_check.run(publish_request)
+      end
     end
 
     context "a response containing a different request id" do
@@ -71,6 +76,11 @@ module PublicationCheck
       it "returns false" do
         expect(content_store_check.run(publish_request))
           .to be(false)
+      end
+
+      it "doesn't mark the publish request as frontend updated" do
+        expect(publish_request).not_to receive(:mark_frontend_updated)
+        content_store_check.run(publish_request)
       end
     end
 
@@ -88,6 +98,11 @@ module PublicationCheck
       it "returns false" do
         expect(content_store_check.run(publish_request))
           .to be(false)
+      end
+
+      it "doesn't mark the publish request as frontend updated" do
+        expect(publish_request).not_to receive(:mark_frontend_updated)
+        content_store_check.run(publish_request)
       end
     end
   end

--- a/spec/lib/publication_check/email_alert_check_spec.rb
+++ b/spec/lib/publication_check/email_alert_check_spec.rb
@@ -26,23 +26,39 @@ module PublicationCheck
       end
 
       context "file exists" do
-        it "returns true" do
+        before do
           allow(client).to receive(:get_object)
             .with(
               bucket: bucket_name,
               key: object_key
           ).and_return s3_object
+        end
+
+        it "returns true" do
+          email_alert_check.run(publish_request)
+        end
+
+        it "marks the PublishRequest email_received" do
+          expect(publish_request).to receive(:mark_email_received)
           email_alert_check.run(publish_request)
         end
       end
 
       context "file doesn't exist" do
-        it "returns false" do
+        before do
           allow(client).to receive(:get_object)
             .with(
               bucket: bucket_name,
               key: object_key
           ).and_raise(Aws::S3::Errors::NoSuchKey.new(nil, "The specified key does not exist."))
+        end
+
+        it "returns false" do
+          email_alert_check.run(publish_request)
+        end
+
+        it "doesn't mark the PublishRequest email_received" do
+          expect(publish_request).not_to receive(:mark_email_received)
           email_alert_check.run(publish_request)
         end
       end

--- a/spec/lib/publication_check/email_notification_sent_check_spec.rb
+++ b/spec/lib/publication_check/email_notification_sent_check_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+module PublicationCheck
+  describe EmailAlertCheck do
+    let(:email_alert_check){ EmailAlertCheck.new }
+    let(:govuk_request_id){ '1234-3345-10.0.0.1' }
+    let(:publish_request){ PublishRequest.new(request_id: govuk_request_id, edition_id: 1) }
+    let(:client){ double() }
+    let(:bucket_name){ "govuk-email-alert-notifications" }
+    let(:s3_object){ double() }
+    let(:object_key){ "travel-advice-alerts/#{govuk_request_id}.msg" }
+
+    before do
+      allow(Aws::S3::Client).to receive(:new)
+        .and_return(client)
+    end
+
+    describe "#run" do
+      it "requests the correct file from s3" do
+        expect(client).to receive(:get_object)
+          .with(
+            bucket: bucket_name,
+            key: "travel-advice-alerts/#{govuk_request_id}.msg"
+        )
+        email_alert_check.run(publish_request)
+      end
+
+      context "file exists" do
+        it "returns true" do
+          allow(client).to receive(:get_object)
+            .with(
+              bucket: bucket_name,
+              key: object_key
+          ).and_return s3_object
+          email_alert_check.run(publish_request)
+        end
+      end
+
+      context "file doesn't exist" do
+        it "returns false" do
+          allow(client).to receive(:get_object)
+            .with(
+              bucket: bucket_name,
+              key: object_key
+          ).and_raise(Aws::S3::Errors::NoSuchKey.new(nil, "The specified key does not exist."))
+          email_alert_check.run(publish_request)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/publication_check/runner_spec.rb
+++ b/spec/lib/publication_check/runner_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 module PublicationCheck
   describe Runner do
-    let(:request_one){ double() }
-    let(:request_two){ double() }
+    let(:request_one){ double(register_check_attempt!: nil) }
+    let(:request_two){ double(register_check_attempt!: nil) }
     let(:publish_requests){ [request_one, request_two] }
     let(:check){ double(new: double(run: true)) }
 
@@ -38,6 +38,11 @@ module PublicationCheck
       expect(result).to receive(:add_checked_request).with(request_one)
       expect(result).to receive(:add_checked_request).with(request_two)
       Runner.run_check(publish_requests, [check])
+    end
+
+    it "registers a check on the PublishRequest" do
+      expect(request_one).to receive(:register_check_attempt!)
+      Runner.run_check([request_one], [check])
     end
   end
 end

--- a/spec/lib/publication_check/runner_spec.rb
+++ b/spec/lib/publication_check/runner_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+module PublicationCheck
+  describe Runner do
+    let(:request_one){ double() }
+    let(:request_two){ double() }
+    let(:publish_requests){ [request_one, request_two] }
+    let(:check){ double(new: double(run: true)) }
+
+    it "passes each request to each check's run method" do
+      allow(EmailAlertCheck).to receive(:new)
+        .and_return(email_check = double())
+      allow(ContentStoreCheck).to receive(:new)
+        .and_return(content_store_check = double())
+
+      publish_requests.each do | publish_request |
+        expect(email_check).to receive(:run)
+          .with(publish_request)
+        expect(content_store_check).to receive(:run)
+          .with(publish_request)
+      end
+
+      Runner.run_check(publish_requests)
+    end
+
+    it "uses a new check object per check" do
+      expect(EmailAlertCheck)
+        .to receive(:new).exactly(2).times
+        .and_return(double(run: true))
+      expect(ContentStoreCheck)
+        .to receive(:new).exactly(2).times
+        .and_return(double(run: true))
+      Runner.run_check(publish_requests)
+    end
+
+    it "adds each checked PublishRequest to the result" do
+      allow(Result).to receive(:new).and_return(result = Result.new)
+      expect(result).to receive(:add_checked_request).with(request_one)
+      expect(result).to receive(:add_checked_request).with(request_two)
+      Runner.run_check(publish_requests, [check])
+    end
+  end
+end
+

--- a/spec/models/publish_request_spec.rb
+++ b/spec/models/publish_request_spec.rb
@@ -1,8 +1,9 @@
 require 'spec_helper'
 
 describe PublishRequest do
+  let(:publish_request){ PublishRequest.new }
+
   describe "#register_check_attempt!" do
-    let(:publish_request){ PublishRequest.new }
     context "no successful checks" do
       it "increments the check_count" do
         publish_request.register_check_attempt!
@@ -130,6 +131,13 @@ describe PublishRequest do
         publish_request.register_check_attempt!
         expect(publish_request.checks_complete?).to be(true)
       end
+    end
+  end
+
+  describe "mark_email_received" do
+    it "sets email_received to true" do
+      publish_request.mark_email_received
+      expect(publish_request.email_received?).to eq(true)
     end
   end
 end

--- a/spec/models/publish_request_spec.rb
+++ b/spec/models/publish_request_spec.rb
@@ -140,4 +140,11 @@ describe PublishRequest do
       expect(publish_request.email_received?).to eq(true)
     end
   end
+
+  describe "mark_frontend_updated" do
+    it "sets frontend_updated to true" do
+      publish_request.mark_frontend_updated
+      expect(publish_request.frontend_updated?).to eq(true)
+    end
+  end
 end

--- a/spec/models/publish_request_spec.rb
+++ b/spec/models/publish_request_spec.rb
@@ -1,0 +1,135 @@
+require 'spec_helper'
+
+describe PublishRequest do
+  describe "#register_check_attempt!" do
+    let(:publish_request){ PublishRequest.new }
+    context "no successful checks" do
+      it "increments the check_count" do
+        publish_request.register_check_attempt!
+        expect(publish_request.check_count).to eq(1)
+      end
+    end
+
+    context "incremented check_count == MAX_RETRIES (3)" do
+      context "no successful checks" do
+        let(:publish_request){ PublishRequest.new(check_count: 2) }
+        before do
+          publish_request.register_check_attempt!
+        end
+
+        it "increments the check count" do
+          expect(publish_request.check_count).to eq(3)
+        end
+
+        it "sets succeeded? to false" do
+          expect(publish_request.succeeded?).to be(false)
+        end
+
+        it "sets checks_complete? to true" do
+          expect(publish_request.checks_complete?).to be(true)
+        end
+      end
+
+      context "one check passed one not" do
+        let(:publish_request){
+          PublishRequest.new(check_count: 2, email_received: true, frontend_updated: false)
+        }
+
+        before do
+          publish_request.register_check_attempt!
+        end
+
+        it "increments the check count" do
+          expect(publish_request.check_count).to eq(3)
+        end
+
+        it "sets succeeded? to false" do
+          expect(publish_request.succeeded?).to be(false)
+        end
+
+        it "sets checks_complete? to true" do
+          expect(publish_request.checks_complete?).to be(true)
+        end
+      end
+
+      context "all checks passed" do
+        let(:publish_request){
+          PublishRequest.new(check_count: 2, email_received: true, frontend_updated: true)
+        }
+
+        before do
+          publish_request.register_check_attempt!
+        end
+
+        it "increments the check count" do
+          expect(publish_request.check_count).to eq(3)
+        end
+
+        it "sets succeeded? to false" do
+          expect(publish_request.succeeded?).to be(true)
+        end
+
+        it "sets checks_complete? to true" do
+          expect(publish_request.checks_complete?).to be(true)
+        end
+      end
+    end
+  end
+
+  context "check_count < MAX_RETRIES" do
+    context "all checks passed" do
+      let(:publish_request){
+        PublishRequest.new(check_count: 0, email_received: true, frontend_updated: true)
+      }
+
+      before do
+        publish_request.register_check_attempt!
+      end
+
+      it "increments the check_count" do
+        expect(publish_request.check_count).to eq(1)
+      end
+
+      it "sets succeeded? to false" do
+        expect(publish_request.succeeded?).to be(true)
+      end
+
+      it "sets checks_complete? to true" do
+        expect(publish_request.checks_complete?).to be(true)
+      end
+    end
+
+    context "all checks not passed" do
+      let(:publish_request){
+        PublishRequest.new(check_count: 0, email_received: true, frontend_updated: false)
+      }
+
+      before do
+        publish_request.register_check_attempt!
+      end
+
+      it "increments the check_count" do
+        expect(publish_request.check_count).to eq(1)
+      end
+
+      it "leaves succeeded? false" do
+        expect(publish_request.succeeded?).to be(false)
+      end
+
+      it "leaves checks_complete? false" do
+        expect(publish_request.checks_complete?).to be(false)
+      end
+    end
+
+    context "check_count > MAX_RETRIES" do
+      let(:publish_request){
+        PublishRequest.new(check_count: 5, email_received: true, frontend_updated: false)
+      }
+
+      it "sets checks_complete? to true" do
+        publish_request.register_check_attempt!
+        expect(publish_request.checks_complete?).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Just for discussion so please don't merge.

The basic flow is that `Runner` accepts an array of `PublishRequest` objects to check and then passes them through each check (currently `EmailAlertCheck` and `ContentStoreCheck`). The check objects will mark the supplied `PublishRequest` as having been successfully checked if the check passes. If not they will do nothing.

When the checks are complete `Runner` will mark the `PublishRequest` as having been checked. This will probably involve incrementing a count on the `PublishRequest` which will allow them to be retried until they haven't passed after _n_ retries at which point they are considered to have failed.

`Result` gets populated by runner and will expose a list of failed `PublishRequest` objects and `#success?` to allow a calling rake task to return the failed publishing attempts if necessary.

None of the state on `PublishRequest` has been implemented as yet.

I'd be interested to hear thoughts on retry intervals and number of attempts. Also whether the use `aws-sdk` as opposed to having a public bucket and just using Net::HTTP... and anything else :)