### PR TITLE
Change rendering app to government-frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ advice](http://www.gov.uk/foreign-travel-advice).  The application persists
 content in MongoDB and in the downstream
 [publishing-api](https://github.com/alphagov/publishing-api).  Travel advice
 content is rendered by
-[multipage-frontend](https://github.com/alphagov/multipage-frontend).
+[government-frontend](https://github.com/alphagov/government-frontend).
 
 ## Dependencies
 

--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -29,7 +29,7 @@ class EditionPresenter
       "description" => edition.overview,
       "locale" => "en",
       "publishing_app" => "travel-advice-publisher",
-      "rendering_app" => "multipage-frontend",
+      "rendering_app" => "government-frontend",
       "routes" => routes,
       "public_updated_at" => public_updated_at.iso8601,
       "update_type" => update_type,

--- a/app/presenters/search_payload_presenter.rb
+++ b/app/presenters/search_payload_presenter.rb
@@ -18,7 +18,7 @@ class SearchPayloadPresenter
   def call
     {
       content_id: content_id,
-      rendering_app: 'frontend',
+      rendering_app: 'government-frontend',
       publishing_app: 'travel-advice-publisher',
       format: 'custom-application',
       title: title,

--- a/docs/further-technical-information.md
+++ b/docs/further-technical-information.md
@@ -6,7 +6,7 @@ Travel Advice Publisher inherits its models from the [govuk_content_models](http
 
 At the present time, the list of countries is defined in [`lib/data/countries.yml`](../lib/data/countries.yml), however it is expected that this will change to consume an api for countries from the [Whitehall](https://github.com/alphagov/whitehall) app in the near future.
 
-Published travel advice is exposed through the [content-store](https://github.com/alphagov/content-store) and presented in [frontend](https://github.com/alphagov/frontend) and [multipage-frontend](https://github.com/alphagov/multipage-frontend).
+Published travel advice is exposed through the [content-store](https://github.com/alphagov/content-store) and presented in [frontend](https://github.com/alphagov/frontend) and [government-frontend](https://github.com/alphagov/government-frontend).
 
 ### Workflow
 

--- a/spec/features/edition_edit_spec.rb
+++ b/spec/features/edition_edit_spec.rb
@@ -368,10 +368,16 @@ feature "Edit Edition page", js: true do
       .and_return(govuk_request_id: "25108-1461151489.528-10.3.3.1-1066")
 
     @old_edition = FactoryGirl.create(:published_travel_advice_edition, country_slug: 'albania')
-    @edition = FactoryGirl.create(:draft_travel_advice_edition, country_slug: 'albania', title: 'Albania travel advice',
-                                  alert_status: TravelAdviceEdition::ALERT_STATUSES[1..0],
-                                  change_description: "Stuff changed", minor_update: false,
-                                  overview: "The overview", summary: "## Summary")
+    @edition = FactoryGirl.create(
+      :draft_travel_advice_edition,
+      country_slug: 'albania',
+      title: 'Albania travel advice',
+      alert_status: TravelAdviceEdition::ALERT_STATUSES[1..0],
+      change_description: "Stuff changed",
+      minor_update: false,
+      overview: "The overview",
+      summary: "## Summary"
+    )
 
     now = Time.now.utc
     visit "/admin/editions/#{@edition.to_param}/edit"
@@ -401,7 +407,7 @@ feature "Edit Edition page", js: true do
       _type: "edition",
       _id: "/foreign-travel-advice/albania",
       content_id: "2a3938e1-d588-45fc-8c8f-0f51814d5409",
-      rendering_app: "frontend",
+      rendering_app: "government-frontend",
       publishing_app: "travel-advice-publisher",
       format: "custom-application",
       title: "Albania travel advice",

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -85,7 +85,7 @@ describe EditionPresenter do
         "description" => "Something something",
         "locale" => "en",
         "publishing_app" => "travel-advice-publisher",
-        "rendering_app" => "multipage-frontend",
+        "rendering_app" => "government-frontend",
         "public_updated_at" => edition.published_at.iso8601,
         "update_type" => "major",
         "routes" => [

--- a/spec/services/search_indexer_spec.rb
+++ b/spec/services/search_indexer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe SearchIndexer do
     assert_rummager_posted_item(
       _type: 'edition',
       _id: "/#{travel_advice_edition.slug}",
-      rendering_app: 'frontend',
+      rendering_app: 'government-frontend',
       publishing_app: 'travel-advice-publisher',
       format: "custom-application",
       title: travel_advice_edition.title,


### PR DESCRIPTION
This is part of the template consolidation work, all functionality has been duplicated in
government frontend and this is the final step

https://github.com/alphagov/government-frontend/pulls?q=is%3Apr+travel+advice+is%3Aclosed

once this has been releases, we will run the rake task to replublish