### PR TITLE
Don't include publishing_request_id if it is blank

### DIFF
--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -53,11 +53,11 @@ private
       "parts" => parts,
       "alert_status" => edition.alert_status,
       "max_cache_time" => 10,
-      "publishing_request_id" => publishing_request_id,
     }
 
     details.merge!("image" => image) if image
     details.merge!("document" => document) if document
+    details.merge!("publishing_request_id" => publishing_request_id) if publishing_request_id
 
     details
   end

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -148,6 +148,17 @@ describe EditionPresenter do
       end
     end
 
+    context "when there is no govuk_request_id header" do
+      before do
+        allow(GdsApi::GovukHeaders).to receive(:headers)
+          .and_return({})
+      end
+
+      it "does not include a publishing_request_id key" do
+        expect(presented_data["details"]).not_to have_key("publishing_request_id")
+      end
+    end
+
     context "when republishing" do
       subject { described_class.new(edition, republish: true) }
 


### PR DESCRIPTION
Schemas don't accept a nil value in this field; leave it out completely if there is no value for the govuk_request_id header. This can happen if the presenter is called from a rake task, for example.