### PR TITLE
Add Link Checker API Callback endpoint

### DIFF
--- a/app/controllers/link_checker_api_controller.rb
+++ b/app/controllers/link_checker_api_controller.rb
@@ -1,0 +1,51 @@
+class LinkCheckerApiController < ApplicationController
+  skip_before_action :verify_authenticity_token
+  skip_before_action :authenticate_user!
+  skip_before_action :require_signin_permission!
+  skip_before_action :set_authenticated_user_header
+  before_action :verify_signature
+
+  rescue_from Mongoid::Errors::DocumentNotFound, with: :render_no_content
+
+  def callback
+    if link_check_report
+      LinkCheckReportUpdater.new(
+        report: link_check_report,
+        payload: params
+      ).call
+    end
+
+    render_no_content
+  end
+
+private
+
+  def render_no_content
+    head :no_content
+  end
+
+  def batch_id
+    params.require(:id)
+  end
+
+  def travel_advice_edition
+    @travel_advice_edition ||= TravelAdviceEdition.find_by("link_check_reports.batch_id": batch_id)
+  end
+
+  def link_check_report
+    @link_check_report ||= travel_advice_edition.link_check_reports.find_by(batch_id: batch_id)
+  end
+
+  def verify_signature
+    return unless webhook_secret_token
+    given_signature = request.headers["X-LinkCheckerApi-Signature"]
+    return head :bad_request unless given_signature
+    body = request.raw_post
+    signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha1"), webhook_secret_token, body)
+    head :bad_request unless Rack::Utils.secure_compare(signature, given_signature)
+  end
+
+  def webhook_secret_token
+    Rails.application.secrets.link_checker_api_secret_token
+  end
+end

--- a/app/services/link_check_report_updater.rb
+++ b/app/services/link_check_report_updater.rb
@@ -1,10 +1,4 @@
 class LinkCheckReportUpdater
-  class InvalidReport < RuntimeError
-    def initialize(original_error)
-      @message = original_error.message
-    end
-  end
-
   def initialize(report:, payload:)
     @report = report
     @payload = payload
@@ -14,8 +8,6 @@ class LinkCheckReportUpdater
     update_report!
     links = payload.fetch("links", [])
     update_links!(links)
-  rescue Mongoid::Errors::Validations => e
-    raise InvalidReport.new(e)
   end
 
 private

--- a/app/services/link_check_report_updater.rb
+++ b/app/services/link_check_report_updater.rb
@@ -1,0 +1,53 @@
+class LinkCheckReportUpdater
+  class InvalidReport < RuntimeError
+    def initialize(original_error)
+      @message = original_error.message
+    end
+  end
+
+  def initialize(report:, payload:)
+    @report = report
+    @payload = payload
+  end
+
+  def call
+    update_report!
+    links = payload.fetch("links", [])
+    update_links!(links)
+  rescue Mongoid::Errors::Validations => e
+    raise InvalidReport.new(e)
+  end
+
+private
+
+  attr_reader :report, :payload
+
+  def update_report!
+    report.update!(
+      status: payload.fetch("status"),
+      completed_at: payload.fetch("completed_at"),
+    )
+  end
+
+  def update_links!(links_payload)
+    links_payload.each do |link_payload|
+      link = report.links.find_by(uri: link_payload.fetch("uri"))
+
+      attributes = link_attributes(link_payload)
+
+      link.update!(attributes)
+    end
+  end
+
+  def link_attributes(link)
+    {
+      uri: link.fetch(:uri),
+      status: link.fetch(:status),
+      checked_at: link.fetch(:checked),
+      check_warnings: link.fetch(:warnings, []),
+      check_errors: link.fetch(:errors, []),
+      problem_summary: link.fetch(:problem_summary),
+      suggested_fix: link.fetch(:suggested_fix)
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
     root to: "countries#index"
   end
 
+  post "/link-checker-api-callback" => "link_checker_api#callback", as: "link_checker_api_callback"
+
   root to: redirect('/admin')
 
   mount GovukAdminTemplate::Engine, at: "/style-guide"

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -12,11 +12,14 @@
 
 development:
   secret_key_base: 38a1a15308aa0df480b2595aa0ecda3d9201f0d26707e0dc96807ac568b51605e035d701da1cc422fa7d2bbe900e59a86d5c429b2f79f3c06108ea736d577030
+  link_checker_api_secret_token: sfeZP6whkbC3DbhGL6csGRKx
 
 test:
   secret_key_base: ec0ce9feb624f0106f5b74c79b227fa26606266f77872d512a0d4a025a4ef2e4804a10f084c8260ddeef4fe3b0b316330b55dad2eec928e9fc7845797b617b28
+  link_checker_api_secret_token: sfeZP6whkbC3DbhGL6csGRKx
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  link_checker_api_secret_token: <%= ENV["LINK_CHECKER_API_SECRET_TOKEN"] %>

--- a/spec/controllers/link_checker_api_spec.rb
+++ b/spec/controllers/link_checker_api_spec.rb
@@ -1,0 +1,63 @@
+require "spec_helper"
+require "gds_api/test_helpers/link_checker_api"
+
+RSpec.describe LinkCheckerApiController, type: :controller do
+  include GdsApi::TestHelpers::LinkCheckerApi
+
+  def generate_signature(body, key)
+    OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha1"), key, body)
+  end
+
+  def set_headers
+    headers = {
+      "Content-Type": "application/json",
+      "X-LinkCheckerApi-Signature": generate_signature(post_body.to_json, Rails.application.secrets.link_checker_api_secret_token)
+    }
+
+    request.headers.merge! headers
+  end
+
+  let(:link_check_report_batch_id) { 5 }
+  let!(:link_check_report) do
+    FactoryGirl.create(:travel_advice_edition_with_pending_link_checks,
+                       batch_id: 5,
+                       link_uris: ['http://www.example.com', 'http://www.gov.com']).link_check_reports.first
+  end
+
+  let(:post_body) do
+    link_checker_api_batch_report_hash(
+      id: link_check_report_batch_id,
+      links: [
+        { uri: 'https://www.gov.uk', status: "ok" },
+      ]
+    )
+  end
+
+  context 'when the report exists' do
+    subject do
+      post :callback, params: post_body
+      link_check_report.reload
+    end
+
+    before do
+      expect(TravelAdviceEdition).to receive(:find_by).with("link_check_reports.batch_id": 5).and_call_original
+    end
+
+    it "POST :update updates LinkCheckReport" do
+      set_headers
+
+      expect { subject }.to change { link_check_report.status }.to('completed')
+    end
+  end
+
+  context 'when the report does not exist' do
+    let(:link_check_report_batch_id) { 1 }
+
+    it 'should not throw an error' do
+      set_headers
+      post :callback, params: post_body
+
+      expect(response.status).to eq(204)
+    end
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -36,4 +36,47 @@ FactoryGirl.define do
       tae.save!
     end
   end
+
+  factory :travel_advice_edition_with_pending_link_checks, parent: :published_travel_advice_edition do
+    transient do
+      batch_id 1
+      link_uris []
+    end
+
+    link_check_reports do
+      [FactoryGirl.build(:link_check_report, :with_pending_links,
+                                             batch_id: batch_id,
+                                             link_uris: link_uris)]
+    end
+  end
+
+  factory :link_check_report do
+    batch_id 1
+    status "in_progress"
+    completed_at Time.now
+    links { [FactoryGirl.build(:link)] }
+
+    trait :completed do
+      status "completed"
+    end
+
+    trait :with_pending_links do
+      transient do
+        link_uris []
+      end
+
+      links do
+        link_uris.map { |uri| FactoryGirl.build(:link, :pending, uri: uri) }
+      end
+    end
+  end
+
+  factory :link do
+    uri "http://www.example.com"
+    status "ok"
+
+    trait :pending do
+      status "pending"
+    end
+  end
 end

--- a/spec/services/link_check_report_updater_spec.rb
+++ b/spec/services/link_check_report_updater_spec.rb
@@ -1,0 +1,57 @@
+require "spec_helper"
+
+RSpec.describe LinkCheckReportUpdater do
+  let(:link_check_report) do
+    FactoryGirl.create(:travel_advice_edition_with_pending_link_checks,
+                       batch_id: 1,
+                       link_uris: ['http://www.example.com', 'http://www.gov.com']).link_check_reports.first
+  end
+
+  let(:completed_at) { Time.now }
+
+  let(:payload) do
+    {
+      status: 'complete',
+      completed_at: completed_at,
+      links: links_payload
+    }.with_indifferent_access
+  end
+
+  let(:links_payload) do
+    [{
+      uri: "http://www.example.com",
+      status: "ok",
+      checked: completed_at.try(:iso8601),
+      problem_summary: nil,
+      suggested_fix: nil
+    }, {
+      uri: "http://www.gov.com",
+      status: "broken",
+      checked: completed_at.try(:iso8601),
+      problem_summary: "Page Not Found",
+      suggested_fix: "Contact site administrator"
+    }]
+  end
+
+  subject do
+    described_class.new(report: link_check_report, payload: payload)
+  end
+
+  it 'should update the link check report' do
+    subject.call
+
+    expect(link_check_report.status).to eq("complete")
+    expect(link_check_report.completed_at).to eq(completed_at)
+  end
+
+  it 'should update the links status' do
+    subject.call
+
+    expect(link_check_report.links.first.status).to eq("ok")
+    expect(link_check_report.links.first.checked_at).to eq(completed_at.try(:iso8601))
+
+    expect(link_check_report.links.last.status).to eq("broken")
+    expect(link_check_report.links.last.checked_at).to eq(completed_at.try(:iso8601))
+    expect(link_check_report.links.last.problem_summary).to eq("Page Not Found")
+  end
+end


### PR DESCRIPTION
This PR adds an endpoint for the `link-checker-api` to POST the results of batch checks to.

Depends on https://github.com/alphagov/govuk-puppet/pull/7007
