### PR TITLE
Register routes as exact rather than prefix

### DIFF
--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -66,11 +66,22 @@ private
     "/foreign-travel-advice/#{edition.country_slug}"
   end
 
-  def routes
+  def base_routes
     [
-      { "path" => base_path, "type" => "prefix" },
+      { "path" => base_path, "type" => "exact" },
       { "path" => "#{base_path}.atom", "type" => "exact" },
+      { "path" => "#{base_path}/print", "type" => "exact" },
     ]
+  end
+
+  def part_routes
+    edition.parts.map do |part|
+      { "path" => "#{base_path}/#{part.slug}", "type" => "exact" }
+    end
+  end
+
+  def routes
+    base_routes + part_routes
   end
 
   def public_updated_at

--- a/lib/registerable_travel_advice_edition.rb
+++ b/lib/registerable_travel_advice_edition.rb
@@ -32,14 +32,20 @@ class RegisterableTravelAdviceEdition
   end
 
   def paths
-    ["/#{slug}.atom"]
+    ["/#{slug}", "/#{slug}.atom", "/#{slug}/print"] + part_paths
   end
 
   def prefixes
-    ["/#{slug}"]
+    []
   end
 
 private
+
+  def part_paths
+    @edition.parts.map do |part|
+      "/#{slug}/#{part.slug}"
+    end
+  end
 
   def country
     Country.find_by_slug(@edition.country_slug)

--- a/spec/lib/registerable_travel_advice_edition_spec.rb
+++ b/spec/lib/registerable_travel_advice_edition_spec.rb
@@ -51,12 +51,27 @@ describe RegisterableTravelAdviceEdition do
       expect(@registerable.need_ids).to eq(['101191'])
     end
 
-    it "should return /<slug>.atom for the paths" do
-      expect(@registerable.paths).to eq(["/foreign-travel-advice/#{@edition.country_slug}.atom"])
+    context "paths" do
+      it "should include /<slug>.atom" do
+        expect(@registerable.paths).to include("/foreign-travel-advice/#{@edition.country_slug}.atom")
+      end
+
+      it "should include /<slug>" do
+        expect(@registerable.paths).to include("/foreign-travel-advice/#{@edition.country_slug}")
+      end
+
+      it "should include /<slug>/print" do
+        expect(@registerable.paths).to include("/foreign-travel-advice/#{@edition.country_slug}/print")
+      end
+
+      it "should include /<slug>/<part.slug>" do
+        @edition.parts << Part.new(title: "Foo", body: "Bar", slug: "foo")
+        expect(@registerable.paths).to include("/foreign-travel-advice/#{@edition.country_slug}/foo")
+      end
     end
 
-    it "should return /<slug> for the prefix routes" do
-      expect(@registerable.prefixes).to eq(["/foreign-travel-advice/#{@edition.country_slug}"])
+    it "should have no prefix paths" do
+      expect(@registerable.prefixes).to be_empty
     end
   end
 

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -89,8 +89,11 @@ describe EditionPresenter do
         "public_updated_at" => edition.published_at.iso8601,
         "update_type" => "major",
         "routes" => [
-          { "path" => "/foreign-travel-advice/aruba", "type" => "prefix" },
-          { "path" => "/foreign-travel-advice/aruba.atom", "type" => "exact" }
+          { "path" => "/foreign-travel-advice/aruba", "type" => "exact" },
+          { "path" => "/foreign-travel-advice/aruba.atom", "type" => "exact" },
+          { "path" => "/foreign-travel-advice/aruba/print", "type" => "exact" },
+          { "path" => "/foreign-travel-advice/aruba/terrorism", "type" => "exact" },
+          { "path" => "/foreign-travel-advice/aruba/safety-and-security", "type" => "exact" },
         ],
         "details" => {
           "summary" => [


### PR DESCRIPTION
Currently routes are registered as prefixes, this means that gibberish routes such as '/foreign-travel-advice/france/fslajasifj' will end up returning a content item rather than giving a 404. This means that frontend applications will have to include their own logic to determine whether the part exists or not.

[Trello Card](https://trello.com/c/2sdS0Aps/905-stop-using-prefix-routes-for-travel-advice-publisher-2)