### PR TITLE
Add email-alert-api bearer token

### DIFF
--- a/config/initializers/email_alert_api.rb
+++ b/config/initializers/email_alert_api.rb
@@ -2,5 +2,6 @@ require "gds_api/email_alert_api"
 require "plek"
 
 TravelAdvicePublisher.email_alert_api = GdsApi::EmailAlertApi.new(
-  Plek.current.find("email-alert-api")
+  Plek.current.find("email-alert-api"),
+  bearer_token: ENV.fetch("EMAIL_ALERT_API_BEARER_TOKEN", "bearer_token")
 )


### PR DESCRIPTION
Email-alert-api is getting authentication/authorisation. This commit adds a bearer token for it.

[Trello](https://trello.com/c/75sVuXhA/455-require-all-apps-to-authenticate-with-email-alert-api)