### PR TITLE
Only run travel advice publisher end to end tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,6 @@
 
 node('mongodb-2.4') {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
+  govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-travel-advice-publisher")
   govuk.buildProject(publishingE2ETests: true)
 }


### PR DESCRIPTION
Rather than running all the e2e tests - which will have us in better stead when the quantity of e2e tests increases.