### PR TITLE
Use the same database names that are used in production

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -1,12 +1,12 @@
 development:
   clients:
     default:
-      uri: <%= ENV["MONGODB_URI"] || "mongodb://localhost/govuk_content_development" %>
+      uri: <%= ENV["MONGODB_URI"] || "mongodb://localhost/travel_advice_publisher_development" %>
 
 test:
   clients:
     default:
-      uri: <%= ENV["TEST_MONGODB_URI"] || "mongodb://localhost/govuk_travel_advice_publisher_test" %>
+      uri: <%= ENV["TEST_MONGODB_URI"] || "mongodb://localhost/travel_advice_publisher_test" %>
 
 # set these environment variables on your prod server
 production:


### PR DESCRIPTION
This enables the replication script to work again.

Do not merge until TAP is using the new database in production and data has been replicated to integration at least once.