### PR TITLE
Remove references to govuk_content_models in documentation

### DIFF
--- a/docs/further-technical-information.md
+++ b/docs/further-technical-information.md
@@ -2,8 +2,6 @@
 
 ### Models
 
-Travel Advice Publisher inherits its models from the [govuk_content_models](https://github.com/alphagov/govuk_content_models) gem. In addition to this, enhancements to the `TravelAdviceEdition` model for integration with the [asset manager](https://github.com/alphagov/asset-manager) are present in the app.
-
 At the present time, the list of countries is defined in [`lib/data/countries.yml`](../lib/data/countries.yml), however it is expected that this will change to consume an api for countries from the [Whitehall](https://github.com/alphagov/whitehall) app in the near future.
 
 Published travel advice is exposed through the [content-store](https://github.com/alphagov/content-store) and presented in [frontend](https://github.com/alphagov/frontend) and [government-frontend](https://github.com/alphagov/government-frontend).


### PR DESCRIPTION
The gem has been removed in https://github.com/alphagov/travel-advice-publisher/pull/174/files

I'm happy to iterate again to have a better wording in this. 

Trello: https://trello.com/c/9Ho9O9Yo/219-epic-retire-govukcontentmodels