### PR TITLE
Add link checker ui

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -4,3 +4,4 @@
 @import "scaffold";
 @import "sortable_accordion";
 @import "diff";
+@import "broken_links_report";

--- a/app/assets/stylesheets/broken_links_report.scss
+++ b/app/assets/stylesheets/broken_links_report.scss
@@ -1,0 +1,46 @@
+.link-check-report {
+  float: right;
+  margin-top: 25px;
+}
+
+.broken-links-report {
+  .issue-summary {
+    font-weight: normal;
+  }
+
+  .issue-list {
+    list-style: none;
+    padding-left: 0;
+
+    li {
+      margin-top: 5px;
+    }
+  }
+
+  .issue-status-description {
+    margin-top: 10px;
+  }
+
+  .issue-list + .issue-status-description {
+    margin: 15px 0;
+  }
+
+  .display-issue-details {
+    display: block;
+    font-weight: bold;
+    padding-top: 5px;
+  }
+
+  .display-issue-details::-webkit-details-marker {
+    display: none;
+  }
+
+  .display-issue-details::before {
+    content: '\25B6';
+    padding-right: 3px;
+  }
+
+  details[open] > .display-issue-details::before {
+    content: '\25BC';
+  }
+}

--- a/app/controllers/link_check_reports_controller.rb
+++ b/app/controllers/link_check_reports_controller.rb
@@ -1,7 +1,4 @@
 class LinkCheckReportsController < ApplicationController
-  skip_before_action :authenticate_user!
-  skip_before_action :require_signin_permission!
-
   def create
     service = LinkCheckReportCreator.new(
       travel_advice_edition_id: link_reportable_params[:travel_advice_edition_id]

--- a/app/controllers/link_check_reports_controller.rb
+++ b/app/controllers/link_check_reports_controller.rb
@@ -1,22 +1,22 @@
 class LinkCheckReportsController < ApplicationController
-  before_action :find_reportable
+  before_action :find_edition
 
   def create
     service = LinkCheckReportCreator.new(
-      travel_advice_edition_id: @reportable
+      travel_advice_edition_id: @edition.id
     )
 
     @report = service.call
 
     respond_to do |format|
-      format.js { render 'link_check_reports/create' }
-      format.html { redirect_to edit_admin_edition_url(@reportable.id) }
+      format.js { render "admin/link_check_reports/create" }
+      format.html { redirect_to edit_admin_edition_url(@edition.id) }
     end
   end
 
 private
 
-  def find_reportable
-    @reportable = TravelAdviceEdition.find(params[:travel_advice_edition_id])
+  def find_edition
+    @edition = TravelAdviceEdition.find(params[:edition_id])
   end
 end

--- a/app/controllers/link_check_reports_controller.rb
+++ b/app/controllers/link_check_reports_controller.rb
@@ -1,17 +1,22 @@
 class LinkCheckReportsController < ApplicationController
+  before_action :find_reportable
+
   def create
     service = LinkCheckReportCreator.new(
-      travel_advice_edition_id: link_reportable_params[:travel_advice_edition_id]
+      travel_advice_edition_id: @reportable
     )
 
-    service.call
+    @report = service.call
 
-    head :created
+    respond_to do |format|
+      format.js { render 'link_check_reports/create' }
+      format.html { redirect_to edit_admin_edition_url(@reportable.id) }
+    end
   end
 
 private
 
-  def link_reportable_params
-    params.require(:link_reportable).permit(:travel_advice_edition_id)
+  def find_reportable
+    @reportable = TravelAdviceEdition.find(params[:travel_advice_edition_id])
   end
 end

--- a/app/models/link_check_report.rb
+++ b/app/models/link_check_report.rb
@@ -14,4 +14,20 @@ class LinkCheckReport
   validates :batch_id, presence: true
   validates :status, presence: true
   validates :links, presence: true
+
+  def completed?
+    status == "completed"
+  end
+
+  def in_progress?
+    !completed?
+  end
+
+  def broken_links
+    links.select { |l| l.status == "broken" }
+  end
+
+  def caution_links
+    links.select { |l| l.status == "caution" }
+  end
 end

--- a/app/models/travel_advice_edition.rb
+++ b/app/models/travel_advice_edition.rb
@@ -139,6 +139,12 @@ class TravelAdviceEdition
     self.parts.in_order.map { |i| %(\# #{i.title}\n\n#{i.body}) }.join("\n\n")
   end
 
+  def latest_link_check_report
+    return nil if link_check_reports.empty?
+
+    link_check_reports.last
+  end
+
 private
 
   def state_for_slug_unique

--- a/app/models/travel_advice_edition.rb
+++ b/app/models/travel_advice_edition.rb
@@ -140,8 +140,6 @@ class TravelAdviceEdition
   end
 
   def latest_link_check_report
-    return nil if link_check_reports.empty?
-
     link_check_reports.last
   end
 

--- a/app/services/link_check_report_creator.rb
+++ b/app/services/link_check_report_creator.rb
@@ -11,7 +11,7 @@ class LinkCheckReportCreator
   end
 
   def call
-    link_report = call_link_checker_api
+    link_report = call_link_checker_api.deep_symbolize_keys
 
     report = travel_advice_edition.link_check_reports.new(
       batch_id: link_report.fetch(:id),
@@ -21,6 +21,8 @@ class LinkCheckReportCreator
     )
 
     report.save!
+
+    report
   end
 
 private

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -94,6 +94,10 @@
           <% end %>
         </div>
 
+        <div class="col-md-4 link-check-report">
+          <%= render "admin/link_check_reports/link_check_report", edition: @edition, report: @edition.latest_link_check_report %>
+        </div>
+
         <div class="col-md-4 govspeak-container">
           <h3>Govspeak help</h3>
 

--- a/app/views/admin/link_check_reports/_form.html.erb
+++ b/app/views/admin/link_check_reports/_form.html.erb
@@ -1,0 +1,1 @@
+<%= link_to button_text, link_check_reports_path(edition_id: edition.id), method: :post, remote: :true, class: "btn btn-default add-top-margin remove-bottom-margin" %>

--- a/app/views/admin/link_check_reports/_link_check_report.html.erb
+++ b/app/views/admin/link_check_reports/_link_check_report.html.erb
@@ -1,0 +1,42 @@
+<div class="broken-links-report">
+  <% if !report.present? %>
+    <section class="alert alert-info">
+      <p>Check this edition for broken links. The report will take a few moments to complete. It only runs against GovSpeak fields.</p>
+      <%= render "admin/link_check_reports/form", edition: edition, button_text: "Check for broken links" %>
+    </section>
+  <% elsif report.in_progress? %>
+    <section class="alert alert-info">
+      <%= image_tag("admin/ajax_loader_blue_32.gif", width: 24, height: 24, class: "pull-left add-right-margin") %>
+      Broken link report in progress.<br />Please wait.
+      Refresh the page to view to see the result.
+    </section>
+  <% elsif report.broken_links.any? || report.caution_links.any? %>
+    <section class="alert alert-warning">
+      <h3 class="remove-top-margin">Links</h3>
+      <% report.links.sort_by(&:status).group_by(&:status).each do |status, links| %>
+        <% next unless %w(broken caution).include? status %>
+        <p class="issue-status-description"><%= status.capitalize %></p>
+        <ul class="issue-list">
+          <% links.each do |link| %>
+            <li>
+              <%= link_to link.uri.truncate(50), link.uri, title: link.uri, class: "link-inherit" %>
+              <details>
+                <summary class="display-issue-details">See more details about this link</summary>
+                <p class="issue-summary"><%= link.problem_summary %></p>
+                <% if link.suggested_fix %>
+                  <p class="issue-summary">Suggested fix: <%= link.suggested_fix %></p>
+                <% end %>
+              </details>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+      <%= render "admin/link_check_reports/form", edition: edition, button_text: "Check again" %>
+    </section>
+  <% else %>
+    <section class="alert alert-success">
+      <p><span class="glyphicon glyphicon-ok add-right-margin"></span> This edition contains no broken links.</p>
+      <%= render "admin/link_check_reports/form", edition: edition, button_text: "Check again" %>
+    </section>
+  <% end %>
+</div>

--- a/app/views/admin/link_check_reports/create.js.erb
+++ b/app/views/admin/link_check_reports/create.js.erb
@@ -1,0 +1,1 @@
+$('.broken-links-report').replaceWith('<%=escape_javascript render("admin/link_check_reports/link_check_report", report: @report, edition: @edition ) %>');

--- a/spec/controllers/link_check_reports_spec.rb
+++ b/spec/controllers/link_check_reports_spec.rb
@@ -38,6 +38,7 @@ describe LinkCheckReportsController, type: :controller do
     end
 
     before do
+      login_as_stub_user
       allow(TravelAdvicePublisher.link_checker_api).to receive(:create_batch).and_return(link_checker_api_response)
     end
 

--- a/spec/controllers/link_check_reports_spec.rb
+++ b/spec/controllers/link_check_reports_spec.rb
@@ -1,50 +1,45 @@
 require "spec_helper"
+require "gds_api/test_helpers/link_checker_api"
 
 describe LinkCheckReportsController, type: :controller do
+  include GdsApi::TestHelpers::LinkCheckerApi
+  include Rails.application.routes.url_helpers
+
   describe "#create" do
     let(:travel_advice_edition) do
       FactoryGirl.create(:travel_advice_edition,
-                         summary: "[link](http://www.example.com)[link_two](http://www.gov.com)")
-    end
-
-    let(:completed_at) { Time.now }
-
-    let(:link_checker_api_response) do
-      {
-        id: 1,
-        completed_at: nil,
-        status: "in_progress",
-        links: [
-          {
-            uri: "http://www.example.com",
-            status: "error",
-            checked: completed_at,
-            warnings: ["example check warnings"],
-            errors: ["example check errors"],
-            problem_summary: "example problem",
-            suggested_fix: "example fix"
-          },
-          {
-            uri: "http://www.gov.com",
-            status: "ok",
-            checked: completed_at,
-            warnings: [],
-            errors: [],
-            problem_summary: "",
-            suggested_fix: ""
-          }
-        ]
-      }
+                         summary: "[link](http://www.example.com)[link_two](http://www.gov.uk)")
     end
 
     before do
       login_as_stub_user
-      allow(TravelAdvicePublisher.link_checker_api).to receive(:create_batch).and_return(link_checker_api_response)
+      @stubbed_api_request = link_checker_api_create_batch(
+        uris: ["http://www.example.com", "http://www.gov.uk"],
+        id: 5,
+        webhook_uri: link_checker_api_callback_url(host: Plek.find("travel-advice-publisher")),
+        webhook_secret_token: Rails.application.secrets.link_checker_api_secret_token
+      )
     end
 
-    it "returns a created status" do
-      post :create, params: { link_reportable: { travel_advice_edition_id: travel_advice_edition.id } }
-      expect(response).to have_http_status(:created)
+    context "#create" do
+      it "should create a link report and redirect on a normal request" do
+        subject = post :create, params: { travel_advice_edition_id: travel_advice_edition.id }
+        travel_advice_edition.reload
+
+        expect(travel_advice_edition.link_check_reports.any?).to eq(true)
+        expect(subject).to redirect_to(edit_admin_edition_path(travel_advice_edition.id))
+      end
+
+      it "should create and render the template on AJAX" do
+        subject = post :create, params: { travel_advice_edition_id: travel_advice_edition.id }, xhr: true
+        travel_advice_edition.reload
+
+        expect(response.status).to eq(200)
+        expect(subject).to render_template(:create)
+
+        expect(travel_advice_edition.link_check_reports.any?).to eq(true)
+        expect(travel_advice_edition.latest_link_check_report.batch_id).to eq(5)
+      end
     end
   end
 end

--- a/spec/controllers/link_check_reports_spec.rb
+++ b/spec/controllers/link_check_reports_spec.rb
@@ -23,7 +23,7 @@ describe LinkCheckReportsController, type: :controller do
 
     context "#create" do
       it "should create a link report and redirect on a normal request" do
-        subject = post :create, params: { travel_advice_edition_id: travel_advice_edition.id }
+        subject = post :create, params: { edition_id: travel_advice_edition.id }
         travel_advice_edition.reload
 
         expect(travel_advice_edition.link_check_reports.any?).to eq(true)
@@ -31,7 +31,7 @@ describe LinkCheckReportsController, type: :controller do
       end
 
       it "should create and render the template on AJAX" do
-        subject = post :create, params: { travel_advice_edition_id: travel_advice_edition.id }, xhr: true
+        subject = post :create, params: { edition_id: travel_advice_edition.id }, xhr: true
         travel_advice_edition.reload
 
         expect(response.status).to eq(200)

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -41,11 +41,35 @@ FactoryGirl.define do
     transient do
       batch_id 1
       link_uris []
+      status "pending"
     end
 
     link_check_reports do
       [FactoryGirl.build(:link_check_report, :with_pending_links,
                                              batch_id: batch_id,
+                                             link_uris: link_uris,
+                                             status: status)]
+    end
+  end
+
+  factory :travel_advice_edition_with_broken_links, parent: :published_travel_advice_edition do
+    transient do
+      link_uris []
+    end
+
+    link_check_reports do
+      [FactoryGirl.build(:link_check_report, :with_broken_links,
+                                             link_uris: link_uris)]
+    end
+  end
+
+  factory :travel_advice_edition_with_caution_links, parent: :published_travel_advice_edition do
+    transient do
+      link_uris []
+    end
+
+    link_check_reports do
+      [FactoryGirl.build(:link_check_report, :with_caution_links,
                                              link_uris: link_uris)]
     end
   end
@@ -67,6 +91,26 @@ FactoryGirl.define do
 
       links do
         link_uris.map { |uri| FactoryGirl.build(:link, :pending, uri: uri) }
+      end
+    end
+
+    trait :with_broken_links do
+      transient do
+        link_uris []
+      end
+
+      links do
+        link_uris.map { |uri| FactoryGirl.build(:link, uri: uri, status: "broken") }
+      end
+    end
+
+    trait :with_caution_links do
+      transient do
+        link_uris []
+      end
+
+      links do
+        link_uris.map { |uri| FactoryGirl.build(:link, uri: uri, status: "caution") }
       end
     end
   end

--- a/spec/models/link_check_report_spec.rb
+++ b/spec/models/link_check_report_spec.rb
@@ -1,45 +1,92 @@
 require "spec_helper"
 
 describe LinkCheckReport, type: :model do
-  let(:attributes) do
-    {
-      links: [{ uri: "http://www.example.com", status: "error" }],
-      batch_id: 1,
-      status: "broken",
-      completed_at: Time.parse("2017-12-01")
-    }
-  end
-
-  subject(:link_check_report) { LinkCheckReport.new(attributes) }
-
-  context "all fields set" do
-    it { should be_valid }
-  end
-
-  it "should be valid without a completed at time" do
-    link_check_report.completed_at = nil
-    expect(link_check_report).to be_valid
-  end
-
-  it "should be invalid without links" do
-    attributes = {
-        links: [],
+  context "validations" do
+    let(:attributes) do
+      {
+        links: [{ uri: "http://www.example.com", status: "error" }],
         batch_id: 1,
         status: "broken",
         completed_at: Time.parse("2017-12-01")
       }
+    end
 
-    link_check_report = LinkCheckReport.new(attributes)
-    expect(link_check_report).not_to be_valid
+    subject(:link_check_report) { LinkCheckReport.new(attributes) }
+
+    context "all fields set" do
+      it { should be_valid }
+    end
+
+    it "should be valid without a completed at time" do
+      link_check_report.completed_at = nil
+      expect(link_check_report).to be_valid
+    end
+
+    it "should be invalid without links" do
+      attributes = {
+          links: [],
+          batch_id: 1,
+          status: "broken",
+          completed_at: Time.parse("2017-12-01")
+        }
+
+      link_check_report = LinkCheckReport.new(attributes)
+      expect(link_check_report).not_to be_valid
+    end
+
+    it "should be invalid without a batch id" do
+      link_check_report.batch_id = nil
+      expect(link_check_report).not_to be_valid
+    end
+
+    it "should be invalid without a status" do
+      link_check_report.status = nil
+      expect(link_check_report).not_to be_valid
+    end
   end
 
-  it "should be invalid without a batch id" do
-    link_check_report.batch_id = nil
-    expect(link_check_report).not_to be_valid
+  context "#completed?" do
+    it "should return true when completed" do
+      link_check_report = FactoryGirl.create(:travel_advice_edition_with_pending_link_checks,
+                                             link_uris: ["http://www.example.com", "http://www.gov.com"],
+                                             status: "completed").link_check_reports.first
+      expect(link_check_report.completed?).to eq true
+    end
+
+    it "should return false when not complete" do
+      link_check_report = FactoryGirl.create(:travel_advice_edition_with_pending_link_checks,
+                                             link_uris: ["http://www.example.com", "http://www.gov.com"]).link_check_reports.first
+      expect(link_check_report.completed?).to eq false
+    end
   end
 
-  it "should be invalid without a status" do
-    link_check_report.status = nil
-    expect(link_check_report).not_to be_valid
+  context "#in_progress?" do
+    it "should return true when still in progress" do
+      link_check_report = FactoryGirl.create(:travel_advice_edition_with_pending_link_checks,
+                                             link_uris: ["http://www.example.com", "http://www.gov.com"]).link_check_reports.first
+      expect(link_check_report.in_progress?).to eq true
+    end
+  end
+
+  context "#broken_links" do
+    it "should return an array of broken links" do
+      link_check_report = FactoryGirl.create(:travel_advice_edition_with_broken_links,
+                                             link_uris: ["http://www.example.com", "http://www.gov.com"]).link_check_reports.first
+
+      expect(link_check_report.broken_links.first.uri).to eq("http://www.example.com")
+      expect(link_check_report.broken_links.last.uri).to eq("http://www.gov.com")
+      expect(link_check_report.broken_links).to be_an_instance_of(Array)
+    end
+  end
+
+  context "#caution_links" do
+    it "should return an array of links with cautions" do
+      link_check_report = FactoryGirl.create(:travel_advice_edition_with_caution_links,
+                                             link_uris: ["http://www.example.com", "http://www.gov.com"]).link_check_reports.first
+
+      expect(link_check_report.caution_links.first.uri).to eq("http://www.example.com")
+      expect(link_check_report.caution_links.last.uri).to eq("http://www.gov.com")
+      expect(link_check_report.caution_links).to be_an_instance_of(Array)
+    end
   end
 end

--- a/spec/models/travel_advice_edition_spec.rb
+++ b/spec/models/travel_advice_edition_spec.rb
@@ -626,4 +626,19 @@ describe TravelAdviceEdition do
       end
     end
   end
+
+  context "latest_link_check_report" do
+    it "should be nil for no reports" do
+      edition = FactoryGirl.create(:published_travel_advice_edition)
+      expect(edition.latest_link_check_report).to eq(nil)
+    end
+
+    it "should return the last report created" do
+      edition = FactoryGirl.create(:published_travel_advice_edition)
+      edition.link_check_reports.create(FactoryGirl.attributes_for(:link_check_report))
+      latest_report = edition.link_check_reports.create(FactoryGirl.attributes_for(:link_check_report, batch_id: 2))
+
+      expect(edition.latest_link_check_report).to eq(latest_report)
+    end
+  end
 end


### PR DESCRIPTION
This PR adds the UI for the Link Checker onto the editions#edit view. This also displays the relevant information about links that have returned with a broken or caution status on the same page. 

![screen shot 2018-01-09 at 15 32 34](https://user-images.githubusercontent.com/8478978/34731023-f1737ef8-f558-11e7-954c-ed3c2a5f077c.png)

  