### PR TITLE
Add uuid to publishing api work

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -100,7 +100,7 @@ class Admin::EditionsController < ApplicationController
       notifier.send_alert(@edition)
       notifier.enqueue
 
-      index_notifier = PublishingApiNotifier.new(request_id: govuk_request_id)
+      index_notifier = PublishingApiNotifier.new
       index_notifier.publish_index
       index_notifier.enqueue
 
@@ -156,7 +156,7 @@ class Admin::EditionsController < ApplicationController
   end
 
   def notifier
-    @notifier ||= PublishingApiNotifier.new(request_id: govuk_request_id)
+    @notifier ||= PublishingApiNotifier.new
   end
 
   def govuk_request_id

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
   before_filter :authenticate_user!
   before_filter :require_signin_permission!
+  before_filter :set_authenticated_user_header
 
   def error_404; error 404; end
 
@@ -11,5 +12,11 @@ class ApplicationController < ActionController::Base
 
   def error(status_code)
     render status: status_code, text: "#{status_code} error"
+  end
+
+  def set_authenticated_user_header
+    if current_user && GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user].nil?
+      GdsApi::GovukHeaders.set_header(:x_govuk_authenticated_user, current_user.uid)
+    end
   end
 end

--- a/app/notifiers/publishing_api_notifier.rb
+++ b/app/notifiers/publishing_api_notifier.rb
@@ -1,7 +1,6 @@
 class PublishingApiNotifier
-  def initialize(request_id:)
+  def initialize
     self.tasks = []
-    self.request_id = request_id
   end
 
   def put_content(edition)
@@ -41,12 +40,12 @@ class PublishingApiNotifier
 
   def enqueue
     validate_tasks_order
-    worker.perform_async(tasks, request_id: request_id) if tasks.any?
+    worker.perform_async(tasks, request_id: request_id, user_id: user_id) if tasks.any?
   end
 
 private
 
-  attr_accessor :tasks, :request_id
+  attr_accessor :tasks
 
   def worker
     PublishingApiWorker
@@ -69,6 +68,14 @@ private
       message = "send_alert must be last and immediately follow a publish"
       raise EnqueueError, message
     end
+  end
+
+  def request_id
+    GdsApi::GovukHeaders.headers[:govuk_request_id]
+  end
+
+  def user_id
+    GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user]
   end
 
   class EnqueueError < StandardError; end

--- a/app/workers/publishing_api_worker.rb
+++ b/app/workers/publishing_api_worker.rb
@@ -3,6 +3,7 @@ class PublishingApiWorker
 
   def perform(jobs, params = {})
     GdsApi::GovukHeaders.set_header(:govuk_request_id, params["request_id"])
+    GdsApi::GovukHeaders.set_header(:x_govuk_authenticated_user, params["user_id"])
 
     jobs.each do |endpoint, content_id, payload|
       payload = payload.symbolize_keys if payload.is_a?(Hash)


### PR DESCRIPTION
https://trello.com/c/6nDCqZXi/729-user-id-into-event-log

Events logged in the publishing API should contain the uid of the admin user
so pass these to the PublishingApiWorker and set them as a header in line with
the expectations of the publishing API and gds-api-adapters.