### PR TITLE
Present all necessary fields to email-alert-api

### DIFF
--- a/app/presenters/email_alert_presenter.rb
+++ b/app/presenters/email_alert_presenter.rb
@@ -9,11 +9,20 @@ class EmailAlertPresenter
 
   def present
     {
+      "title" => title,
+      "description" => description,
+      "change_note" => change_description,
       "subject" => subject,
+      "body" => body,
       "tags" => tags,
       "links" => links,
       "document_type" => document_type,
-      "body" => body,
+      "email_document_supertype" => "other",
+      "government_document_supertype" => "other",
+      "content_id" => content_id,
+      "public_updated_at" => public_updated_at,
+      "publishing_app" => "travel-advice-publisher",
+      "base_path" => base_path,
     }
   end
 
@@ -25,8 +34,12 @@ private
 
   attr_accessor :edition
 
-  def subject
+  def title
     edition.title
+  end
+
+  def subject
+    title
   end
 
   def tags
@@ -71,6 +84,10 @@ private
 
   def formatted_published_at
     edition.published_at.strftime("%d-%m-%Y %H:%M %p GMT")
+  end
+
+  def public_updated_at
+    edition.published_at.to_time.iso8601
   end
 
   def absolute_path

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -14,6 +14,7 @@ FactoryGirl.define do
   factory :travel_advice_edition do
     sequence(:country_slug) { |n| "test-country-#{n}" }
     sequence(:title) { |n| "Test Country #{n}" }
+    sequence(:summary) { |n| "Travel advice about Test Country #{n}" }
     change_description "Stuff changed"
   end
 

--- a/spec/notifiers/publishing_api_notifier_spec.rb
+++ b/spec/notifiers/publishing_api_notifier_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe PublishingApiNotifier do
 
   subject { PublishingApiNotifier.new }
 
-  let(:edition) { FactoryGirl.create(:travel_advice_edition, country_slug: "aruba", published_at: Time.zone.now) }
+  let(:edition) { FactoryGirl.create(:travel_advice_edition, country_slug: "aruba") }
 
   describe "put_content and enqueue" do
     let(:presenter) { EditionPresenter.new(edition) }

--- a/spec/presenters/email_alert_presenter_spec.rb
+++ b/spec/presenters/email_alert_presenter_spec.rb
@@ -44,4 +44,12 @@ RSpec.describe EmailAlertPresenter do
       '</div>',
     ]
   end
+
+  it "includes the necessary fields" do
+    expect(email_alert.compact.keys).to match_array(%w(
+      title description change_note subject body tags links document_type
+      email_document_supertype government_document_supertype content_id
+      public_updated_at publishing_app base_path
+    ))
+  end
 end


### PR DESCRIPTION
These new fields are required by the API for GOV.UK Notify integration.

[Trello Card](https://trello.com/c/02JCCXB6/185-tap-and-specialist-publisher-should-match-service-regarding-what-they-send-to-the-api)