### PR TITLE
Update rummager format to `travel-advice`

### DIFF
--- a/app/presenters/search_payload_presenter.rb
+++ b/app/presenters/search_payload_presenter.rb
@@ -20,7 +20,7 @@ class SearchPayloadPresenter
       content_id: content_id,
       rendering_app: travel_advice_page.try(:rendering_app) || 'government-frontend',
       publishing_app: 'travel-advice-publisher',
-      format: 'custom-application',
+      format: travel_advice_page.try(:format) || 'travel_advice',
       title: title,
       description: description,
       indexable_content: indexable_content,

--- a/lib/tasks/rummager.rake
+++ b/lib/tasks/rummager.rake
@@ -9,6 +9,7 @@ namespace :rummager do
       description: "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",
       indexable_content: "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",
       rendering_app: "frontend",
+      format: "custom-application",
     )
 
     RummagerNotifier.notify(record)

--- a/spec/features/edition_edit_spec.rb
+++ b/spec/features/edition_edit_spec.rb
@@ -406,7 +406,7 @@ feature "Edit Edition page", js: true do
       content_id: "2a3938e1-d588-45fc-8c8f-0f51814d5409",
       rendering_app: "government-frontend",
       publishing_app: "travel-advice-publisher",
-      format: "custom-application",
+      format: "travel_advice",
       title: "Albania travel advice",
       description: "The overview",
       indexable_content: "Summary Part One Body text",

--- a/spec/services/search_indexer_spec.rb
+++ b/spec/services/search_indexer_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe SearchIndexer do
       _id: "/#{travel_advice_edition.slug}",
       rendering_app: 'government-frontend',
       publishing_app: 'travel-advice-publisher',
-      format: "custom-application",
+      format: "travel_advice",
       title: travel_advice_edition.title,
       description: travel_advice_edition.description,
       indexable_content: travel_advice_edition.indexable_content,

--- a/spec/tasks/rummager_rake_spec.rb
+++ b/spec/tasks/rummager_rake_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+require 'rake'
+require 'gds_api/test_helpers/rummager'
+
+describe "rummager rake tasks", type: :rake_task do
+  include GdsApi::TestHelpers::Rummager
+
+  before do
+    Rake.application = nil # Reset any previously loaded tasks
+    Rails.application.load_tasks
+
+    stub_any_rummager_post
+  end
+
+  describe "rummager:index" do
+    let(:task) { Rake::Task['rummager:index'] }
+
+    it 'registers the travel advice index page in rummager' do
+      task.invoke
+
+      assert_rummager_posted_item(
+        _type: 'edition',
+        _id: "/foreign-travel-advice",
+        rendering_app: 'frontend',
+        publishing_app: 'travel-advice-publisher',
+        format: "custom-application",
+        title: "Foreign travel advice",
+        description: "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",
+        indexable_content: "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",
+        link: "/foreign-travel-advice",
+      )
+    end
+  end
+end


### PR DESCRIPTION
This only affects country pages, not the main index page
which has been left using `custom-application`.

This change has been made to simplify the migration of
travel advice documents to being index via the publishing API.

https://trello.com/c/36ZgSxPD/465-we-are-indexing-travel-advice-index-from-the-publishing-api