### PR TITLE
Add travel advice pages to the search index via Rummager

### DIFF
--- a/app/models/enhancements/travel_advice_edition.rb
+++ b/app/models/enhancements/travel_advice_edition.rb
@@ -11,6 +11,7 @@ class TravelAdviceEdition
 
   state_machine.after_transition to: :published do |edition, _|
     edition.register_with_panopticon
+    edition.register_with_rummager
   end
 
   after_validation :extract_part_errors
@@ -31,6 +32,11 @@ class TravelAdviceEdition
     details = RegisterableTravelAdviceEdition.new(self)
     registerer = GdsApi::Panopticon::Registerer.new(owning_app: 'travel-advice-publisher', rendering_app: "multipage-frontend", kind: 'travel-advice')
     registerer.register(details)
+  end
+
+  def register_with_rummager
+    details = RegisterableTravelAdviceEdition.new(self)
+    RummagerNotifier.notify(details)
   end
 
   private

--- a/app/presenters/search_payload_presenter.rb
+++ b/app/presenters/search_payload_presenter.rb
@@ -1,0 +1,30 @@
+class SearchPayloadPresenter
+  attr_reader :travel_advice_page
+  delegate :slug,
+           :title,
+           :description,
+           :indexable_content,
+           :content_id,
+           to: :travel_advice_page
+
+  def initialize(travel_advice_page)
+    @travel_advice_page = travel_advice_page
+  end
+
+  def self.call(travel_advice_page)
+    new(travel_advice_page).call
+  end
+
+  def call
+    {
+      content_id: content_id,
+      rendering_app: 'frontend',
+      publishing_app: 'travel-advice-publisher',
+      format: 'custom-application',
+      title: title,
+      description: description,
+      indexable_content: indexable_content,
+      link: "/#{slug}"
+    }
+  end
+end

--- a/app/services/rummager_notifier.rb
+++ b/app/services/rummager_notifier.rb
@@ -1,0 +1,24 @@
+require 'gds_api/rummager'
+
+class RummagerNotifier
+  attr_reader :travel_advice_page
+
+  def self.notify(travel_advice_page)
+    new(travel_advice_page).notify
+  end
+
+  def initialize(travel_advice_page)
+    @travel_advice_page = travel_advice_page
+  end
+
+  def notify
+    logger.info "Indexing '#{travel_advice_page.title}' in rummager..."
+    SearchIndexer.call(travel_advice_page)
+  end
+
+private
+
+  def logger
+    GdsApi::Base.logger = Logger.new(STDERR).tap { |l| l.level = Logger::INFO }
+  end
+end

--- a/app/services/search_indexer.rb
+++ b/app/services/search_indexer.rb
@@ -1,0 +1,30 @@
+class SearchIndexer
+  attr_reader :travel_advice_page
+  delegate :slug, to: :travel_advice_page
+
+  def initialize(travel_advice_page)
+    @travel_advice_page = travel_advice_page
+  end
+
+  def self.call(travel_advice_page)
+    new(travel_advice_page).call
+  end
+
+  def call
+    TravelAdvicePublisher.rummager.add_document(document_type, document_id, payload)
+  end
+
+private
+
+  def document_type
+    'edition'
+  end
+
+  def document_id
+    "/#{slug}"
+  end
+
+  def payload
+    SearchPayloadPresenter.call(travel_advice_page)
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,7 @@ module TravelAdvicePublisher
   mattr_accessor :asset_api
   mattr_accessor :publishing_api_v2
   mattr_accessor :email_alert_api
+  mattr_accessor :rummager
 
   # Maslow need ID for Travel Advice Publisher
   NEED_ID = '101191'

--- a/config/initializers/rummager.rb
+++ b/config/initializers/rummager.rb
@@ -1,0 +1,4 @@
+require 'gds_api/rummager'
+require 'plek'
+
+TravelAdvicePublisher.rummager = GdsApi::Rummager.new(Plek.find("search"))

--- a/docs/further-technical-information.md
+++ b/docs/further-technical-information.md
@@ -21,8 +21,9 @@ To add or rename a country, update the [`lib/data/countries.yml`](../lib/data/co
 - Publish the content item for the country to Publishing API
 - Publish the email signup content item for the country to Publishing API
 - Publish an artefact for the country to Panopticon
+- Publish the document to Rummager
 
-See [`lib/tasks/publishing_api.rake`](../lib/tasks/publishing_api.rake) and [`lib/tasks/panopticon.rake`](../lib/tasks/panopticon.rake) for details on how to do this.
+See [`lib/tasks/publishing_api.rake`](../lib/tasks/publishing_api.rake), [`lib/tasks/panopticon.rake`](../lib/tasks/panopticon.rake) and [`lib/tasks/rummager.rake`](../lib/tasks/rummager.rake) for details on how to do this.
 
 To maintain the history of a country when renaming you will need to perform a [migration](../db/migrate/20160916161059_rename_democratic_republic_of_congo.rb) on TravelAdviceEdition
 

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -1,0 +1,23 @@
+namespace :rummager do
+  desc "Indexes the main travel advice page in Rummager"
+  task index: :environment do
+    slug = "foreign-travel-advice"
+    record = OpenStruct.new(
+      slug: slug,
+      content_id: TravelAdvicePublisher::INDEX_CONTENT_ID,
+      title: "Foreign travel advice",
+      description: "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",
+      indexable_content: "Latest travel advice by country including safety and security, entry requirements, travel warnings and health"
+    )
+
+    RummagerNotifier.notify(record)
+  end
+
+  desc 'Indexes all published travel advice pages in Rummager'
+  task index_all: :environment do
+    TravelAdviceEdition.published.each do |edition|
+      details = RegisterableTravelAdviceEdition.new(edition)
+      RummagerNotifier.notify(details)
+    end
+  end
+end

--- a/spec/models/travel_advice_edition_spec.rb
+++ b/spec/models/travel_advice_edition_spec.rb
@@ -3,6 +3,10 @@ require "gds_api/asset_manager"
 require "gds_api/exceptions"
 
 describe TravelAdviceEdition do
+  before do
+    class_double('RummagerNotifier').as_stubbed_const
+    allow(RummagerNotifier).to receive(:notify)
+  end
 
   describe "CSV Synonyms" do
     before do
@@ -92,6 +96,19 @@ describe TravelAdviceEdition do
       expect(GdsApi::Panopticon::Registerer).to_not receive(:new)
 
       ed.save!
+    end
+  end
+
+  describe 'indexing the page with rummager on publish' do
+    it 'should index the page' do
+      ed = FactoryGirl.create(:travel_advice_edition, :state => 'draft')
+      registerable_edition = double("RegisterableEdition")
+
+      allow(RegisterableTravelAdviceEdition).to receive(:new).with(ed).and_return(registerable_edition)
+
+      expect(RummagerNotifier).to receive(:notify)
+
+      ed.publish
     end
   end
 

--- a/spec/notifiers/publishing_api_notifier_spec.rb
+++ b/spec/notifiers/publishing_api_notifier_spec.rb
@@ -2,9 +2,12 @@ require "spec_helper"
 require "sidekiq/testing"
 
 RSpec.describe PublishingApiNotifier do
+  include GdsApiHelpers
+
   before do
     Sidekiq::Worker.clear_all
     stub_request(:put, %r{#{GdsApi::TestHelpers::Panopticon::PANOPTICON_ENDPOINT}/artefacts.*})
+    stub_rummager
 
     allow(GdsApi::GovukHeaders).to receive(:headers).and_return({
       govuk_request_id: "12345-54321",

--- a/spec/services/search_indexer_spec.rb
+++ b/spec/services/search_indexer_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+require 'gds_api/test_helpers/rummager'
+
+RSpec.describe SearchIndexer do
+  include GdsApi::TestHelpers::Rummager
+
+  before do
+    stub_any_rummager_post_with_queueing_enabled
+  end
+
+  it 'indexes the travel advice page in rummager' do
+    country_page = Country.find_by_slug('aruba')
+    edition = country_page.build_new_edition
+    travel_advice_edition = RegisterableTravelAdviceEdition.new(edition)
+
+    described_class.call(travel_advice_edition)
+
+    assert_rummager_posted_item(
+      _type: 'edition',
+      _id: "/#{travel_advice_edition.slug}",
+      rendering_app: 'frontend',
+      publishing_app: 'travel-advice-publisher',
+      format: "custom-application",
+      title: travel_advice_edition.title,
+      description: travel_advice_edition.description,
+      indexable_content: travel_advice_edition.indexable_content,
+      link: "/#{travel_advice_edition.slug}"
+    )
+  end
+end

--- a/spec/support/gds_api.rb
+++ b/spec/support/gds_api.rb
@@ -5,6 +5,10 @@ module GdsApiHelpers
     allow_any_instance_of(GdsApi::Panopticon::Registerer).to receive(:register)
   end
 
+  def stub_rummager
+    allow(TravelAdvicePublisher.rummager).to receive(:add_document)
+  end
+
   # Fallback to using WebMock so that we can filter on draft registrations only.
   def stub_panopticon_draft_registration
     WebMock.stub_request(:put, %r{\A#{GdsApi::TestHelpers::Panopticon::PANOPTICON_ENDPOINT}/artefacts}).
@@ -28,6 +32,7 @@ RSpec.configuration.include GdsApiHelpers, :type => :controller
 RSpec.configuration.include GdsApi::TestHelpers::Panopticon, :type => :controller
 RSpec.configuration.before :each, :type => :controller do
   stub_panopticon_registration
+  stub_rummager
 end
 
 RSpec.configuration.include GdsApiHelpers, :type => :feature


### PR DESCRIPTION
Previously, panopticon would send artifacts to Rummager. That flow is now being
deprecated in favour of a simpler approach which is to send documents directly
to rummager.

This commit adds a class that allows us to add travel advice pages to the
search index directly. It also adds a rake task `rummager:index_all` whose job
is to index travel advice pages in Rummager.

The payload now includes the following extra attributes:

- publishing_app
- rendering_app
- content_id

Trello: https://trello.com/c/gsHnT5WF/161-epic-send-things-to-rummager-directly-instead-of-via-panopticon