### PR TITLE
Conditionally draft newly created editions to the Publishing API

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -16,9 +16,11 @@ class Admin::EditionsController < ApplicationController
     end
 
     if edition.save
-      notifier.put_content(edition)
-      notifier.patch_links(edition)
-      notifier.enqueue
+      unless edition.first_draft
+        notifier.put_content(edition)
+        notifier.patch_links(edition)
+        notifier.enqueue
+      end
       redirect_to edit_admin_edition_path(edition)
     else
       redirect_to admin_country_path(@country.slug), alert: "Failed to create new edition"

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -22,7 +22,7 @@ class Country
     elsif (latest_edition = editions.first)
       latest_edition.build_clone
     else
-      TravelAdviceEdition.new(country_slug: slug, title: "#{name} travel advice")
+      TravelAdviceEdition.new(country_slug: slug, title: "#{name} travel advice", first_draft: true)
     end
   end
 

--- a/app/models/travel_advice_edition.rb
+++ b/app/models/travel_advice_edition.rb
@@ -22,6 +22,8 @@ class TravelAdviceEdition
   field :published_at,         type: Time
   field :reviewed_at,          type: Time
 
+  attr_accessor :first_draft
+
   embeds_many :actions
 
   index({ country_slug: 1, version_number: -1 }, unique: true)

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -121,6 +121,7 @@ describe Country do
       expect(ed).to be_new_record
       expect(ed.country_slug).to eq('aruba')
       expect(ed.title).to eq("Aruba travel advice")
+      expect(ed.first_draft).to be true
     end
   end
 


### PR DESCRIPTION
https://trello.com/c/vU0gCJds/2-stop-sending-empty-drafts-to-publishing-api

When a country has no previous editions a newly created edition will have no content and will not pass schema validation in the Publishing API.
The test setup in the e2e tests has highlighted this problem which we don't see in real life as we have yet to introduce a new country via the Publishing API.
It's still an edge case we should close off for the [sake of the e2e tests](https://ci.integration.publishing.service.gov.uk/job/publishing-e2e-tests/job/TAP_e2e_tests/1/artifact/tmp/errors-verbose.log).

cc @kevindew 