### PR TITLE
Update responses to behave like a hash

### DIFF
--- a/app/models/travel_advice_edition.rb
+++ b/app/models/travel_advice_edition.rb
@@ -247,7 +247,7 @@ private
       define_method("upload_#{field}") do
         begin
           response = TravelAdvicePublisher.asset_api.create_asset(file: instance_variable_get("@#{field}_file"))
-          self.send("#{field}_id=", response.id.match(/\/([^\/]+)\z/) { |m| m[1] })
+          self.send("#{field}_id=", response[:id].match(/\/([^\/]+)\z/) { |m| m[1] })
         rescue GdsApi::BaseError
           errors.add("#{field}_id".to_sym, "could not be uploaded")
         end

--- a/app/presenters/asset_presenter.rb
+++ b/app/presenters/asset_presenter.rb
@@ -10,8 +10,8 @@ class AssetPresenter
   def present
     if asset
       {
-        "url" => asset.file_url,
-        "content_type" => asset.content_type,
+        "url" => asset[:file_url],
+        "content_type" => asset[:content_type],
       }
     end
   end

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -51,7 +51,7 @@
             <% if @edition.image %>
               <div class="well uploaded-image">
                 <p><strong>Current map image</strong></p>
-                <p><%= image_tag @edition.image.file_url %></p>
+                <p><%= image_tag @edition.image[:file_url] %></p>
                 <p><%= label_tag do %>Remove image? <%= check_box_tag "edition[remove_image]", "1" %><% end %></p>
               </div>
 
@@ -64,7 +64,7 @@
             <% if @edition.document %>
               <div class="well uploaded-document">
                 <p><strong>Current PDF</strong></p>
-                <p><%= link_to @edition.document.file_url do %>Download <em><%= @edition.document.name %></em><% end %></p>
+                <p><%= link_to @edition.document[:file_url] do %>Download <em><%= @edition.document[:name] %></em><% end %></p>
                 <p><%= label_tag do %>
                   Remove PDF? <%= check_box_tag "edition[remove_document]", "1" %>
                 <% end %></p>

--- a/spec/features/edition_edit_spec.rb
+++ b/spec/features/edition_edit_spec.rb
@@ -543,17 +543,17 @@ avoid_all_but_essential_travel_to_parts))
     file_one = File.open(Rails.root.join("spec", "fixtures", "uploads", "image.jpg"))
     file_two = File.open(Rails.root.join("spec", "fixtures", "uploads", "image_two.jpg"))
 
-    asset_one = OpenStruct.new(
+    asset_one = {
       id: 'http://asset-manager.dev.gov.uk/assets/an_image_id',
       file_url: 'http://path/to/image_one.jpg',
       content_type: "image/jpeg",
-    )
+    }
 
-    asset_two = OpenStruct.new(
+    asset_two = {
       id: 'http://asset-manager.dev.gov.uk/assets/another_image_id',
       file_url: 'http://path/to/image_two.jpg',
       content_type: "image/jpeg",
-    )
+    }
 
     expect(TravelAdvicePublisher.asset_api).to receive(:create_asset).and_return(asset_one)
 
@@ -623,19 +623,19 @@ avoid_all_but_essential_travel_to_parts))
     file_one = File.open(Rails.root.join("spec", "fixtures", "uploads", "document.pdf"))
     file_two = File.open(Rails.root.join("spec", "fixtures", "uploads", "document_two.pdf"))
 
-    asset_one = OpenStruct.new(
+    asset_one = {
       id: 'http://asset-manager.dev.gov.uk/assets/a_document_id',
       name: "document_one.pdf",
       file_url: 'http://path/to/document_one.pdf',
       content_type: "application/pdf",
-    )
+    }
 
-    asset_two = OpenStruct.new(
+    asset_two = {
       id: 'http://asset-manager.dev.gov.uk/assets/another_document_id',
       name: "document_two.pdf",
       file_url: 'http://path/to/document_two.pdf',
       content_type: "application/pdf",
-    )
+    }
 
     expect(TravelAdvicePublisher.asset_api).to receive(:create_asset).and_return(asset_one)
 

--- a/spec/models/travel_advice_edition_spec.rb
+++ b/spec/models/travel_advice_edition_spec.rb
@@ -538,20 +538,25 @@ describe TravelAdviceEdition do
     it "retrieves the asset from the api" do
       ed = FactoryGirl.create(:travel_advice_edition, state: 'draft', image_id: "an_image_id")
 
-      asset = OpenStruct.new(file_url: "/path/to/image")
+      asset = {
+        file_url: "/path/to/image"
+      }
       allow_any_instance_of(GdsApi::AssetManager).to receive(:asset).with("an_image_id").and_return(asset)
 
-      expect(ed.image.file_url).to eq("/path/to/image")
+      expect(ed.image[:file_url]).to eq("/path/to/image")
     end
 
     it "caches the asset from the api" do
       ed = FactoryGirl.create(:travel_advice_edition, state: 'draft', image_id: "an_image_id")
 
-      asset = OpenStruct.new(something: "one", something_else: "two")
+      asset = {
+        something: "one",
+        something_else: "two"
+      }
       expect_any_instance_of(GdsApi::AssetManager).to receive(:asset).once.with("an_image_id").and_return(asset)
 
-      expect(ed.image.something).to eq("one")
-      expect(ed.image.something_else).to eq("two")
+      expect(ed.image[:something]).to eq("one")
+      expect(ed.image[:something_else]).to eq("two")
     end
 
     it "assigns a file and detects it has changed" do
@@ -574,7 +579,7 @@ describe TravelAdviceEdition do
         @ed = FactoryGirl.create(:travel_advice_edition, state: 'draft')
         @file = File.open(Rails.root.join("spec/fixtures/uploads/image.jpg"))
 
-        @asset = double(id: 'http://asset-manager.dev.gov.uk/assets/an_image_id')
+        @asset = { id: 'http://asset-manager.dev.gov.uk/assets/an_image_id' }
       end
 
       it "uploads the asset" do

--- a/spec/presenters/asset_presenter_spec.rb
+++ b/spec/presenters/asset_presenter_spec.rb
@@ -2,10 +2,10 @@ require "spec_helper"
 
 RSpec.describe AssetPresenter do
   let(:asset) do
-    OpenStruct.new(
+    {
       file_url: "http://example.com/image.jpg",
       content_type: "image/jpeg",
-    )
+    }
   end
 
   it "presents the asset" do


### PR DESCRIPTION
Following on from the gds-api-adapters upgrade to 47.2, OpenStruct responses are now longer supported and must now be hashes.