### PR TITLE
Add in Healthcheck to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,6 @@ ADD . $APP_HOME
 ARG COMPILE_ASSETS=false
 RUN if [ "$COMPILE_ASSETS" = "true" ] ; then bundle exec rails assets:precompile ; fi
 
+HEALTHCHECK CMD curl --silent --fail localhost:$PORT || exit 1
+
 CMD bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p $PORT -b '0.0.0.0'"


### PR DESCRIPTION
Hey :wave:,

Moving this check from the docker-compose.yml in publishing-e2e-tests to each repo makes the Dockerfile more useful if used outside of publishing-e2e-tests.