### PR TITLE
Let publishing-api generate index via dependency resolution

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -111,10 +111,6 @@ class Admin::EditionsController < ApplicationController
       notifier.send_alert(@edition)
       notifier.enqueue
 
-      index_notifier = PublishingApiNotifier.new
-      index_notifier.publish_index
-      index_notifier.enqueue
-
       # catch any upload errors
       if @edition.errors.any?
         flash[:alert] = @edition.errors.full_messages.join(", ")

--- a/app/presenters/index_presenter.rb
+++ b/app/presenters/index_presenter.rb
@@ -26,7 +26,6 @@ class IndexPresenter
       "update_type" => update_type,
       "details" => {
         "email_signup_link" => "#{base_path}/email-signup",
-        "countries" => countries,
         "max_cache_time" => 10,
       }
     }
@@ -36,22 +35,6 @@ private
 
   def base_path
     "/foreign-travel-advice"
-  end
-
-  def countries
-    Country.all.map do |country|
-      edition = country.last_published_edition
-      next unless edition
-
-      {
-        "name" => country.name,
-        "base_path" => "/foreign-travel-advice/#{country.slug}",
-        "updated_at" => updated_at(edition).iso8601,
-        "public_updated_at" => public_updated_at(edition).iso8601,
-        "change_description" => edition.change_description,
-        "synonyms" => edition.synonyms,
-      }
-    end.compact
   end
 
   def public_updated_at(edition)

--- a/spec/controllers/admin/editions_controller_spec.rb
+++ b/spec/controllers/admin/editions_controller_spec.rb
@@ -224,7 +224,7 @@ describe Admin::EditionsController do
 
         post :update, id: @draft.to_param, edition: {}, commit: "Save & Publish"
 
-        expect(PublishingApiWorker.jobs.size).to eq(2)
+        expect(PublishingApiWorker.jobs.size).to eq(1)
       end
 
       it "creates a PublishRequest for that edition" do

--- a/spec/features/edition_edit_spec.rb
+++ b/spec/features/edition_edit_spec.rb
@@ -414,10 +414,6 @@ feature "Edit Edition page", js: true do
       update_type: "major"
     })
 
-    assert_publishing_api_publish(TravelAdvicePublisher::INDEX_CONTENT_ID, {
-      update_type: "minor"
-    })
-
     assert_details_contains("2a3938e1-d588-45fc-8c8f-0f51814d5409",
                             "publishing_request_id", "25108-1461151489.528-10.3.3.1-1066")
 

--- a/spec/presenters/index_presenter_spec.rb
+++ b/spec/presenters/index_presenter_spec.rb
@@ -20,23 +20,6 @@ describe IndexPresenter do
     let(:presented_data) { subject.render_for_publishing_api }
     let(:three_days_ago) { 3.days.ago }
 
-    before do
-      FactoryGirl.create(
-        :published_travel_advice_edition,
-        country_slug: "aruba",
-        version_number: 2,
-        published_at: three_days_ago,
-        synonyms: ["foo", "bar"],
-      )
-
-      FactoryGirl.create(:archived_travel_advice_edition, country_slug: "aruba", version_number: 1)
-
-      FactoryGirl.create(:published_travel_advice_edition, country_slug: "andorra", version_number: 2)
-      FactoryGirl.create(:draft_travel_advice_edition, country_slug: "andorra", version_number: 1)
-
-      FactoryGirl.create(:draft_travel_advice_edition, country_slug: "argentina", version_number: 1)
-    end
-
     it "is valid against the content schemas" do
       expect(presented_data["schema_name"]).to eq("travel_advice_index")
       expect(presented_data).to be_valid_against_schema('travel_advice_index')
@@ -64,24 +47,6 @@ describe IndexPresenter do
           "update_type" => "minor",
           "details" => {
             "email_signup_link" => "/foreign-travel-advice/email-signup",
-            "countries" => [
-              {
-                "name" => "Andorra",
-                "base_path" => "/foreign-travel-advice/andorra",
-                "updated_at" => Time.zone.now.iso8601,
-                "public_updated_at" => Time.zone.now.iso8601,
-                "change_description" => "Stuff changed",
-                "synonyms" => [],
-              },
-              {
-                "name" => "Aruba",
-                "base_path" => "/foreign-travel-advice/aruba",
-                "updated_at" => Time.zone.now.iso8601,
-                "public_updated_at" => three_days_ago.iso8601,
-                "change_description" => "Stuff changed",
-                "synonyms" => ["foo", "bar"],
-              },
-            ],
             "max_cache_time" => 10,
           },
         )

--- a/spec/requests/request_tracing_spec.rb
+++ b/spec/requests/request_tracing_spec.rb
@@ -41,9 +41,9 @@ RSpec.describe "Request tracing", type: :request do
       "X-Govuk-Authenticated-User" => govuk_authenticated_user,
     }
     expect(WebMock).to have_requested(:post, /rummager.*documents/).with(headers: onward_headers)
-    expect(WebMock).to have_requested(:put, /publishing-api.*content/).with(headers: onward_headers).twice
-    expect(WebMock).to have_requested(:patch, /publishing-api.*links/).with(headers: onward_headers).twice
-    expect(WebMock).to have_requested(:post, /publishing-api.*publish/).with(headers: onward_headers).twice
+    expect(WebMock).to have_requested(:put, /publishing-api.*content/).with(headers: onward_headers)
+    expect(WebMock).to have_requested(:patch, /publishing-api.*links/).with(headers: onward_headers)
+    expect(WebMock).to have_requested(:post, /publishing-api.*publish/).with(headers: onward_headers)
     expect(WebMock).to have_requested(:post, /email-alert-api/).with(headers: onward_headers)
   end
 end


### PR DESCRIPTION
Include the synonyms in the details sent for the country pages. Remove the generation of countries data inside the index presenter and stop automatically sending the index when a country is published; both of these will now be done automatically by publishing-api.

The tests won't pass until https://github.com/alphagov/govuk-content-schemas/pull/553 is merged. 