### PR TITLE
Send blank change_description as empty string.

### DIFF
--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -48,7 +48,7 @@ private
       },
       "updated_at" => updated_at.iso8601,
       "reviewed_at" => reviewed_at.iso8601,
-      "change_description" => edition.change_description,
+      "change_description" => edition.change_description || "",
       "email_signup_link" => "#{base_path}/email-signup",
       "parts" => parts,
       "alert_status" => edition.alert_status,

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -140,6 +140,14 @@ describe EditionPresenter do
       end
     end
 
+    context "when the edition does not have a change_description" do
+      it "sets change_description to an empty string" do
+        edition.change_description = nil
+
+        expect(presented_data["details"]["change_description"]).to eq("")
+      end
+    end
+
     context "when republishing" do
       subject { described_class.new(edition, republish: true) }
 


### PR DESCRIPTION
The schema requires a string, not nil.