### PR TITLE
Preview historical versions in app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'logstasher', '0.4.8'
 gem 'airbrake', '~> 4.0.0'
 gem 'govspeak', '~> 3.5.2'
 gem 'govuk_sidekiq', '0.0.4'
+gem "slimmer", "10.0.0"
 
 group :development, :test do
   gem 'rspec-rails', '3.4.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -338,6 +338,14 @@ GEM
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
+    slimmer (10.0.0)
+      activesupport
+      json
+      nokogiri (>= 1.5.0, < 1.7.0)
+      null_logger
+      plek (>= 1.1.0)
+      rack
+      rest-client
     slop (3.6.0)
     sprockets (3.7.0)
       concurrent-ruby (~> 1.0)
@@ -419,6 +427,7 @@ DEPENDENCIES
   rspec-rails (= 3.4.2)
   sass-rails (= 5.0.4)
   simplecov-rcov (= 0.2.3)
+  slimmer (= 10.0.0)
   test-unit
   timecop (= 0.5.9.2)
   uglifier (>= 1.0.3)

--- a/app/controllers/admin/countries_controller.rb
+++ b/app/controllers/admin/countries_controller.rb
@@ -1,4 +1,5 @@
 class Admin::CountriesController < ApplicationController
+  before_filter :skip_slimmer
   before_filter :load_country, :only => [:show]
 
   def index

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -1,8 +1,11 @@
 class Admin::EditionsController < ApplicationController
+  include Slimmer::Headers
+  include Slimmer::GovukComponents
 
-  before_filter :load_country, :only => [:create]
-  before_filter :load_country_and_edition, :only => [:edit, :update, :destroy, :diff]
-  before_filter :strip_empty_alert_statuses, :only => :update
+  before_filter :skip_slimmer, except: :historical_edition
+  before_filter :load_country, only: [:create]
+  before_filter :load_country_and_edition, only: [:edit, :update, :destroy, :diff]
+  before_filter :strip_empty_alert_statuses, only: :update
 
   def create
     if params[:edition_version].nil?
@@ -61,6 +64,7 @@ class Admin::EditionsController < ApplicationController
     edition = TravelAdviceEdition.find(params[:edition_id])
     country = Country.find_by_slug(edition.country_slug)
     @presenter = HistoricalEditionPresenter.new(edition, country)
+    set_slimmer_headers template: "print"
     render layout: "historical_edition"
   end
 

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -57,6 +57,13 @@ class Admin::EditionsController < ApplicationController
     end
   end
 
+  def historical_edition
+    edition = TravelAdviceEdition.find(params[:edition_id])
+    country = Country.find_by_slug(edition.country_slug)
+    @presenter = HistoricalEditionPresenter.new(edition, country)
+    render layout: "historical_edition"
+  end
+
   private
   def permitted_edition_attributes
     params[:edition].permit(

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,4 +19,8 @@ class ApplicationController < ActionController::Base
       GdsApi::GovukHeaders.set_header(:x_govuk_authenticated_user, current_user.uid)
     end
   end
+
+  def skip_slimmer
+    response.headers[Slimmer::Headers::SKIP_HEADER] = "true"
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,8 +3,22 @@ module ApplicationHelper
     link_to (edition.draft? ? 'edit' : 'view details'), edit_admin_edition_path(edition)
   end
 
-  def preview_edition_path(edition, cache = true)
-    "#{Plek.current.find("private-frontend")}/foreign-travel-advice/#{edition.country_slug}" + "?edition=#{edition.version_number}&cache=#{Time.now().to_i}"
+  def preview_edition_link(edition, short, options = {})
+    if !Rails.application.config.show_historical_edition_link
+      name = "Preview saved version"
+      url = "#{Plek.current.find('private-frontend')}/foreign-travel-advice/#{edition.country_slug}?edition=#{edition.version_number}&cache=#{Time.now.to_i}"
+    elsif edition.draft?
+      name = "Preview saved version"
+      url = "#{Plek.current.find('draft-origin')}/foreign-travel-advice/#{edition.country_slug}?cache=#{Time.now.to_i}"
+    elsif edition.published?
+      name = "View on site"
+      url = "#{Plek.current.website_root}/foreign-travel-advice/#{edition.country_slug}?cache=#{Time.now.to_i}"
+    else
+      name = "Print historical version"
+      url = admin_edition_historical_edition_path(edition)
+    end
+    name = name.downcase.split(' ').first if short
+    link_to(name, url, options.merge(target: "blank"))
   end
 
   def timestamp(time)

--- a/app/models/enhancements/travel_advice_edition.rb
+++ b/app/models/enhancements/travel_advice_edition.rb
@@ -39,7 +39,7 @@ class TravelAdviceEdition
     RummagerNotifier.notify(details)
   end
 
-  private
+private
 
   def extract_part_errors
     # govuk_content_models merges in the Parts errors into the main hash in a

--- a/app/presenters/historical_edition_presenter.rb
+++ b/app/presenters/historical_edition_presenter.rb
@@ -1,0 +1,48 @@
+class HistoricalEditionPresenter
+  extend Forwardable
+
+  def_delegators :edition,
+     :alert_status,
+     :change_description,
+     :overview,
+     :title,
+     :document,
+     :image,
+     :reviewed_at,
+     :updated_at
+
+  attr_accessor :edition, :country
+  Part = Struct.new(:slug, :title, :body)
+
+  def initialize(edition, country)
+    @edition = edition
+    @country = country
+  end
+
+  def parts
+    edition.parts.map do |part|
+      Part.new(
+        part.slug,
+        part.title,
+        Govspeak::Document.new(part.body).to_html
+      )
+    end
+  end
+
+  def summary
+    Govspeak::Document.new(edition.summary).to_html
+  end
+
+  # FIXME: Update publishing app UI and remove from content
+  # Change description is used as "Latest update" but isn't labelled that way
+  # in the publisher. The frontend didn't add this label before.
+  # This led to users appending (in a variety of formats)
+  # "Latest update:" to the start of the change description. The frontend now
+  # has a latest update label, so we can strip this out.
+  # Avoids: "Latest update: Latest update - …"
+  def latest_update
+    change_description.sub(/^Latest update:?\s-?\s?/i, '').tap do |latest|
+      latest[0] = latest[0].capitalize
+    end
+  end
+end

--- a/app/views/admin/countries/show.html.erb
+++ b/app/views/admin/countries/show.html.erb
@@ -33,7 +33,7 @@
         <td><%= edition.state %></td>
         <td><%= timestamp(edition.updated_at) %></td>
         <td><%= edition.reviewed_at ? timestamp(edition.reviewed_at) : "N/A" %></td>
-        <td><%= edition_edit_link(edition) %> — <%= link_to "preview", preview_edition_path(edition), :target => "blank" %></td>
+        <td><%= edition_edit_link(edition) %> — <%= preview_edition_link(edition, true, :target => "blank") %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/admin/editions/_country_summary.html.erb
+++ b/app/views/admin/editions/_country_summary.html.erb
@@ -1,0 +1,34 @@
+<header>
+  <h1 class="part-content-title">Summary</h1>
+</header>
+
+<%= render 'govuk_component/metadata',
+    other: {
+      "Still current at" => Date.today.strftime("%e %B %Y"),
+      "Updated" => (presenter.reviewed_at || presenter.updated_at).strftime("%e %B %Y"),
+      "Latest update" => simple_format(presenter.latest_update)
+    }
+%>
+
+<% if presenter.alert_status.present? %>
+  <div class="help-notice">
+    <% presenter.alert_status.each do |alert| %>
+      <p><%= raw t("travel_advice.alert_status.#{alert}") %></p>
+    <% end %>
+  </div>
+<% end %>
+
+<% if presenter.image %>
+  <p>
+    <img class="map-image" src="<%= presenter.image.file_url %>" alt="" />
+  </p>
+<% end %>
+<% if presenter.document %>
+  <div class="form-download">
+  <p>
+    <a href="<%= presenter.document.file_url %>">Download map (PDF)</a>
+  </p>
+  </div>
+<% end %>
+
+<%= render 'govuk_component/govspeak', content: presenter.summary %>

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -126,7 +126,7 @@
             <%= link_to "Delete", admin_edition_path(@edition), :method => :delete, :class => 'btn btn-danger', :disabled => ! @edition.draft? %>
             <%= link_to "Cancel", admin_country_path(@edition.country_slug), :class => "btn btn-primary" %>
             <span class="navbar-right">
-              <%= link_to "Preview saved version", preview_edition_path(@edition), :class => "btn btn-default", :target => "blank" %>
+              <%= preview_edition_link(@edition, false, class: "btn btn-default") %>
               <% if @edition.published? %>
                 <%= f.submit "Update review date", :class => "btn btn-success", data: { disable_with: "Updating..." } %>
               <% end %>

--- a/app/views/admin/editions/historical_edition.html.erb
+++ b/app/views/admin/editions/historical_edition.html.erb
@@ -1,0 +1,16 @@
+<header>
+  <h1><%= @presenter.country.name %> travel advice</h1>
+</header>
+
+<div class="content-block" id="summary">
+  <%= render partial: "country_summary", locals: {presenter: @presenter}, formats: ["html"] %>
+</div>
+<% @presenter.parts.each do |part| %>
+  <article class="content-block" id="<%= part.slug %>">
+    <header>
+      <h1><%= part.title %></h1>
+    </header>
+
+    <%= raw part.body %>
+  </article>
+<% end %>

--- a/app/views/layouts/historical_edition.html.erb
+++ b/app/views/layouts/historical_edition.html.erb
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title><%= @presenter.title %> - GOV.UK</title>
+  <% if @presenter.overview.present? %>
+    <meta name="description" content="<%= @presenter.overview %>">
+  <% end %>
+
+  <%= yield :extra_headers %>
+</head>
+<body>
+  <div id="wrapper" class="travel-advice-guide">
+    <main role="main" id="content">
+    <%= yield %>
+    </main>
+  </div>
+</body>
+</html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,5 +50,7 @@ module TravelAdvicePublisher
 
     # Disable Rack::Cache
     config.action_dispatch.rack_cache = nil
+
+    config.slimmer.use_cache = true
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,4 +35,7 @@ TravelAdvicePublisher::Application.configure do
 
   # We should always send email alerts in development
   config.send_email_alerts = true
+
+  # Feature flag for historical edition functionality; always true in dev
+  config.show_historical_edition_link = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,4 +75,7 @@ Rails.application.configure do
 
   # Feature flag to enable the sending of email alerts
   config.send_email_alerts = (ENV["SEND_EMAIL_ALERTS"] == "1")
+
+  # Feature flag for historical edition viewing functionality
+  config.show_historical_edition_link = (ENV["SHOW_HISTORICAL_EDITION_LINK"] == "1")
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,4 +42,7 @@ TravelAdvicePublisher::Application.configure do
 
   # We should always send email alerts in test
   config.send_email_alerts = true
+
+  # Feature flag for historical edition functionality; always true in test
+  config.show_historical_edition_link = true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
 
     resources :editions, only: [:edit, :update, :destroy] do
       get 'diff/:compare_id', action: :diff, as: :diff, on: :member
+      get 'historical_edition'
     end
 
     root to: "countries#index"

--- a/spec/controllers/admin/editions_controller_spec.rb
+++ b/spec/controllers/admin/editions_controller_spec.rb
@@ -3,6 +3,7 @@ require "sidekiq/testing"
 
 describe Admin::EditionsController do
   include GdsApi::TestHelpers::PublishingApiV2
+  render_views
 
   before do
     stub_panopticon_registration

--- a/spec/controllers/admin/editions_controller_spec.rb
+++ b/spec/controllers/admin/editions_controller_spec.rb
@@ -237,4 +237,19 @@ describe Admin::EditionsController do
       end
     end
   end
+
+  describe "historical_edition" do
+    before do
+      login_as_stub_user
+      @edition = FactoryGirl.create(:travel_advice_edition, country_slug: 'aruba')
+      @country = Country.find_by_slug('aruba')
+    end
+
+    it "shows a print preview for that edition" do
+      get :historical_edition, edition_id: @edition._id
+      expect(response).to be_success
+      expect(assigns(:presenter).edition).to eq(@edition)
+      expect(assigns(:presenter).country).to eq(@country)
+    end
+  end
 end

--- a/spec/features/country_version_index_spec.rb
+++ b/spec/features/country_version_index_spec.rb
@@ -65,9 +65,9 @@ feature "Country version index" do
     expect(rows).to eq([
       ["Version", "State", "Updated", "Reviewed", ""],
       ["Version 4", "draft", e4.updated_at.strftime("%d/%m/%Y %H:%M %Z"), "N/A", "edit — preview"],
-      ["Version 3", "published", e3.updated_at.strftime("%d/%m/%Y %H:%M %Z"), "N/A", "view details — preview"],
-      ["Version 2", "archived", e2.updated_at.strftime("%d/%m/%Y %H:%M %Z"), "N/A", "view details — preview"],
-      ["Version 1", "archived", e1.updated_at.strftime("%d/%m/%Y %H:%M %Z"), "N/A", "view details — preview"],
+      ["Version 3", "published", e3.updated_at.strftime("%d/%m/%Y %H:%M %Z"), "N/A", "view details — view"],
+      ["Version 2", "archived", e2.updated_at.strftime("%d/%m/%Y %H:%M %Z"), "N/A", "view details — print"],
+      ["Version 1", "archived", e1.updated_at.strftime("%d/%m/%Y %H:%M %Z"), "N/A", "view details — print"],
     ])
 
     within :xpath, "//tr[contains(., 'Version 4')]" do
@@ -76,7 +76,7 @@ feature "Country version index" do
 
     within :xpath, "//tr[contains(., 'Version 2')]" do
       expect(page).to have_link("view details", href: "/admin/editions/#{e2.id}/edit")
-      expect(page).to have_selector("a[href^='http://private-frontend.dev.gov.uk/foreign-travel-advice/aruba?edition=2']", text: "preview")
+      expect(page).to have_selector("a[href^='/admin/editions/#{e2.id}/historical_edition']", text: "print")
     end
 
     expect(page).not_to have_button("Create new edition")

--- a/spec/features/edition_edit_spec.rb
+++ b/spec/features/edition_edit_spec.rb
@@ -516,7 +516,7 @@ feature "Edit Edition page", js: true do
     @edition = FactoryGirl.create(:published_travel_advice_edition, country_slug: 'albania')
     visit "/admin/editions/#{@edition.to_param}/edit"
 
-    expect(page).to have_selector("a[href^='http://private-frontend.dev.gov.uk/foreign-travel-advice/albania?edition=1']", text: "Preview saved version")
+    expect(page).to have_selector("a[href^='http://www.dev.gov.uk/foreign-travel-advice/albania?cache=']", text: "View on site")
   end
 
   scenario "create a note" do

--- a/spec/presenters/historical_edition_presenter_spec.rb
+++ b/spec/presenters/historical_edition_presenter_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe HistoricalEditionPresenter do
+
+  let(:country) {
+    Country.new(
+      "name" => "Aruba",
+      "slug" => "aruba",
+      "content_id" => SecureRandom.uuid,
+      "email_signup_content_id" => SecureRandom.uuid
+    )
+  }
+
+  let(:edition) {
+    FactoryGirl.build(
+      :travel_advice_edition,
+      country_slug: 'aruba',
+      title: "Aruba travel advice",
+      overview: "Something something",
+      published_at: 5.minutes.ago,
+      summary: "### Summary",
+      alert_status: [TravelAdviceEdition::ALERT_STATUSES.first],
+      change_description: "Latest update: added latest events"
+    ).tap do |e|
+      e.parts.build(
+        slug: "terrorism",
+        title: "Terrorism",
+        body: "There is an underlying threat from ...",
+        order: 2,
+      )
+
+      e.parts.build(
+        slug: "safety-and-security",
+        title: "Safety and security",
+        body: "Keep your valuables safely stored ...",
+        order: 1,
+      )
+    end
+  }
+
+  subject { described_class.new(edition, country) }
+
+  describe "govspeak fields" do
+    it "renders the summary as govspeak" do
+      expect(subject.summary).to eq("<h3 id=\"summary\">Summary</h3>\n")
+    end
+
+    it "renders the parts as govspeak" do
+      expect(subject.parts.length).to eq(2)
+      expect(subject.parts.first.body).to eq("<p>There is an underlying threat from &hellip;</p>\n")
+      expect(subject.parts.second.body).to eq("<p>Keep your valuables safely stored &hellip;</p>\n")
+    end
+  end
+
+  describe "delegated fields" do
+    it "passes fields to the edition" do
+      expect(subject.overview).to eq("Something something")
+      expect(subject.title).to eq("Aruba travel advice")
+    end
+  end
+
+  describe "#latest_update" do
+    it "strips out any initial 'latest update' prompt" do
+      expect(subject.latest_update).to eq("Added latest events")
+    end
+  end
+end

--- a/spec/support/gds_api.rb
+++ b/spec/support/gds_api.rb
@@ -21,6 +21,11 @@ module GdsApiHelpers
       with(:body => hash_including('related_artefact_ids' => anything)).
       to_return(:status => 200, :body => "{}")
   end
+
+  def stub_shared_templates
+    WebMock.stub_request(:get, %r{\A#{Plek.current.find('static')}/templates}).
+      to_return(status: 200, body: "{}")
+  end
 end
 
 RSpec.configuration.include GdsApiHelpers, :type => :model
@@ -33,12 +38,14 @@ RSpec.configuration.include GdsApi::TestHelpers::Panopticon, :type => :controlle
 RSpec.configuration.before :each, :type => :controller do
   stub_panopticon_registration
   stub_rummager
+  stub_shared_templates
 end
 
 RSpec.configuration.include GdsApiHelpers, :type => :feature
 RSpec.configuration.include GdsApi::TestHelpers::Panopticon, :type => :feature
 RSpec.configuration.before :each, :type => :feature do
   stub_panopticon_draft_registration
+  stub_shared_templates
 end
 
 RSpec.configuration.include GdsApiHelpers, :type => :rake_task


### PR DESCRIPTION
Replace the link to private-frontend for 'preview' of historical versions with a locally rendered version using the print template.

FCO have confirmed that they only use the historical preview for creating PDFs to send in response to enquiries about what the advice was on a particular date. Removing the link to private-frontend helps in the process of deprecating that site and disentangling TAP from content-models.

In addition this allows us to use the draft site for previewing the actual current draft, and link to the live site for the published version.

Currently this is protected by a feature flag so that we can try the functionality on integration.