### PR TITLE
Use plek for Errbit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'state_machines-mongoid', '~> 0.1'
 
 gem 'diffy', '3.0.7'
 
-gem 'plek', '~> 1.9.0'
+gem 'plek', '~> 2.0'
 gem 'gds-sso', '~> 13.2'
 
 gem 'uglifier', '>= 1.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,7 +205,7 @@ GEM
     parser (2.4.0.0)
       ast (~> 2.2)
     phantomjs (2.1.1.0)
-    plek (1.9.0)
+    plek (2.0.0)
     poltergeist (1.8.1)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -403,7 +403,7 @@ DEPENDENCIES
   logstasher (= 0.4.8)
   mongoid (~> 6.1)
   mongoid_rails_migrations (= 1.1.0)
-  plek (~> 1.9.0)
+  plek (~> 2.0)
   poltergeist (= 1.8.1)
   pry-byebug
   pry-rails

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,8 +1,10 @@
 if ENV.has_key?("ERRBIT_API_KEY")
+  errbit_uri = Plek.find_uri("errbit")
+
   Airbrake.configure do |config|
     config.api_key = ENV["ERRBIT_API_KEY"]
-    config.host = "errbit.#{ENV['GOVUK_APP_DOMAIN']}"
-    config.secure = true
+    config.host = errbit_uri.host
+    config.secure = errbit_uri.scheme == "https"
     config.environment_name = ENV["ERRBIT_ENVIRONMENT_NAME"]
   end
 end


### PR DESCRIPTION
This allows the Errbit configuration to be tailored more to the environment, which is useful for end to end tests.