### PR TITLE
Index the correct rendering_app for home

### DIFF
--- a/app/presenters/search_payload_presenter.rb
+++ b/app/presenters/search_payload_presenter.rb
@@ -18,7 +18,7 @@ class SearchPayloadPresenter
   def call
     {
       content_id: content_id,
-      rendering_app: 'government-frontend',
+      rendering_app: travel_advice_page.try(:rendering_app) || 'government-frontend',
       publishing_app: 'travel-advice-publisher',
       format: 'custom-application',
       title: title,

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -7,7 +7,8 @@ namespace :rummager do
       content_id: TravelAdvicePublisher::INDEX_CONTENT_ID,
       title: "Foreign travel advice",
       description: "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",
-      indexable_content: "Latest travel advice by country including safety and security, entry requirements, travel warnings and health"
+      indexable_content: "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",
+      rendering_app: "frontend",
     )
 
     RummagerNotifier.notify(record)


### PR DESCRIPTION
We currently tell rummager that the /foreign-travel-advice page is rendered by government-frontend. It isn't.

@fofr 