### PR TITLE
Link check report controller

### DIFF
--- a/app/controllers/link_check_reports_controller.rb
+++ b/app/controllers/link_check_reports_controller.rb
@@ -1,0 +1,20 @@
+class LinkCheckReportsController < ApplicationController
+  skip_before_action :authenticate_user!
+  skip_before_action :require_signin_permission!
+
+  def create
+    service = LinkCheckReportCreator.new(
+      travel_advice_edition_id: link_reportable_params[:travel_advice_edition_id]
+    )
+
+    service.call
+
+    head :created
+  end
+
+private
+
+  def link_reportable_params
+    params.require(:link_reportable).permit(:travel_advice_edition_id)
+  end
+end

--- a/app/services/link_check_report_creator.rb
+++ b/app/services/link_check_report_creator.rb
@@ -1,0 +1,63 @@
+require "gds_api/link_checker_api"
+require "govspeak/link_extractor"
+
+class LinkCheckReportCreator
+  include Rails.application.routes.url_helpers
+
+  CALLBACK_HOST = Plek.find("travel-advice-publisher")
+
+  def initialize(travel_advice_edition_id:)
+    @travel_advice_edition_id = travel_advice_edition_id
+  end
+
+  def call
+    link_report = call_link_checker_api
+
+    report = travel_advice_edition.link_check_reports.new(
+      batch_id: link_report.fetch(:id),
+      completed_at: link_report.fetch(:completed_at),
+      status: link_report.fetch(:status),
+      links: link_report.fetch(:links).map { |link| map_link_attrs(link) }
+    )
+
+    report.save!
+  end
+
+private
+
+  attr_reader :travel_advice_edition_id
+
+  def travel_advice_edition
+    @travel_advice_edition ||= TravelAdviceEdition.find(travel_advice_edition_id)
+  end
+
+  def call_link_checker_api
+    callback = link_checker_api_callback_url(host: CALLBACK_HOST)
+
+    TravelAdvicePublisher.link_checker_api.create_batch(
+      uris,
+      webhook_uri: callback,
+      webhook_secret_token: Rails.application.secrets.link_checker_api_secret_token
+    )
+  end
+
+  def govspeak_document
+    Govspeak::Document.new(travel_advice_edition.summary)
+  end
+
+  def uris
+    govspeak_document.extracted_links
+  end
+
+  def map_link_attrs(link)
+    {
+      uri: link.fetch(:uri),
+      status: link.fetch(:status),
+      checked_at: link.fetch(:checked),
+      check_warnings: link.fetch(:warnings, []),
+      check_errors: link.fetch(:errors, []),
+      problem_summary: link.fetch(:problem_summary),
+      suggested_fix: link.fetch(:suggested_fix)
+    }
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,7 @@ module TravelAdvicePublisher
   mattr_accessor :asset_api
   mattr_accessor :publishing_api_v2
   mattr_accessor :email_alert_api
+  mattr_accessor :link_checker_api
 
   # Maslow need ID for Travel Advice Publisher
   NEED_ID = '101191'.freeze

--- a/config/initializers/link_checker_api.rb
+++ b/config/initializers/link_checker_api.rb
@@ -1,0 +1,6 @@
+require "gds_api/link_checker_api"
+require "plek"
+
+TravelAdvicePublisher.link_checker_api = GdsApi::LinkCheckerApi.new(
+  Plek.find("link-checker-api")
+)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Rails.application.routes.draw do
     root to: "countries#index"
   end
 
+  resources :link_check_reports
+
   post "/link-checker-api-callback" => "link_checker_api#callback", as: "link_checker_api_callback"
 
   root to: redirect('/admin')

--- a/spec/controllers/link_check_reports_spec.rb
+++ b/spec/controllers/link_check_reports_spec.rb
@@ -1,0 +1,49 @@
+require "spec_helper"
+
+describe LinkCheckReportsController, type: :controller do
+  describe "#create" do
+    let(:travel_advice_edition) do
+      FactoryGirl.create(:travel_advice_edition,
+                         summary: "[link](http://www.example.com)[link_two](http://www.gov.com)")
+    end
+
+    let(:completed_at) { Time.now }
+
+    let(:link_checker_api_response) do
+      {
+        id: 1,
+        completed_at: nil,
+        status: "in_progress",
+        links: [
+          {
+            uri: "http://www.example.com",
+            status: "error",
+            checked: completed_at,
+            warnings: ["example check warnings"],
+            errors: ["example check errors"],
+            problem_summary: "example problem",
+            suggested_fix: "example fix"
+          },
+          {
+            uri: "http://www.gov.com",
+            status: "ok",
+            checked: completed_at,
+            warnings: [],
+            errors: [],
+            problem_summary: "",
+            suggested_fix: ""
+          }
+        ]
+      }
+    end
+
+    before do
+      allow(TravelAdvicePublisher.link_checker_api).to receive(:create_batch).and_return(link_checker_api_response)
+    end
+
+    it "returns a created status" do
+      post :create, params: { link_reportable: { travel_advice_edition_id: travel_advice_edition.id } }
+      expect(response).to have_http_status(:created)
+    end
+  end
+end

--- a/spec/services/link_check_report_creator_spec.rb
+++ b/spec/services/link_check_report_creator_spec.rb
@@ -1,0 +1,132 @@
+require "spec_helper"
+
+RSpec.describe LinkCheckReportCreator do
+  let(:travel_advice_edition) do
+    FactoryGirl.create(:travel_advice_edition,
+                       summary: "[link](http://www.example.com)[link_two](http://www.gov.com)")
+  end
+
+  let(:completed_at) { Time.now }
+
+  let(:link_checker_api_response) do
+    {
+      id: 1,
+      completed_at: nil,
+      status: "in_progress",
+      links: [
+        {
+          uri: "http://www.example.com",
+          status: "error",
+          checked: completed_at,
+          warnings: ["example check warnings"],
+          errors: ["example check errors"],
+          problem_summary: "example problem",
+          suggested_fix: "example fix"
+        },
+        {
+          uri: "http://www.gov.com",
+          status: "ok",
+          checked: completed_at,
+          warnings: [],
+          errors: [],
+          problem_summary: "",
+          suggested_fix: ""
+        }
+      ]
+    }
+  end
+
+  let(:link_check_report) do
+    FactoryGirl.create(:travel_advice_edition_with_pending_link_checks,
+                       batch_id: 1,
+                       link_uris: ['http://www.example.com', 'http://www.gov.com']).link_check_reports.first
+  end
+
+  before do
+    allow(TravelAdvicePublisher.link_checker_api).to receive(:create_batch).and_return(link_checker_api_response)
+    allow(LinkCheckReport).to receive(:new).and_return(link_check_report)
+  end
+
+  subject do
+    described_class.new(travel_advice_edition_id: travel_advice_edition.id)
+  end
+
+  it 'should call the link checker api with a callback url and secret token' do
+    expect(TravelAdvicePublisher.link_checker_api).to receive(:create_batch)
+
+    subject.call
+  end
+
+
+  context "when the link checker api is called" do
+    it "sets link check api attributes on report" do
+      expect(LinkCheckReport).to receive(:new).with(
+        hash_including(
+          batch_id: 1,
+          completed_at: nil,
+          status: "in_progress"
+        )
+      )
+      subject.call
+    end
+
+    it "sets link array on report" do
+      expect(LinkCheckReport).to receive(:new).with(
+        batch_id: 1,
+        completed_at: nil,
+        status: "in_progress",
+        links:
+        [{ uri: "http://www.example.com",
+           status: "error",
+           checked_at: completed_at,
+           check_warnings: ["example check warnings"],
+           check_errors: ["example check errors"],
+           problem_summary: "example problem",
+           suggested_fix: "example fix" },
+         { uri: "http://www.gov.com",
+           status: "ok",
+           checked_at: completed_at,
+           check_warnings: [],
+           check_errors: [],
+           problem_summary: "",
+           suggested_fix: "" }]
+      )
+      subject.call
+    end
+  end
+
+  context "when the report is valid" do
+    it "saves the report" do
+      expect(link_check_report).to receive(:save!)
+      subject.call
+    end
+  end
+
+  context "when there are no errors" do
+    it "saves errors as an empty array" do
+      link_checker_api_response[:links].first.delete(:errors)
+      expect(LinkCheckReport).to receive(:new).with(
+        hash_including(
+          links: array_including(
+            hash_including(check_errors: [])
+          )
+        )
+      )
+      subject.call
+    end
+  end
+
+  context "when there are no warnings" do
+    it "saves warnings as an empty array" do
+      link_checker_api_response[:links].first.delete(:warnings)
+      expect(LinkCheckReport).to receive(:new).with(
+        hash_including(
+          links: array_including(
+            hash_including(check_warnings: [])
+          )
+        )
+      )
+      subject.call
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the link checker API and uses it to make `create_batch` requests for Travel Advice Editions. It creates LinkCheckReports with the response from the API.