### PR TITLE
Run all tests for schema testing

### DIFF
--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -3,6 +3,5 @@
 export INITIATING_REPO_NAME="alphagov/govuk-content-schemas"
 export INITIATING_GIT_COMMIT=${SCHEMA_GIT_COMMIT}
 export CONTEXT_MESSAGE="Verify travel-advice-publisher against content schemas"
-export TEST_TASK="spec:schema"
 
 exec ./jenkins.sh

--- a/lib/tasks/rspec.rake
+++ b/lib/tasks/rspec.rake
@@ -1,10 +1,3 @@
 if Rails.env.test? || Rails.env.development?
   require 'rspec/core/rake_task'
-
-  namespace :spec do
-    desc "Run all schema specs"
-    RSpec::Core::RakeTask.new(:schema) do |t|
-      t.rspec_opts = '-t schema_test'
-    end
-  end
 end

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -63,7 +63,7 @@ describe EditionPresenter do
       Timecop.freeze { example.run }
     end
 
-    it "is valid against the content schemas", :schema_test => true do
+    it "is valid against the content schemas" do
       expect(presented_data["schema_name"]).to eq("travel_advice")
       expect(presented_data).to be_valid_against_schema('travel_advice')
     end

--- a/spec/presenters/index_presenter_spec.rb
+++ b/spec/presenters/index_presenter_spec.rb
@@ -38,7 +38,7 @@ describe IndexPresenter do
       FactoryGirl.create(:draft_travel_advice_edition, country_slug: "argentina", version_number: 1)
     end
 
-    it "is valid against the content schemas", :schema_test => true do
+    it "is valid against the content schemas" do
       expect(presented_data["schema_name"]).to eq("travel_advice_index")
       expect(presented_data).to be_valid_against_schema('travel_advice_index')
     end


### PR DESCRIPTION
This app currently runs only a subset of schema tests for PRs on govuk-content-schemas. This was originally done so that the schema tests finish quickly.

This causes two problems:

- Ordering dependencies in tests are making the schema tests fail intermittently on CI
(https://ci.dev.publishing.service.gov.uk/job/govuk_travel_advice_publisher_schema_tests/). This is not picked up in normal testing, because the CI runs everything
- In other applications we've seen that people forget to tag their tests, so that the tests aren't run on CI for schema branches. This causes failures on master.

This commit makes the schema CI tests run the same suite as normal CI runs. It will slow down testing, but I think it's worth the trade-off.