### PR TITLE
Default value for summary to be an empty string

### DIFF
--- a/app/models/travel_advice_edition.rb
+++ b/app/models/travel_advice_edition.rb
@@ -14,7 +14,7 @@ class TravelAdviceEdition
   field :version_number,       type: Integer
   field :state,                type: String,    default: "draft"
   field :alert_status,         type: Array,     default: []
-  field :summary,              type: String
+  field :summary,              type: String,    default: ""
   field :change_description,   type: String
   field :minor_update,         type: Boolean,   default: false
   field :synonyms,             type: Array,     default: []


### PR DESCRIPTION
We see lots of errors in publishing-e2e-testing from summary being nil rather than a string. This sets summary to an empty string by default, which seems to have the effect of resolving the errors we are seeing.

A different way to skin the cat than: https://github.com/alphagov/travel-advice-publisher/pull/208

