### PR TITLE
Run travel advice end to end tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,7 +85,8 @@ node('mongodb-2.4') {
       govuk.runPublishingE2ETests(
         "TRAVEL_ADVICE_PUBLISHER_COMMITTISH",
         DEFAULT_PUBLISHING_E2E_TESTS_BRANCH,
-        REPOSITORY
+        REPOSITORY,
+        "test-travel-advice-publisher",
       )
     }
 


### PR DESCRIPTION
This filters which tests run on CI to be just the travel advice
end-to-end tests in order to reduce testing apps TAP is not concerned
with.