### PR TITLE
Add page published check

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -109,7 +109,11 @@ class Admin::EditionsController < ApplicationController
         flash[:alert] = @edition.errors.full_messages.join(", ")
       end
 
-      PublishRequest.create(request_id: govuk_request_id, edition_id: @edition.id)
+      PublishRequest.create(
+        request_id: govuk_request_id,
+        edition_id: @edition.id,
+        country_slug: @edition.country_slug
+      )
 
       redirect_to admin_country_path(@edition.country_slug), :alert => "#{@edition.title} published."
     else

--- a/app/models/publish_request.rb
+++ b/app/models/publish_request.rb
@@ -7,7 +7,7 @@ class PublishRequest
   field :checks_attempted, type: Array, default: []
   field :succeeded, type: Boolean, default: false
   field :checks_complete, type: Boolean, default: false
-  field :frontend_updated, type: Boolean, default: false
+  field :frontend_updated, type: DateTime, default: nil
   field :country_slug, type: String
 
   MAX_RETRIES = 3
@@ -40,7 +40,7 @@ class PublishRequest
   def register_check_attempt!
     self.checks_attempted << Time.now
     self.checks_complete = check_count >= MAX_RETRIES
-    if self.frontend_updated?
+    if frontend_updated.present?
       self.succeeded = true
       self.checks_complete = true
     end
@@ -48,7 +48,7 @@ class PublishRequest
   end
 
   def mark_frontend_updated
-    self.frontend_updated = true
+    self.frontend_updated = DateTime.now.utc
   end
 
   def check_count

--- a/app/models/publish_request.rb
+++ b/app/models/publish_request.rb
@@ -4,4 +4,20 @@ class PublishRequest
 
   field :edition_id
   field :request_id
+  field :check_count, type: Integer, default: 0
+  field :succeeded, type: Boolean, default: false
+  field :checks_complete, type: Boolean, default: false
+  field :frontend_updated, type: Boolean, default: false
+
+  MAX_RETRIES = 3
+
+  def register_check_attempt!
+    self.check_count = check_count + 1
+    self.checks_complete = check_count >= MAX_RETRIES
+    if self.frontend_updated?
+      self.succeeded = true
+      self.checks_complete = true
+    end
+    save!
+  end
 end

--- a/app/models/publish_request.rb
+++ b/app/models/publish_request.rb
@@ -8,6 +8,7 @@ class PublishRequest
   field :succeeded, type: Boolean, default: false
   field :checks_complete, type: Boolean, default: false
   field :frontend_updated, type: Boolean, default: false
+  field :country_slug, type: String
 
   MAX_RETRIES = 3
 

--- a/app/models/publish_request.rb
+++ b/app/models/publish_request.rb
@@ -4,7 +4,7 @@ class PublishRequest
 
   field :edition_id
   field :request_id
-  field :check_count, type: Integer, default: 0
+  field :checks_attempted, type: Array, default: []
   field :succeeded, type: Boolean, default: false
   field :checks_complete, type: Boolean, default: false
   field :frontend_updated, type: Boolean, default: false
@@ -38,7 +38,7 @@ class PublishRequest
   end
 
   def register_check_attempt!
-    self.check_count = check_count + 1
+    self.checks_attempted << Time.now
     self.checks_complete = check_count >= MAX_RETRIES
     if self.frontend_updated?
       self.succeeded = true
@@ -49,5 +49,9 @@ class PublishRequest
 
   def mark_frontend_updated
     self.frontend_updated = true
+  end
+
+  def check_count
+    checks_attempted.length
   end
 end

--- a/app/models/publish_request.rb
+++ b/app/models/publish_request.rb
@@ -20,4 +20,8 @@ class PublishRequest
     end
     save!
   end
+
+  def mark_frontend_updated
+    self.frontend_updated = true
+  end
 end

--- a/db/migrate/20160627100205_populate_publish_request_country_slugs.rb
+++ b/db/migrate/20160627100205_populate_publish_request_country_slugs.rb
@@ -1,0 +1,12 @@
+class PopulatePublishRequestCountrySlugs < Mongoid::Migration
+  def self.up
+    publish_requests = PublishRequest.all
+    publish_requests.each do |publish_request|
+      edition = TravelAdviceEdition.find(publish_request.edition_id)
+      publish_request.update_attributes!(country_slug: edition.country_slug)
+    end
+  end
+
+  def self.down
+  end
+end

--- a/lib/publication_check/content_store_check.rb
+++ b/lib/publication_check/content_store_check.rb
@@ -1,0 +1,41 @@
+module PublicationCheck
+  class ContentStoreCheck
+    attr_reader :request_id, :publish_request
+
+    def run(publish_request)
+      @publish_request = publish_request
+      @request_id = publish_request.request_id
+      page_has_request_id?
+    end
+
+  private
+
+    def content_store_url
+      File.join(Plek.new.website_root, "api/content/foreign-travel-advice", country_slug)
+    end
+
+    def edition
+      @edition ||= TravelAdviceEdition.find(publish_request.edition_id)
+    end
+
+    def country_slug
+      edition.country_slug
+    end
+
+    def page_response
+      uri = URI(content_store_url)
+      request = Net::HTTP::Get.new(uri)
+      request.basic_auth ENV["AUTH_USERNAME"], ENV["AUTH_PASSWORD"]
+      Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == "https") do |http|
+        http.request(request)
+      end
+    end
+
+    def page_has_request_id?
+      response_json = JSON.parse(page_response.body)
+      content_store_request_id = response_json["details"]["publishing_request_id"]
+      content_store_request_id.present? &&
+        content_store_request_id == request_id
+    end
+  end
+end

--- a/lib/publication_check/content_store_check.rb
+++ b/lib/publication_check/content_store_check.rb
@@ -5,7 +5,9 @@ module PublicationCheck
     def run(publish_request)
       @publish_request = publish_request
       @request_id = publish_request.request_id
-      page_has_request_id?
+      result = page_has_request_id?
+      publish_request.mark_frontend_updated if result
+      result
     end
 
   private

--- a/lib/publication_check/result.rb
+++ b/lib/publication_check/result.rb
@@ -1,0 +1,17 @@
+module PublicationCheck
+  class Result
+    def initialize
+      @publish_requests = []
+    end
+
+    def add_checked_request(publish_request)
+      @publish_requests << publish_request
+    end
+
+    def success?
+      #TODO check the state of the publish requests and return
+      #based on if any have failed all retries
+      true
+    end
+  end
+end

--- a/lib/publication_check/result.rb
+++ b/lib/publication_check/result.rb
@@ -8,10 +8,37 @@ module PublicationCheck
       @publish_requests << publish_request
     end
 
-    def success?
-      #TODO check the state of the publish requests and return
-      #based on if any have failed all retries
-      true
+    def failed?
+      complete_and_unsuccessful.any?
+    end
+
+    def report
+      report_lines = publish_requests.map do |publish_request|
+        generate_report_line(publish_request)
+      end
+      report_lines.join("\n")
+    end
+
+  private
+
+    attr_reader :publish_requests
+
+    def complete_and_unsuccessful
+      publish_requests.select do |publish_request|
+        publish_request.succeeded? == false && publish_request.checks_complete?
+      end
+    end
+
+    def generate_report_line(publish_request)
+      "#{status_string(publish_request)} #{publish_request.edition_id} #{publish_request.country_slug} checked. check_count: #{publish_request.check_count}, frontend_updated: #{publish_request.frontend_updated || 'no'}"
+    end
+
+    def status_string(publish_request)
+      if publish_request.checks_complete?
+        publish_request.succeeded? ? "SUCCESS:" : "FAILURE:"
+      else
+        "ONGOING:"
+      end
     end
   end
 end

--- a/lib/publication_check/runner.rb
+++ b/lib/publication_check/runner.rb
@@ -4,7 +4,7 @@ module PublicationCheck
       ContentStoreCheck
     ]
 
-    def self.run_check(publish_requests, checks = DEFAULT_CHECKS)
+    def self.run_check(publish_requests: PublishRequest.awaiting_check, checks: DEFAULT_CHECKS)
       Result.new.tap do |result|
         publish_requests.each do |publish_request|
           checks.map(&:new).each do |check|

--- a/lib/publication_check/runner.rb
+++ b/lib/publication_check/runner.rb
@@ -1,0 +1,21 @@
+module PublicationCheck
+  class Runner
+    DEFAULT_CHECKS = [
+      ContentStoreCheck
+    ]
+
+    def self.run_check(publish_requests, checks = DEFAULT_CHECKS)
+      Result.new.tap do |result|
+        publish_requests.each do |publish_request|
+          checks.map(&:new).each do |check|
+            check.run(publish_request)
+          end
+          result.add_checked_request(publish_request)
+          #TODO update publish_request state eg. publish_request.mark_checked
+          #which would either increment the checked count for retry attempts (if all checks haven't passed)
+          #or else set a successfully checked flag
+        end
+      end
+    end
+  end
+end

--- a/lib/publication_check/runner.rb
+++ b/lib/publication_check/runner.rb
@@ -10,10 +10,8 @@ module PublicationCheck
           checks.map(&:new).each do |check|
             check.run(publish_request)
           end
+          publish_request.register_check_attempt!
           result.add_checked_request(publish_request)
-          #TODO update publish_request state eg. publish_request.mark_checked
-          #which would either increment the checked count for retry attempts (if all checks haven't passed)
-          #or else set a successfully checked flag
         end
       end
     end

--- a/lib/tasks/publication_checks.rake
+++ b/lib/tasks/publication_checks.rake
@@ -1,0 +1,8 @@
+namespace :publication_checks do
+  desc "Runs the PublicationChecks"
+  task run: :environment do
+    result = PublicationCheck::Runner.run_check
+    puts result.report
+    exit(2) if result.failed?
+  end
+end

--- a/spec/lib/publication_check/content_store_check_spec.rb
+++ b/spec/lib/publication_check/content_store_check_spec.rb
@@ -45,6 +45,11 @@ module PublicationCheck
         expect(content_store_check.run(publish_request))
           .to be(true)
       end
+
+      it "marks the publish request as frontend updated" do
+        expect(publish_request).to receive(:mark_frontend_updated)
+        content_store_check.run(publish_request)
+      end
     end
 
     context "a response containing a different request id" do
@@ -55,6 +60,11 @@ module PublicationCheck
       it "returns false" do
         expect(content_store_check.run(publish_request))
           .to be(false)
+      end
+
+      it "doesn't mark the publish request as frontend updated" do
+        expect(publish_request).not_to receive(:mark_frontend_updated)
+        content_store_check.run(publish_request)
       end
     end
 
@@ -72,6 +82,11 @@ module PublicationCheck
       it "returns false" do
         expect(content_store_check.run(publish_request))
           .to be(false)
+      end
+
+      it "doesn't mark the publish request as frontend updated" do
+        expect(publish_request).not_to receive(:mark_frontend_updated)
+        content_store_check.run(publish_request)
       end
     end
   end

--- a/spec/lib/publication_check/content_store_check_spec.rb
+++ b/spec/lib/publication_check/content_store_check_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+module PublicationCheck
+  describe ContentStoreCheck do
+    let(:edition){
+      FactoryGirl.create(
+        :published_travel_advice_edition,
+        country_slug: "andorra",
+        version_number: 2)
+    }
+    let(:publish_request){
+      PublishRequest.new(
+        request_id: "25107-1461581820.634-185.22.224.96-13641",
+        edition_id: edition.id
+      )
+    }
+    let(:content_store_check){ ContentStoreCheck.new }
+    let(:content_store_url){
+      "http://www.dev.gov.uk/api/content/foreign-travel-advice/#{edition.country_slug}"
+    }
+    let(:response_publishing_request_id){
+      "25107-1461581820.634-185.22.224.96-13641"
+    }
+    let(:response_body){
+      <<-JSON
+        {
+          "base_path": "test/base/path",
+          "content_id": "7a2554bd-9dc5-4a2e-953c-263c65ced66b",
+          "details": {
+            "publishing_request_id": "#{response_publishing_request_id}"
+          }
+        }
+      JSON
+    }
+
+    before do
+      ENV["AUTH_USERNAME"] = "dave"
+      ENV["AUTH_PASSWORD"] = "lemmein"
+      stub_request(:get, "http://dave:lemmein@www.dev.gov.uk/api/content/foreign-travel-advice/andorra")
+        .to_return(status: 200, body: response_body, headers: {})
+    end
+
+    context "a response containing the request id" do
+      it "returns true" do
+        expect(content_store_check.run(publish_request))
+          .to be(true)
+      end
+    end
+
+    context "a response containing a different request id" do
+      let(:response_publishing_request_id){
+        "25107-1461581820.634-185.22.224.96-1234"
+      }
+
+      it "returns false" do
+        expect(content_store_check.run(publish_request))
+          .to be(false)
+      end
+    end
+
+    context "the response contains no request_id" do
+      let(:response_body){
+        <<-JSON
+          {
+            "base_path": "test/base/path",
+            "content_id": "7a2554bd-9dc5-4a2e-953c-263c65ced66b",
+            "details": {}
+          }
+        JSON
+      }
+
+      it "returns false" do
+        expect(content_store_check.run(publish_request))
+          .to be(false)
+      end
+    end
+  end
+end

--- a/spec/lib/publication_check/result_spec.rb
+++ b/spec/lib/publication_check/result_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+
+module PublicationCheck
+  describe Result do
+    describe "#failed?" do
+      context "there is an unsuccessful PublishRequest" do
+        it "returns true" do
+          result = Result.new
+          result.add_checked_request(PublishRequest.new(succeeded: false, checks_complete: true))
+          expect(result.failed?).to be true
+        end
+      end
+
+      context "there are no unsuccessful PublishRequests" do
+        it "returns false" do
+          result = Result.new
+          result.add_checked_request(PublishRequest.new(succeeded: true, checks_complete: true))
+          expect(result.failed?).to be false
+        end
+      end
+    end
+
+    describe "#report" do
+      context "for an incomplete check" do
+        it "returns 'ONGOING: <id> <country_slug> checked. checks_count: <n>, frontend_updated: no" do
+          expected = "ONGOING: 1234 scotland checked. check_count: 1, frontend_updated: no"
+          request = PublishRequest.new(
+            edition_id: 1234,
+            country_slug: "scotland",
+            succeeded: false,
+            checks_complete: false,
+            checks_attempted: [Time.now],
+            frontend_updated: nil,
+          )
+          result = Result.new
+          result.add_checked_request(request)
+          expect(result.report).to eq(expected)
+        end
+      end
+
+      context "for a complete successful check" do
+        let(:updated_time){ DateTime.now }
+        it "returns 'SUCCESS: <id> <country_slug> checked. checks_count: <n>, frontend_updated: <date>" do
+          expected = "SUCCESS: 1234 scotland checked. check_count: 1, frontend_updated: #{updated_time.utc}"
+          request = PublishRequest.new(
+            edition_id: 1234,
+            country_slug: "scotland",
+            succeeded: true,
+            checks_complete: true,
+            checks_attempted: [Time.now],
+            frontend_updated: updated_time,
+          )
+          result = Result.new
+          result.add_checked_request(request)
+          expect(result.report).to eq(expected)
+        end
+      end
+
+      context "for a complete unsuccessful check" do
+        let(:updated_time){ DateTime.now }
+        it "returns 'FAILURE: <id> <country_slug> checked. checks_count: <n>, frontend_updated: no" do
+          expected = "FAILURE: 1234 scotland checked. check_count: 1, frontend_updated: no"
+          request = PublishRequest.new(
+            edition_id: 1234,
+            country_slug: "scotland",
+            succeeded: false,
+            checks_complete: true,
+            checks_attempted: [Time.now],
+            frontend_updated: nil,
+          )
+          result = Result.new
+          result.add_checked_request(request)
+          expect(result.report).to eq(expected)
+        end
+      end
+
+      context "more than one check" do
+        it "returns multiple lines" do
+          result = Result.new
+          result.add_checked_request(PublishRequest.new)
+          result.add_checked_request(PublishRequest.new)
+          expect(result.report.split("\n").count).to eq(2)
+        end
+      end
+    end
+
+  end
+end

--- a/spec/lib/publication_check/runner_spec.rb
+++ b/spec/lib/publication_check/runner_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+module PublicationCheck
+  describe Runner do
+    let(:request_one){ double() }
+    let(:request_two){ double() }
+    let(:publish_requests){ [request_one, request_two] }
+    let(:check){ double(new: double(run: true)) }
+
+    it "passes each request to each check's run method" do
+      allow(ContentStoreCheck).to receive(:new)
+        .and_return(content_store_check = double())
+
+      publish_requests.each do | publish_request |
+        expect(content_store_check).to receive(:run)
+          .with(publish_request)
+      end
+
+      Runner.run_check(publish_requests)
+    end
+
+    it "uses a new check object per check" do
+      expect(ContentStoreCheck)
+        .to receive(:new).exactly(2).times
+        .and_return(double(run: true))
+      Runner.run_check(publish_requests)
+    end
+
+    it "adds each checked PublishRequest to the result" do
+      allow(Result).to receive(:new).and_return(result = Result.new)
+      expect(result).to receive(:add_checked_request).with(request_one)
+      expect(result).to receive(:add_checked_request).with(request_two)
+      Runner.run_check(publish_requests, [check])
+    end
+  end
+end
+

--- a/spec/lib/publication_check/runner_spec.rb
+++ b/spec/lib/publication_check/runner_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 module PublicationCheck
   describe Runner do
-    let(:request_one){ double() }
-    let(:request_two){ double() }
+    let(:request_one){ double(register_check_attempt!: nil) }
+    let(:request_two){ double(register_check_attempt!: nil) }
     let(:publish_requests){ [request_one, request_two] }
     let(:check){ double(new: double(run: true)) }
 
@@ -31,6 +31,11 @@ module PublicationCheck
       expect(result).to receive(:add_checked_request).with(request_one)
       expect(result).to receive(:add_checked_request).with(request_two)
       Runner.run_check(publish_requests, [check])
+    end
+
+    it "registers a check on the PublishRequest" do
+      expect(request_one).to receive(:register_check_attempt!)
+      Runner.run_check([request_one], [check])
     end
   end
 end

--- a/spec/models/publish_request_spec.rb
+++ b/spec/models/publish_request_spec.rb
@@ -1,0 +1,135 @@
+require 'spec_helper'
+
+describe PublishRequest do
+  describe "#register_check_attempt!" do
+    let(:publish_request){ PublishRequest.new }
+    context "no successful checks" do
+      it "increments the check_count" do
+        publish_request.register_check_attempt!
+        expect(publish_request.check_count).to eq(1)
+      end
+    end
+
+    context "incremented check_count == MAX_RETRIES (3)" do
+      context "no successful checks" do
+        let(:publish_request){ PublishRequest.new(check_count: 2) }
+        before do
+          publish_request.register_check_attempt!
+        end
+
+        it "increments the check count" do
+          expect(publish_request.check_count).to eq(3)
+        end
+
+        it "sets succeeded? to false" do
+          expect(publish_request.succeeded?).to be(false)
+        end
+
+        it "sets checks_complete? to true" do
+          expect(publish_request.checks_complete?).to be(true)
+        end
+      end
+
+      context "one check passed one not" do
+        let(:publish_request){
+          PublishRequest.new(check_count: 2, frontend_updated: false)
+        }
+
+        before do
+          publish_request.register_check_attempt!
+        end
+
+        it "increments the check count" do
+          expect(publish_request.check_count).to eq(3)
+        end
+
+        it "sets succeeded? to false" do
+          expect(publish_request.succeeded?).to be(false)
+        end
+
+        it "sets checks_complete? to true" do
+          expect(publish_request.checks_complete?).to be(true)
+        end
+      end
+
+      context "all checks passed" do
+        let(:publish_request){
+          PublishRequest.new(check_count: 2, frontend_updated: true)
+        }
+
+        before do
+          publish_request.register_check_attempt!
+        end
+
+        it "increments the check count" do
+          expect(publish_request.check_count).to eq(3)
+        end
+
+        it "sets succeeded? to false" do
+          expect(publish_request.succeeded?).to be(true)
+        end
+
+        it "sets checks_complete? to true" do
+          expect(publish_request.checks_complete?).to be(true)
+        end
+      end
+    end
+  end
+
+  context "check_count < MAX_RETRIES" do
+    context "all checks passed" do
+      let(:publish_request){
+        PublishRequest.new(check_count: 0, frontend_updated: true)
+      }
+
+      before do
+        publish_request.register_check_attempt!
+      end
+
+      it "increments the check_count" do
+        expect(publish_request.check_count).to eq(1)
+      end
+
+      it "sets succeeded? to false" do
+        expect(publish_request.succeeded?).to be(true)
+      end
+
+      it "sets checks_complete? to true" do
+        expect(publish_request.checks_complete?).to be(true)
+      end
+    end
+
+    context "all checks not passed" do
+      let(:publish_request){
+        PublishRequest.new(check_count: 0, frontend_updated: false)
+      }
+
+      before do
+        publish_request.register_check_attempt!
+      end
+
+      it "increments the check_count" do
+        expect(publish_request.check_count).to eq(1)
+      end
+
+      it "leaves succeeded? false" do
+        expect(publish_request.succeeded?).to be(false)
+      end
+
+      it "leaves checks_complete? false" do
+        expect(publish_request.checks_complete?).to be(false)
+      end
+    end
+
+    context "check_count > MAX_RETRIES" do
+      let(:publish_request){
+        PublishRequest.new(check_count: 5, frontend_updated: false)
+      }
+
+      it "sets checks_complete? to true" do
+        publish_request.register_check_attempt!
+        expect(publish_request.checks_complete?).to be(true)
+      end
+    end
+  end
+end

--- a/spec/models/publish_request_spec.rb
+++ b/spec/models/publish_request_spec.rb
@@ -137,9 +137,52 @@ describe PublishRequest do
     let(:publish_request){
       PublishRequest.new
     }
+
     it "sets frontend_updated to true" do
       publish_request.mark_frontend_updated
       expect(publish_request.frontend_updated?).to eq(true)
+    end
+  end
+
+  describe "awaiting_check scope" do
+    it "returns checks_complete? == false older then 5 minutes" do
+      publish_request = PublishRequest.create(
+        checks_complete: false,
+        created_at: 6.minutes.ago
+      )
+      expect(PublishRequest.awaiting_check[0]).to eq(publish_request)
+    end
+
+    it "doesn't return checks_complete? == false newer than 5 minutes" do
+      PublishRequest.create(
+        checks_complete: false,
+        created_at: 4.minutes.ago
+      )
+      expect(PublishRequest.awaiting_check).to be_empty
+    end
+
+    context "where there are two incomplete PublishRequests for the country_slug" do
+      let!(:publish_request_one){
+        PublishRequest.create(
+          checks_complete: false,
+          created_at: 10.minutes.ago,
+          country_slug: 'denmark'
+        )
+      }
+
+      let!(:publish_request_two){
+        PublishRequest.create(
+          checks_complete: false,
+          created_at: 5.minutes.ago,
+          country_slug: 'denmark'
+        )
+      }
+
+      it "only returns the most recent one" do
+        results = PublishRequest.awaiting_check
+        expect(results.count).to eq(1)
+        expect(results[0]).to eq(publish_request_two)
+      end
     end
   end
 end

--- a/spec/models/publish_request_spec.rb
+++ b/spec/models/publish_request_spec.rb
@@ -132,4 +132,14 @@ describe PublishRequest do
       end
     end
   end
+
+  describe "mark_frontend_updated" do
+    let(:publish_request){
+      PublishRequest.new
+    }
+    it "sets frontend_updated to true" do
+      publish_request.mark_frontend_updated
+      expect(publish_request.frontend_updated?).to eq(true)
+    end
+  end
 end

--- a/spec/models/publish_request_spec.rb
+++ b/spec/models/publish_request_spec.rb
@@ -48,7 +48,7 @@ describe PublishRequest do
         let(:publish_request){
           PublishRequest.new(
             checks_attempted: [10.minutes.ago, 5.minutes.ago],
-            frontend_updated: false)
+            frontend_updated: nil)
         }
 
         before do
@@ -72,7 +72,7 @@ describe PublishRequest do
         let(:publish_request){
           PublishRequest.new(
             checks_attempted: [10.minutes.ago, 5.minutes.ago],
-            frontend_updated: true
+            frontend_updated: 5.minutes.ago
           )
         }
 
@@ -100,7 +100,7 @@ describe PublishRequest do
       let(:publish_request){
         PublishRequest.new(
           checks_attempted: [],
-          frontend_updated: true
+          frontend_updated: 1.minute.ago
         )
       }
 
@@ -125,7 +125,7 @@ describe PublishRequest do
       let(:publish_request){
         PublishRequest.new(
           checks_attempted: [],
-          frontend_updated: false)
+          frontend_updated: nil)
       }
 
       before do
@@ -149,7 +149,7 @@ describe PublishRequest do
       let(:publish_request){
         PublishRequest.new(
           checks_attempted: (1..5).map{ |i| i.minutes.ago },
-          frontend_updated: false
+          frontend_updated: nil
         )
       }
 
@@ -164,10 +164,12 @@ describe PublishRequest do
     let(:publish_request){
       PublishRequest.new
     }
+    before { Timecop.freeze( Time.new(2015,4,10,5,0,0) ) }
+    after { Timecop.return }
 
-    it "sets frontend_updated to true" do
+    it "sets frontend_updated to DateTime.now" do
       publish_request.mark_frontend_updated
-      expect(publish_request.frontend_updated?).to eq(true)
+      expect(publish_request.frontend_updated).to eq(DateTime.now.utc)
     end
   end
 


### PR DESCRIPTION
This PR adds a mechanism for checking that a `TravelAdviceEdition` is being rendered on the front end following publication.

This will be run from a Jenkins job via `rake` allowing an alert to be raised in the event that the published edition fails to make it's way to the content store.

The basic workflow is to retrieve the latest `PublishRequest` that has not previously completed the checks successfully and, if it is older than 5 minutes, compare the `request_id` with that rendered into the content store response for the slug. Success or failure is then stored on the `PublishRequest`.

Once a 'run' of checks is complete any that have failed 3 times cause an error message to be returned and the rake task to `exit(2)`. 

[Trello](https://trello.com/c/mjBCZz2N/402-check-publication-has-succeeded-from-within-travel-advice-publisher-medium)