### PR TITLE
Send synonyms field in the country pages detail.

### DIFF
--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -44,6 +44,7 @@ private
       "country" => {
         "slug" => country.slug,
         "name" => country.name,
+        "synonyms" => edition.synonyms
       },
       "updated_at" => updated_at.iso8601,
       "reviewed_at" => reviewed_at.iso8601,

--- a/app/presenters/links_presenter.rb
+++ b/app/presenters/links_presenter.rb
@@ -6,8 +6,7 @@ class LinksPresenter
   def present
     {
       links: {
-        # Foreign travel advice index page
-        parent: ["08d48cdd-6b50-43ff-a53b-beab47f4aab0"]
+        parent: [TravelAdvicePublisher::INDEX_CONTENT_ID]
       }
     }
   end

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -100,6 +100,7 @@ describe EditionPresenter do
           "country" => {
             "slug" => "aruba",
             "name" => "Aruba",
+            "synonyms" => [],
           },
           "updated_at" => Time.zone.now.iso8601,
           "reviewed_at" => Time.zone.now.iso8601,


### PR DESCRIPTION
This data is required to let publishing-api generate the index.

(This commit was split out from #175 , since we need to ensure the field is fully populated before we stop sending the full country data in the index itself).