### PR TITLE
Register the Document Type with Rummager

### DIFF
--- a/app/presenters/search_payload_presenter.rb
+++ b/app/presenters/search_payload_presenter.rb
@@ -24,7 +24,8 @@ class SearchPayloadPresenter
       title: title,
       description: description,
       indexable_content: indexable_content,
-      link: "/#{slug}"
+      link: "/#{slug}",
+      content_store_document_type: 'travel_advice',
     }
   end
 end


### PR DESCRIPTION
We need to be able to filter Rummager on document_type for Guidance content, so this change updates Searchable to present the document type for all "Editions".

This has been tested locally by running the `rummager:index_all` Rake task and checking that the `content_store_document_type` was present on a given document.

Trello: https://trello.com/c/M1cXENeB/341-add-content-store-document-type-to-all-guidance-content-in-rummager