### PR TITLE
Rename Democratic Republic of Congo to Democratic Republic of the Congo

### DIFF
--- a/db/migrate/20160916161059_rename_democratic_republic_of_congo.rb
+++ b/db/migrate/20160916161059_rename_democratic_republic_of_congo.rb
@@ -1,0 +1,13 @@
+class RenameDemocraticRepublicOfCongo < Mongoid::Migration
+  def self.up
+    TravelAdviceEdition
+      .where(country_slug: "democratic-republic-of-congo")
+      .update_all(country_slug: "democratic-republic-of-the-congo")
+  end
+
+  def self.down
+    TravelAdviceEdition
+      .where(country_slug: "democratic-republic-of-the-congo")
+      .update_all(country_slug: "democratic-republic-of-congo")
+  end
+end

--- a/docs/further-technical-information.md
+++ b/docs/further-technical-information.md
@@ -4,7 +4,7 @@
 
 Travel Advice Publisher inherits its models from the [govuk_content_models](https://github.com/alphagov/govuk_content_models) gem. In addition to this, enhancements to the `TravelAdviceEdition` model for integration with the [asset manager](https://github.com/alphagov/asset-manager) are present in the app.
 
-At the present time, the list of countries is defined in `lib/data/countries.yml`, however it is expected that this will change to consume an api for countries from the [Whitehall](https://github.com/alphagov/whitehall) app in the near future.
+At the present time, the list of countries is defined in [`lib/data/countries.yml`](../lib/data/countries.yml), however it is expected that this will change to consume an api for countries from the [Whitehall](https://github.com/alphagov/whitehall) app in the near future.
 
 Published travel advice is exposed through the [content-store](https://github.com/alphagov/content-store) and presented in [frontend](https://github.com/alphagov/frontend) and [multipage-frontend](https://github.com/alphagov/multipage-frontend).
 
@@ -16,13 +16,13 @@ When published, unless the 'minor update' checkbox is checked, a change descript
 
 ### Adding or Renaming a Country
 
-To add or rename a country, update the `lib/data/countries.yml` file. You will then need to:
+To add or rename a country, update the [`lib/data/countries.yml`](../lib/data/countries.yml) file. You will then need to:
 
 - Publish the content item for the country to Publishing API
 - Publish the email signup content item for the country to Publishing API
 - Publish an artefact for the country to Panopticon
 
-See `lib/tasks/publishing_api.rake` and `lib/tasks/panopticon.rake` for details on how to do this.
+See [`lib/tasks/publishing_api.rake`](../lib/tasks/publishing_api.rake) and [`lib/tasks/panopticon.rake`](../lib/tasks/panopticon.rake) for details on how to do this.
 
 ### Publishing API
 

--- a/docs/further-technical-information.md
+++ b/docs/further-technical-information.md
@@ -24,6 +24,8 @@ To add or rename a country, update the [`lib/data/countries.yml`](../lib/data/co
 
 See [`lib/tasks/publishing_api.rake`](../lib/tasks/publishing_api.rake) and [`lib/tasks/panopticon.rake`](../lib/tasks/panopticon.rake) for details on how to do this.
 
+To maintain the history of a country when renaming you will need to perform a [migration](../db/migrate/20160916161059_rename_democratic_republic_of_congo.rb) on TravelAdviceEdition
+
 ### Publishing API
 
 Travel advice content reaches the [content-store](https://github.com/alphagov/content-store) via the [publishing-api](https://github.com/alphagov/publishing-api), editorial work is batch-enqueued with Sidekiq for processing out of request.

--- a/lib/data/countries.yml
+++ b/lib/data/countries.yml
@@ -223,8 +223,8 @@
   slug: czech-republic
   content_id: b5e5c48e-dac9-4443-a7cc-8042ccdf8404
   email_signup_content_id: 14303daa-ff18-4cdb-bd07-d81ce5ae78ea
-- name: Democratic Republic of Congo
-  slug: democratic-republic-of-congo
+- name: Democratic Republic of the Congo
+  slug: democratic-republic-of-the-congo
   content_id: 88122213-1a2f-420f-94f9-c622147d4300
   email_signup_content_id: 30bd8028-c26f-4db3-aadf-2b30b577e872
 - name: Denmark


### PR DESCRIPTION
This updates the country `the lib/data/countries.yml` file, it has a migration so that all previous editions are now associated with this country and also updates the documentation minorly.

Once this has been deployed the following rake tasks should be run:

- [ ] `rake "publishing_api:republish_edition[democratic-republic-of-the-congo]"`
- [ ] `rake publishing_api:republish_email_signups`
- [ ] `rake panopticon:reregister_editions`

At the time of writing `rake "publishing_api:republish_edition[democratic-republic-of-the-congo]"` is failing on integration as the Publishing API is rejecting items which don't match the content store schema. 