### PR TITLE
Configure via env vars

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,1 +1,8 @@
-# This file is overwritten on deploy
+if ENV.has_key?("ERRBIT_API_KEY")
+  Airbrake.configure do |config|
+    config.api_key = ENV["ERRBIT_API_KEY"]
+    config.host = "errbit.#{ENV["GOVUK_APP_DOMAIN"]}"
+    config.secure = true
+    config.environment_name = ENV["ERRBIT_ENVIRONMENT_NAME"]
+  end
+end

--- a/config/initializers/asset_manager.rb
+++ b/config/initializers/asset_manager.rb
@@ -3,4 +3,7 @@
 require 'gds_api/asset_manager'
 require 'plek'
 
-TravelAdvicePublisher.asset_api = GdsApi::AssetManager.new(Plek.current.find('asset-manager'), :bearer_token => "12345678")
+TravelAdvicePublisher.asset_api = GdsApi::AssetManager.new(
+  Plek.current.find('asset-manager'),
+  :bearer_token => ENV.fetch("ASSET_MANAGER_BEARER_TOKEN", "12345678")
+)

--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -1,6 +1,6 @@
 GDS::SSO.config do |config|
-  config.user_model   = 'User'
-  config.oauth_id     = 'abcdefghjasndjkasndtraveladvicepublisher'
-  config.oauth_secret = 'secret'
+  config.user_model   = "User"
+  config.oauth_id     = ENV.fetch("OAUTH_ID", "abcdefghjasndjkasndtraveladvicepublisher")
+  config.oauth_secret = ENV.fetch("OAUTH_SECRET", "secret")
   config.oauth_root_url = Plek.current.find("signon")
 end

--- a/config/initializers/panopticon_api_credentials.rb
+++ b/config/initializers/panopticon_api_credentials.rb
@@ -1,0 +1,3 @@
+PANOPTICON_API_CREDENTIALS = {
+  bearer_token: ENV["PANOPTICON_BEARER_TOKEN"] || "something"
+}


### PR DESCRIPTION
Part of https://trello.com/c/BrKRdn4f/495-rebuild-gov-uk-app-deployment-pipeline

This application is moving to the new deployment pipeline, it will receive its configuration for things like Errbit, Asset Manager, SSO and Panopticon from environment vars.

Depends on https://github.com/alphagov/govuk-puppet/pull/5152