### PR TITLE
Don't try to config activerecord in prod environ.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,5 +92,5 @@ Rails.application.configure do
   config.send_email_alerts = (ENV["SEND_EMAIL_ALERTS"] == "1")
 
   # Do not dump schema after migrations.
-  config.active_record.dump_schema_after_migration = false
+  # config.active_record.dump_schema_after_migration = false
 end


### PR DESCRIPTION
The gem is not loaded because we use Mongoid, so attempting to configure it fails and prevents the app from loading when deployed.