### PR TITLE
Add parent to content item

### DIFF
--- a/app/presenters/links_presenter.rb
+++ b/app/presenters/links_presenter.rb
@@ -5,7 +5,10 @@ class LinksPresenter
 
   def present
     {
-      links: {}
+      links: {
+        # Foreign travel advice index page
+        parent: ["08d48cdd-6b50-43ff-a53b-beab47f4aab0"]
+      }
     }
   end
 

--- a/spec/presenters/links_presenter_spec.rb
+++ b/spec/presenters/links_presenter_spec.rb
@@ -15,7 +15,9 @@ RSpec.describe LinksPresenter do
     let(:presented_data) { subject.present }
 
     it "returns travel advice breadcrumbs data" do
-      expect(presented_data).to eq(links: {})
+      expect(presented_data).to eq(links: {
+        parent: ["08d48cdd-6b50-43ff-a53b-beab47f4aab0"]
+      })
     end
   end
 end


### PR DESCRIPTION
This commit adds the foreign travel advice index page as the parent of all travel advice pages. This allows `govuk_navigation_components` to render the breadcrumbs and related items correctly.

Trello: https://trello.com/c/4vhboo0w/296-adding-related-link-to-travel-advice-waiting-for-related-links-to-be-in-content-tagger