### PR TITLE
Send update type with put content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'formtastic-bootstrap', '3.0.0'
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '~> 36.4.0'
+  gem 'gds-api-adapters', '~> 47.2'
 end
 
 gem 'logstasher', '0.4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,7 +77,7 @@ GEM
     diff-lcs (1.3)
     diffy (3.0.7)
     docile (1.1.5)
-    domain_name (0.5.20170223)
+    domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.7.0)
@@ -92,7 +92,7 @@ GEM
       actionpack (>= 3.0)
     formtastic-bootstrap (3.0.0)
       formtastic (>= 2.2)
-    gds-api-adapters (36.4.1)
+    gds-api-adapters (47.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -222,7 +222,7 @@ GEM
       pry (~> 0.10)
     pry-rails (0.3.5)
       pry (>= 0.9.10)
-    rack (2.0.1)
+    rack (2.0.3)
     rack-cache (1.7.0)
       rack (>= 0.4)
     rack-protection (1.5.3)
@@ -262,7 +262,7 @@ GEM
     redis (3.3.3)
     redis-namespace (1.5.3)
       redis (~> 3.0, >= 3.0.4)
-    rest-client (2.0.1)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
@@ -360,7 +360,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.2)
+    unf_ext (0.0.7.4)
     unicorn (5.0.1)
       kgio (~> 2.6)
       rack
@@ -392,7 +392,7 @@ DEPENDENCIES
   factory_girl_rails
   formtastic (= 2.3.0)
   formtastic-bootstrap (= 3.0.0)
-  gds-api-adapters (~> 36.4.0)
+  gds-api-adapters (~> 47.2)
   gds-sso (~> 13.2)
   govspeak (~> 3.5.2)
   govuk-content-schema-test-helpers (~> 1.4.0)
@@ -422,4 +422,4 @@ DEPENDENCIES
   webmock (= 1.22.6)
 
 BUNDLED WITH
-   1.13.1
+   1.15.1

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -154,7 +154,7 @@ private
 
     if @edition.save!
       notifier.put_content(@edition)
-      notifier.publish(@edition, update_type: "minor")
+      notifier.publish(@edition)
       notifier.enqueue
       redirect_to admin_country_path(@edition.country_slug), alert: "Updated review date"
     else

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -9,7 +9,7 @@ namespace :publishing_api do
 
     api_v2.put_content(presenter.content_id, presenter.render_for_publishing_api)
     api_v2.patch_links(TravelAdvicePublisher::INDEX_CONTENT_ID, IndexLinksPresenter.present)
-    api_v2.publish(presenter.content_id, presenter.update_type)
+    api_v2.publish(presenter.content_id)
   end
 
   desc "republish all published editions to publishing-api"

--- a/spec/features/edition_edit_spec.rb
+++ b/spec/features/edition_edit_spec.rb
@@ -229,7 +229,7 @@ feature "Edit Edition page", js: true do
 
       expect(page).to have_content "Updated review date"
       assert_details_contains("2a3938e1-d588-45fc-8c8f-0f51814d5409", "reviewed_at", Time.zone.now.iso8601)
-      assert_publishing_api_publish("2a3938e1-d588-45fc-8c8f-0f51814d5409", update_type: "minor")
+      assert_publishing_api_publish("2a3938e1-d588-45fc-8c8f-0f51814d5409")
     end
   end
 

--- a/spec/tasks/publishing_api_rake_spec.rb
+++ b/spec/tasks/publishing_api_rake_spec.rb
@@ -25,7 +25,7 @@ describe "publishing_api rake tasks", type: :rake_task do
                                                                                    update_type: "minor",
       ))
 
-      assert_publishing_api_publish(TravelAdvicePublisher::INDEX_CONTENT_ID, update_type: "minor")
+      assert_publishing_api_publish(TravelAdvicePublisher::INDEX_CONTENT_ID)
     end
   end
 


### PR DESCRIPTION
We are deprecating sending the update_type in publish requests made to the Publishing API, and now expect clients to send update_type in PUT requests instead. We also upgrade gds-api-adapters to bring this app up to date with the new expected behaviour.

https://trello.com/c/LnJlkb9e/987-5-deprecate-the-usage-of-updatetype-in-publish-for-publishing-api-and-update-usage-across-govuk