### PR TITLE
Remove publishing request ID

### DIFF
--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -59,7 +59,6 @@ private
 
     details["image"] = image if image
     details["document"] = document if document
-    details["publishing_request_id"] = publishing_request_id if publishing_request_id
 
     details
   end
@@ -122,9 +121,5 @@ private
 
   def document
     @document ||= AssetPresenter.present(edition.document)
-  end
-
-  def publishing_request_id
-    GdsApi::GovukHeaders.headers[:govuk_request_id]
   end
 end

--- a/lib/publication_check/content_store_check.rb
+++ b/lib/publication_check/content_store_check.rb
@@ -35,7 +35,7 @@ module PublicationCheck
 
     def page_has_request_id?
       response_json = JSON.parse(page_response.body)
-      content_store_request_id = response_json["details"]["publishing_request_id"]
+      content_store_request_id = response_json["details"].fetch("publishing_request_id", response_json["publishing_request_id"])
       content_store_request_id.present? &&
         content_store_request_id == request_id
     end

--- a/spec/features/edition_edit_spec.rb
+++ b/spec/features/edition_edit_spec.rb
@@ -415,9 +415,6 @@ feature "Edit Edition page", js: true do
 
     assert_publishing_api_publish("2a3938e1-d588-45fc-8c8f-0f51814d5409", update_type: "major")
 
-    assert_details_contains("2a3938e1-d588-45fc-8c8f-0f51814d5409",
-                            "publishing_request_id", "25108-1461151489.528-10.3.3.1-1066")
-
     assert_email_alert_sent("subject" => "Albania travel advice")
   end
 

--- a/spec/lib/publication_check/content_store_check_spec.rb
+++ b/spec/lib/publication_check/content_store_check_spec.rb
@@ -26,9 +26,8 @@ module PublicationCheck
         {
           "base_path": "test/base/path",
           "content_id": "7a2554bd-9dc5-4a2e-953c-263c65ced66b",
-          "details": {
-            "publishing_request_id": "#{response_publishing_request_id}"
-          }
+          "details": { },
+          "publishing_request_id": "#{response_publishing_request_id}"
         }
       JSON
     }

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -126,8 +126,8 @@ describe EditionPresenter do
           ],
           "alert_status" => ["avoid_all_but_essential_travel_to_parts"],
           "max_cache_time" => 10,
-          "publishing_request_id" => "25108-1461151489.528-10.3.3.1-1066"
         },
+        "publishing_request_id" => "25108-1461151489.528-10.3.3.1-1066",
       )
     end
 
@@ -153,17 +153,6 @@ describe EditionPresenter do
         edition.change_description = nil
 
         expect(presented_data["details"]["change_description"]).to eq("Stuff previously changed")
-      end
-    end
-
-    context "when there is no govuk_request_id header" do
-      before do
-        allow(GdsApi::GovukHeaders).to receive(:headers)
-          .and_return({})
-      end
-
-      it "does not include a publishing_request_id key" do
-        expect(presented_data["details"]).not_to have_key("publishing_request_id")
       end
     end
 

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -127,7 +127,6 @@ describe EditionPresenter do
           "alert_status" => ["avoid_all_but_essential_travel_to_parts"],
           "max_cache_time" => 10,
         },
-        "publishing_request_id" => "25108-1461151489.528-10.3.3.1-1066",
       )
     end
 


### PR DESCRIPTION
This PR removes the old `publishing_request_id` field and instead relies on the new `govuk_request_id` field which will be sent to the Content Store.

Do not merge until https://github.com/alphagov/content-store/pull/290 has gone in and been deployed.

[Trello Card](https://trello.com/c/JZ5Zabe9/702-remove-publishing-request-id-from-travel-advice-publisher-details-hash-2)