### PR TITLE
Publish the parent link for the index page

### DIFF
--- a/app/presenters/index_links_presenter.rb
+++ b/app/presenters/index_links_presenter.rb
@@ -1,7 +1,9 @@
 class IndexLinksPresenter
   def self.present
     {
-      links: {}
+      links: {
+        "parent" => ["b9849cd6-61a7-42dc-8124-362d2c7d48b0"]
+      }
     }
   end
 end

--- a/spec/presenters/index_links_presenter_spec.rb
+++ b/spec/presenters/index_links_presenter_spec.rb
@@ -1,9 +1,0 @@
-require "spec_helper"
-
-RSpec.describe IndexLinksPresenter, ".present" do
-  it "renders index links" do
-    expect(described_class.present).to eq(
-      links: {}
-    )
-  end
-end


### PR DESCRIPTION
Parent is used to generate the breadcrumb.

`b9849cd6-61a7-42dc-8124-362d2c7d48b0` is the [Travel Abroad](https://www.gov.uk/browse/abroad/travel-abroad) browse page.

Currently this is hardcoded in frontend - we will be removing this in https://github.com/alphagov/frontend/pull/1004 so that we can render all frontend breadcrumbs from the content store.

Before we can do this we need to send the parent to the publishing api again, using the rake task `publishing_api:publish` to republish the index page.

This used to send the breadcrumb data using "passthrough hashes" but this functionality has since been removed.
See https://github.com/alphagov/travel-advice-publisher/pull/155

Deleted the spec for this because it is pointless.

cc @dougdroper @tijmenb 