### PR TITLE
Assign emails as high priority

### DIFF
--- a/app/presenters/email_alert_presenter.rb
+++ b/app/presenters/email_alert_presenter.rb
@@ -23,6 +23,7 @@ class EmailAlertPresenter
       "public_updated_at" => public_updated_at,
       "publishing_app" => "travel-advice-publisher",
       "base_path" => base_path,
+      "priority" => "high",
     }
   end
 

--- a/spec/presenters/email_alert_presenter_spec.rb
+++ b/spec/presenters/email_alert_presenter_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe EmailAlertPresenter do
     expect(email_alert.compact.keys).to match_array(%w(
       title description change_note subject body tags links document_type
       email_document_supertype government_document_supertype content_id
-      public_updated_at publishing_app base_path
+      public_updated_at publishing_app base_path priority
     ))
   end
 end


### PR DESCRIPTION
This means that the emails will be sent with a higher priority than other kinds of emails.

Depends on https://github.com/alphagov/email-alert-api/pull/382

[Trello Card](https://trello.com/c/mHXNdskh/550-setup-delivery-priorities)