### PR TITLE
Publish email signup when edition first published

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -108,6 +108,7 @@ private
     if @edition.update_attributes(permitted_edition_attributes) && @edition.publish_as(current_user)
       notifier.put_content(@edition)
       notifier.patch_links(@edition)
+      notifier.email_signup(@edition) if @edition.previous_version.nil?
       notifier.publish(@edition)
       notifier.send_alert(@edition)
       notifier.enqueue

--- a/app/notifiers/publishing_api_notifier.rb
+++ b/app/notifiers/publishing_api_notifier.rb
@@ -9,6 +9,13 @@ class PublishingApiNotifier
     tasks << [:put_content, presenter.content_id, presenter.render_for_publishing_api]
   end
 
+  def email_signup(edition)
+    presenter = EmailAlertSignup::EditionPresenter.new(edition)
+
+    tasks << [:put_content, presenter.content_id, presenter.content_payload]
+    tasks << [:publish, presenter.content_id, presenter.update_type]
+  end
+
   def patch_links(edition)
     presenter = LinksPresenter.new(edition)
 

--- a/spec/requests/request_tracing_spec.rb
+++ b/spec/requests/request_tracing_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe "Request tracing", type: :request do
       "GOVUK-Request-Id" => govuk_request_id,
       "X-Govuk-Authenticated-User" => govuk_authenticated_user,
     }
-    expect(WebMock).to have_requested(:put, /publishing-api.*content/).with(headers: onward_headers)
+    expect(WebMock).to have_requested(:put, /publishing-api.*content/).with(headers: onward_headers).twice
     expect(WebMock).to have_requested(:patch, /publishing-api.*links/).with(headers: onward_headers)
-    expect(WebMock).to have_requested(:post, /publishing-api.*publish/).with(headers: onward_headers)
+    expect(WebMock).to have_requested(:post, /publishing-api.*publish/).with(headers: onward_headers).twice
     expect(WebMock).to have_requested(:post, /email-alert-api/).with(headers: onward_headers)
   end
 end


### PR DESCRIPTION
Automatically publish the signup page when the country gets it's first edition

https://trello.com/c/oom1LAQE/52-create-new-travel-advice-page-for-cook-islands-tokelau-and-niue