### PR TITLE
Tidy up historical preview feature

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,10 +4,7 @@ module ApplicationHelper
   end
 
   def preview_edition_link(edition, short, options = {})
-    if !Rails.application.config.show_historical_edition_link
-      name = "Preview saved version"
-      url = "#{Plek.current.find('private-frontend')}/foreign-travel-advice/#{edition.country_slug}?edition=#{edition.version_number}&cache=#{Time.now.to_i}"
-    elsif edition.draft?
+    if edition.draft?
       name = "Preview saved version"
       url = "#{Plek.current.find('draft-origin')}/foreign-travel-advice/#{edition.country_slug}?cache=#{Time.now.to_i}"
     elsif edition.published?

--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -48,7 +48,7 @@ private
       },
       "updated_at" => updated_at.iso8601,
       "reviewed_at" => reviewed_at.iso8601,
-      "change_description" => edition.change_description || "",
+      "change_description" => change_description,
       "email_signup_link" => "#{base_path}/email-signup",
       "parts" => parts,
       "alert_status" => edition.alert_status,
@@ -74,7 +74,7 @@ private
   end
 
   def public_updated_at
-    edition.published_at || Time.zone.now
+    edition.published_at || previous.published_at || Time.zone.now
   end
 
   def updated_at
@@ -82,7 +82,15 @@ private
   end
 
   def reviewed_at
-    edition.reviewed_at || Time.zone.now
+    edition.reviewed_at || previous.reviewed_at || Time.zone.now
+  end
+
+  def change_description
+    edition.change_description.presence || previous.change_description || ""
+  end
+
+  def previous
+    @previous ||= edition.previous_version
   end
 
   def country

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,7 +35,4 @@ TravelAdvicePublisher::Application.configure do
 
   # We should always send email alerts in development
   config.send_email_alerts = true
-
-  # Feature flag for historical edition functionality; always true in dev
-  config.show_historical_edition_link = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,7 +75,4 @@ Rails.application.configure do
 
   # Feature flag to enable the sending of email alerts
   config.send_email_alerts = (ENV["SEND_EMAIL_ALERTS"] == "1")
-
-  # Feature flag for historical edition viewing functionality
-  config.show_historical_edition_link = (ENV["SHOW_HISTORICAL_EDITION_LINK"] == "1")
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,7 +42,4 @@ TravelAdvicePublisher::Application.configure do
 
   # We should always send email alerts in test
   config.send_email_alerts = true
-
-  # Feature flag for historical edition functionality; always true in test
-  config.show_historical_edition_link = true
 end

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -37,9 +37,17 @@ describe EditionPresenter do
     edition
   }
 
+  let(:previous) {
+    FactoryGirl.build(
+      :travel_advice_edition,
+      change_description: "Stuff previously changed"
+    )
+  }
+
   before do
     allow(GdsApi::GovukHeaders).to receive(:headers)
       .and_return(govuk_request_id: "25108-1461151489.528-10.3.3.1-1066")
+    allow(edition).to receive(:previous_version).and_return(previous)
   end
 
   subject { described_class.new(edition) }
@@ -141,10 +149,10 @@ describe EditionPresenter do
     end
 
     context "when the edition does not have a change_description" do
-      it "sets change_description to an empty string" do
+      it "sets change_description from the previous version" do
         edition.change_description = nil
 
-        expect(presented_data["details"]["change_description"]).to eq("")
+        expect(presented_data["details"]["change_description"]).to eq("Stuff previously changed")
       end
     end
 


### PR DESCRIPTION
Remove the historical edition feature flag now that the change has been approved.

Also fix an issue with blank change descriptions being sent to the draft content-store.