### PR TITLE
Add Link and LinkCheckReport models

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,0 +1,17 @@
+class Link
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  embedded_in :link_check_report
+
+  field :uri, type: String
+  field :status, type: String
+  field :checked_at, type: DateTime
+  field :check_warnings, type: Array
+  field :check_errors, type: Array
+  field :problem_summary, type: String
+  field :suggested_fix, type: String
+
+  validates :uri, presence: true
+  validates :status, presence: true
+end

--- a/app/models/link_check_report.rb
+++ b/app/models/link_check_report.rb
@@ -1,0 +1,17 @@
+class LinkCheckReport
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  embedded_in :travel_advice_edition
+  embeds_many :links
+
+  accepts_nested_attributes_for :links
+
+  field :batch_id, type: Integer
+  field :status, type: String
+  field :completed_at, type: DateTime
+
+  validates :batch_id, presence: true
+  validates :status, presence: true
+  validates :links, presence: true
+end

--- a/app/models/travel_advice_edition.rb
+++ b/app/models/travel_advice_edition.rb
@@ -23,6 +23,7 @@ class TravelAdviceEdition
   field :reviewed_at,          type: Time
 
   embeds_many :actions
+  embeds_many :link_check_reports
 
   index({ country_slug: 1, version_number: -1 }, unique: true)
 

--- a/spec/models/link_check_report_spec.rb
+++ b/spec/models/link_check_report_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+
+describe LinkCheckReport, type: :model do
+  let(:attributes) do
+    {
+      links: [{ uri: "http://www.example.com", status: "error" }],
+      batch_id: 1,
+      status: "broken",
+      completed_at: Time.parse("2017-12-01")
+    }
+  end
+
+  subject(:link_check_report) { LinkCheckReport.new(attributes) }
+
+  context "all fields set" do
+    it { should be_valid }
+  end
+
+  it "should be valid without a completed at time" do
+    link_check_report.completed_at = nil
+    expect(link_check_report).to be_valid
+  end
+
+  it "should be invalid without links" do
+    attributes = {
+        links: [],
+        batch_id: 1,
+        status: "broken",
+        completed_at: Time.parse("2017-12-01")
+      }
+
+    link_check_report = LinkCheckReport.new(attributes)
+    expect(link_check_report).not_to be_valid
+  end
+
+  it "should be invalid without a batch id" do
+    link_check_report.batch_id = nil
+    expect(link_check_report).not_to be_valid
+  end
+
+  it "should be invalid without a status" do
+    link_check_report.status = nil
+    expect(link_check_report).not_to be_valid
+  end
+end

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -1,0 +1,64 @@
+require "spec_helper"
+
+describe Link do
+  let(:attributes) {
+    {
+      uri: "http://www.example.com",
+      status: "error",
+      checked_at: Time.parse("2017-12-01"),
+      check_warnings: ["example check warnings"],
+      check_errors: ["example check errors"],
+      problem_summary: "example problem",
+      suggested_fix: "example fix"
+    }
+  }
+
+  subject(:link) { Link.new(attributes) }
+
+  context "all fields set" do
+    it { should be_valid }
+  end
+
+  it "should be valid without a checked time" do
+    link.checked_at = nil
+    expect(link).to be_valid
+  end
+
+  it "should be valid without check warnings" do
+    link.check_warnings = nil
+    expect(link).to be_valid
+  end
+
+  it "should be valid without check errors" do
+    link.check_errors = nil
+    expect(link).to be_valid
+  end
+
+  it "should be valid without a problem summary" do
+    link.problem_summary = nil
+    expect(link).to be_valid
+  end
+
+  it "should be valid without a suggested fix" do
+    link.suggested_fix = nil
+    expect(link).to be_valid
+  end
+
+  it "should be invalid without a uri" do
+    link.uri = nil
+    expect(link).not_to be_valid
+  end
+
+  it "should be invalid without a status" do
+    link.status = nil
+    expect(link).not_to be_valid
+  end
+
+  it "should store warnings as an array" do
+    expect(link.check_warnings).to be_kind_of(Array)
+  end
+
+  it "should store errors as an array" do
+    expect(link.check_errors).to be_kind_of(Array)
+  end
+end

--- a/spec/models/travel_advice_edition_spec.rb
+++ b/spec/models/travel_advice_edition_spec.rb
@@ -448,6 +448,24 @@ describe TravelAdviceEdition do
     end
   end
 
+  context "link_check_reports" do
+    it "does not have any link_check_reports by default" do
+      edition = FactoryGirl.create(:travel_advice_edition)
+      expect(edition.link_check_reports.size).to eq(0)
+    end
+
+    it "adds a new link_check_report" do
+      edition = FactoryGirl.create(:travel_advice_edition)
+      edition.link_check_reports.build(
+        links: [{ uri: "http://www.example.com", status: "error" }],
+        batch_id: 1,
+        status: "broken",
+        completed_at: Time.parse("2017-12-01")
+      )
+      expect(edition.link_check_reports.size).to eq(1)
+    end
+  end
+
   describe "CSV Synonyms" do
     before do
       @edition = Country.find_by_slug('aruba').build_new_edition


### PR DESCRIPTION
Add the Link and LinkCheckReport models. These will be used to store the status of links on a TravelAdviceEdition when checked against the LinkChecker API. This PR will be followed by:
- New controller for creating/sending batch requests to the API
- New callback controller to update the LinkCheckReport and Links
- Implementation of UI to kick-off poll check and show results
