### PR TITLE
Update gds-api-adapters to 36.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ end
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 30.2.0'
+  gem 'gds-api-adapters', '~> 36.4.0'
 end
 
 gem 'logstasher', '0.4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,7 @@ GEM
     diff-lcs (1.2.5)
     diffy (3.0.7)
     docile (1.1.5)
-    domain_name (0.5.20160615)
+    domain_name (0.5.20160826)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
@@ -91,13 +91,13 @@ GEM
       actionpack (>= 3.0)
     formtastic-bootstrap (3.0.0)
       formtastic (>= 2.2)
-    gds-api-adapters (30.2.1)
+    gds-api-adapters (36.4.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek (>= 1.9.0)
       rack-cache
-      rest-client (~> 1.8.0)
+      rest-client (~> 2.0)
     gds-sso (11.2.1)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
@@ -142,7 +142,7 @@ GEM
     hashdiff (0.3.0)
     hashie (3.4.4)
     htmlentities (4.3.4)
-    http-cookie (1.0.2)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.7.0)
     jasmine (2.1.0)
@@ -171,7 +171,9 @@ GEM
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
     method_source (0.8.2)
-    mime-types (2.99.2)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.9.0)
     mongo (2.2.5)
@@ -271,10 +273,10 @@ GEM
     redis (3.3.0)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
-    rest-client (1.8.0)
+    rest-client (2.0.0)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -397,7 +399,7 @@ DEPENDENCIES
   factory_girl_rails
   formtastic (= 2.3.0)
   formtastic-bootstrap (= 3.0.0)
-  gds-api-adapters (~> 30.2.0)
+  gds-api-adapters (~> 36.4.0)
   gds-sso (~> 11.2)
   govspeak (~> 3.5.2)
   govuk-content-schema-test-helpers (~> 1.4.0)
@@ -424,4 +426,4 @@ DEPENDENCIES
   webmock (= 1.22.6)
 
 BUNDLED WITH
-   1.10.6
+   1.13.1

--- a/config/initializers/rummager.rb
+++ b/config/initializers/rummager.rb
@@ -1,4 +1,4 @@
 require 'gds_api/rummager'
 require 'plek'
 
-TravelAdvicePublisher.rummager = GdsApi::Rummager.new(Plek.find("search"))
+TravelAdvicePublisher.rummager = GdsApi::Rummager.new(Plek.find("rummager"))

--- a/spec/features/edition_edit_spec.rb
+++ b/spec/features/edition_edit_spec.rb
@@ -374,7 +374,7 @@ feature "Edit Edition page", js: true do
   end
 
   scenario "save and publish an edition" do
-    stub_any_rummager_post_with_queueing_enabled
+    stub_any_rummager_post
 
     allow(GdsApi::GovukHeaders).to receive(:headers)
       .and_return(govuk_request_id: "25108-1461151489.528-10.3.3.1-1066")
@@ -418,7 +418,6 @@ feature "Edit Edition page", js: true do
         'content_id' => '2a3938e1-d588-45fc-8c8f-0f51814d5409', # from countries.yml fixture
         'name' => 'Albania travel advice',
         'description' => 'The overview',
-        'indexable_content' => 'Summary Part One Body text',
         'kind' => 'travel-advice',
         'owning_app' => 'travel-advice-publisher',
         'rendering_app' => 'multipage-frontend',

--- a/spec/requests/request_tracing_spec.rb
+++ b/spec/requests/request_tracing_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-require 'sidekiq/testing'
+require 'govuk_sidekiq/testing'
 require "gds_api/test_helpers/email_alert_api"
 require 'gds_api/test_helpers/rummager'
 
@@ -42,7 +42,7 @@ RSpec.describe "Request tracing", type: :request do
       "X-Govuk-Authenticated-User" => govuk_authenticated_user,
     }
     expect(WebMock).to have_requested(:put, /panopticon/).with(headers: onward_headers)
-    expect(WebMock).to have_requested(:post, /search.*documents/).with(headers: onward_headers)
+    expect(WebMock).to have_requested(:post, /rummager.*documents/).with(headers: onward_headers)
     expect(WebMock).to have_requested(:put, /publishing-api.*content/).with(headers: onward_headers).twice
     expect(WebMock).to have_requested(:patch, /publishing-api.*links/).with(headers: onward_headers).twice
     expect(WebMock).to have_requested(:post, /publishing-api.*publish/).with(headers: onward_headers).twice


### PR DESCRIPTION
Update to the latest version, particularly as we've updated the
Panopticon adapter to stop handling search-related attributes (see
alphagov/gds-api-adapters#592).

Includes a test helper update to remove deprecation warnings.