### PR TITLE
Retry on errors other than 409

### DIFF
--- a/app/workers/email_alert_api_worker.rb
+++ b/app/workers/email_alert_api_worker.rb
@@ -5,13 +5,8 @@ class EmailAlertApiWorker
     GdsApi::GovukHeaders.set_header(:govuk_request_id, params["request_id"])
 
     api.send_alert(payload) if send_alert?
-  rescue StandardError => e
-    message = "\n\n=== Failed request details ==="
-    message += "\n#{payload}"
-
-    GovukError.notify(
-      WorkerError.new(self, e, message)
-    )
+  rescue GdsApi::HTTPConflict
+    logger.info("email-alert-api returned 409 conflict for #{payload}")
   end
 
 private


### PR DESCRIPTION
The `EmailAlertApiWorker` was configured to swallow all errors, apparently to avoid sending duplicate emails. email-alert-api now handles duplicate requests and returns a 409 so we only need to swallow
this now. It should be safe to retry in other cases.