### PR TITLE
FOR DISCUSSION: Preview historical versions within app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'logstasher', '0.4.8'
 gem 'airbrake', '~> 4.0.0'
 gem 'govspeak', '~> 3.5.2'
 gem 'govuk_sidekiq', '0.0.4'
+gem "slimmer", "10.0.0"
 
 group :development, :test do
   gem 'rspec-rails', '3.4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -338,6 +338,14 @@ GEM
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
+    slimmer (10.0.0)
+      activesupport
+      json
+      nokogiri (>= 1.5.0, < 1.7.0)
+      null_logger
+      plek (>= 1.1.0)
+      rack
+      rest-client
     slop (3.6.0)
     sprockets (3.7.0)
       concurrent-ruby (~> 1.0)
@@ -419,6 +427,7 @@ DEPENDENCIES
   rspec-rails (= 3.4.2)
   sass-rails (= 5.0.4)
   simplecov-rcov (= 0.2.3)
+  slimmer (= 10.0.0)
   test-unit
   timecop (= 0.5.9.2)
   uglifier (>= 1.0.3)

--- a/app/controllers/admin/countries_controller.rb
+++ b/app/controllers/admin/countries_controller.rb
@@ -1,4 +1,5 @@
 class Admin::CountriesController < ApplicationController
+  before_filter :skip_slimmer
   before_filter :load_country, :only => [:show]
 
   def index

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -57,6 +57,13 @@ class Admin::EditionsController < ApplicationController
     end
   end
 
+  def preview
+    edition = TravelAdviceEdition.find(params[:edition_id])
+    country = Country.find_by_slug(edition.country_slug)
+    @presenter = EditionPreviewPresenter.new(edition, country)
+    render layout: "preview"
+  end
+
   private
   def permitted_edition_attributes
     params[:edition].permit(

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -1,5 +1,8 @@
 class Admin::EditionsController < ApplicationController
+  include Slimmer::Headers
+  include Slimmer::GovukComponents
 
+  before_filter :skip_slimmer, :except => :preview
   before_filter :load_country, :only => [:create]
   before_filter :load_country_and_edition, :only => [:edit, :update, :destroy, :diff]
   before_filter :strip_empty_alert_statuses, :only => :update
@@ -61,6 +64,7 @@ class Admin::EditionsController < ApplicationController
     edition = TravelAdviceEdition.find(params[:edition_id])
     country = Country.find_by_slug(edition.country_slug)
     @presenter = EditionPreviewPresenter.new(edition, country)
+    set_slimmer_headers template: "print"
     render layout: "preview"
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,4 +19,8 @@ class ApplicationController < ActionController::Base
       GdsApi::GovukHeaders.set_header(:x_govuk_authenticated_user, current_user.uid)
     end
   end
+
+  def skip_slimmer
+   response.headers[Slimmer::Headers::SKIP_HEADER] = "true"
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,7 +4,11 @@ module ApplicationHelper
   end
 
   def preview_edition_path(edition, cache = true)
-    "#{Plek.current.find("private-frontend")}/foreign-travel-advice/#{edition.country_slug}" + "?edition=#{edition.version_number}&cache=#{Time.now().to_i}"
+    if edition.latest_edition?
+      "#{Plek.current.find("draft-origin")}/foreign-travel-advice/#{edition.country_slug}?cache=#{Time.now().to_i}"
+    else
+      admin_edition_preview_path(edition)
+    end
   end
 
   def timestamp(time)

--- a/app/models/enhancements/travel_advice_edition.rb
+++ b/app/models/enhancements/travel_advice_edition.rb
@@ -39,6 +39,14 @@ class TravelAdviceEdition
     RummagerNotifier.notify(details)
   end
 
+  def latest_sibling
+    @latest_sibling ||= TravelAdviceEdition.where(country_slug: country_slug).order_by([:version_number, :desc]).first
+  end
+
+  def latest_edition?
+    self == latest_sibling
+  end
+
   private
 
   def extract_part_errors

--- a/app/presenters/edition_preview_presenter.rb
+++ b/app/presenters/edition_preview_presenter.rb
@@ -1,0 +1,49 @@
+class EditionPreviewPresenter
+  extend Forwardable
+
+  def_delegators :edition,
+     :alert_status,
+     :change_description,
+     :overview,
+     :title,
+     :document,
+     :image,
+     :reviewed_at,
+     :updated_at
+
+  attr_accessor :edition, :country
+  Part = Struct.new(:slug, :title, :body)
+
+  def initialize(edition, country)
+    @edition = edition
+    @country = country
+  end
+
+  def parts
+    edition.parts.map do |part|
+      Part.new(
+        part.slug,
+        part.title,
+        Govspeak::Document.new(part.body).to_html
+      )
+    end
+  end
+
+  def summary
+    Govspeak::Document.new(edition.summary).to_html
+  end
+
+  # FIXME: Update publishing app UI and remove from content
+  # Change description is used as "Latest update" but isn't labelled that way
+  # in the publisher. The frontend didn't add this label before.
+  # This led to users appending (in a variety of formats)
+  # "Latest update:" to the start of the change description. The frontend now
+  # has a latest update label, so we can strip this out.
+  # Avoids: "Latest update: Latest update - …"
+  def latest_update
+    change_description.sub(/^Latest update:?\s-?\s?/i, '').tap do |latest|
+      latest[0] = latest[0].capitalize
+    end
+  end
+
+end

--- a/app/views/admin/editions/_country_summary.html.erb
+++ b/app/views/admin/editions/_country_summary.html.erb
@@ -1,0 +1,34 @@
+<header>
+  <h1 class="part-content-title">Summary</h1>
+</header>
+
+<%= render 'govuk_component/metadata',
+    other: {
+      "Still current at" => Date.today.strftime("%e %B %Y"),
+      "Updated" => (presenter.reviewed_at || presenter.updated_at).strftime("%e %B %Y"),
+      "Latest update" => simple_format(presenter.latest_update)
+    }
+%>
+
+<% if presenter.alert_status.present? %>
+  <div class="help-notice">
+    <% presenter.alert_status.each do |alert| %>
+      <p><%= raw t("travel_advice.alert_status.#{alert}") %></p>
+    <% end %>
+  </div>
+<% end %>
+
+<% if presenter.image %>
+  <p>
+    <img class="map-image" src="<%= presenter.image.file_url %>" alt="" />
+  </p>
+<% end %>
+<% if presenter.document %>
+  <div class="form-download">
+  <p>
+    <a href="<%= presenter.document.file_url %>">Download map (PDF)</a>
+  </p>
+  </div>
+<% end %>
+
+<%= render 'govuk_component/govspeak', content: presenter.summary %>

--- a/app/views/admin/editions/preview.html.erb
+++ b/app/views/admin/editions/preview.html.erb
@@ -1,0 +1,17 @@
+<header>
+  <h1><%= @presenter.country.name %> travel advice</h1>
+</header>
+
+<div class="content-block" id="summary">
+  <%= render partial: "country_summary", locals: {presenter: @presenter}, formats: ["html"] %>
+</div>
+<% (@presenter.parts || []).each do |part| %>
+  <article class="content-block" id="<%= part.slug %>">
+    <header>
+      <h1><%= part.title %></h1>
+    </header>
+
+    <%= raw part.body %>
+  </article>
+<% end %>
+

--- a/app/views/layouts/preview.html.erb
+++ b/app/views/layouts/preview.html.erb
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title><%= @presenter.title %> - GOV.UK</title>
+  <% if @presenter.overview.present? %>
+    <meta name="description" content="<%= @presenter.overview %>">
+  <% end %>
+
+  <%= yield :extra_headers %>
+</head>
+<body>
+  <div id="wrapper" class="travel-advice-guide">
+    <main role="main" id="content">
+    <%= yield %>
+    </main>
+  </div>
+</body>
+</html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,5 +50,7 @@ module TravelAdvicePublisher
 
     # Disable Rack::Cache
     config.action_dispatch.rack_cache = nil
+
+    config.slimmer.use_cache = true
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
 
     resources :editions, only: [:edit, :update, :destroy] do
       get 'diff/:compare_id', action: :diff, as: :diff, on: :member
+      get 'preview'
     end
 
     root to: "countries#index"


### PR DESCRIPTION
This is a prototype of how we might move the "preview" of historical versions of travel-advice away from private-frontend.

FCO have confirmed that they don't need the full in-site preview for these; their only use for them is for printing PDFs in response for queries from the public or travel operators/insurance companies about what the advice was on a certain date.

This PR therefore presents the page within the TAP itself, and replaces the link to private-frontend with an internal link for historical versions, or one to draft-origin for the current preview.

To allow this I have copied over a couple of templates, and a small amount of presenter code, from multipage-frontend, which is obviously not ideal. It also requires the addition of Slimmer, which even though it is disabled on all other pages still adds a bit of overhead.

Comments and alternative approaches welcome.