### PR TITLE
Send past part slugs to the Publishing API

### DIFF
--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -75,9 +75,25 @@ private
     ]
   end
 
+  def previous_part_slugs
+    TravelAdviceEdition.where(country_slug: edition.country_slug)
+      .pluck("parts.slug")
+      .compact
+      .flat_map { |slugs| slugs.map { |slug| slug["slug"] } }
+      .uniq
+  end
+
+  def current_part_slugs
+    edition.parts.map(&:slug)
+  end
+
+  def all_part_slugs
+    (previous_part_slugs + current_part_slugs).uniq
+  end
+
   def part_routes
-    edition.parts.map do |part|
-      { "path" => "#{base_path}/#{part.slug}", "type" => "exact" }
+    all_part_slugs.map do |slug|
+      { "path" => "#{base_path}/#{slug}", "type" => "exact" }
     end
   end
 

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -6,7 +6,7 @@ describe EditionPresenter do
   let(:edition) {
     edition = FactoryGirl.build(
       :travel_advice_edition,
-      country_slug: 'aruba',
+      country_slug: "aruba",
       title: "Aruba travel advice",
       overview: "Something something",
       published_at: 5.minutes.ago,
@@ -38,10 +38,20 @@ describe EditionPresenter do
   }
 
   let(:previous) {
-    FactoryGirl.build(
+    previous = FactoryGirl.create(
       :travel_advice_edition,
+      country_slug: "aruba",
       change_description: "Stuff previously changed"
     )
+
+    previous.parts.create(
+      slug: "money",
+      title: "Money",
+      body: "Use a piggy bank ...",
+      order: 1,
+    )
+
+    previous
   }
 
   before do
@@ -92,6 +102,7 @@ describe EditionPresenter do
           { "path" => "/foreign-travel-advice/aruba", "type" => "exact" },
           { "path" => "/foreign-travel-advice/aruba.atom", "type" => "exact" },
           { "path" => "/foreign-travel-advice/aruba/print", "type" => "exact" },
+          { "path" => "/foreign-travel-advice/aruba/money", "type" => "exact" },
           { "path" => "/foreign-travel-advice/aruba/terrorism", "type" => "exact" },
           { "path" => "/foreign-travel-advice/aruba/safety-and-security", "type" => "exact" },
         ],


### PR DESCRIPTION
This means that past routes can still be stored and redirected appropriately.

[Trello Card](https://trello.com/c/7Dn3P7B3/954-store-past-routes-so-they-can-be-redirected-2)