### PR TITLE
Don't send description with emails

### DIFF
--- a/app/presenters/email_alert_presenter.rb
+++ b/app/presenters/email_alert_presenter.rb
@@ -10,7 +10,7 @@ class EmailAlertPresenter
   def present
     {
       "title" => title,
-      "description" => description,
+      "description" => "",
       "change_note" => change_description,
       "subject" => subject,
       "body" => body,
@@ -77,10 +77,6 @@ private
 
   def change_description
     edition.change_description
-  end
-
-  def description
-    edition.summary
   end
 
   def formatted_published_at

--- a/spec/presenters/email_alert_presenter_spec.rb
+++ b/spec/presenters/email_alert_presenter_spec.rb
@@ -48,4 +48,8 @@ RSpec.describe EmailAlertPresenter do
       public_updated_at publishing_app base_path priority
     ))
   end
+
+  it "ensures the description is blank" do
+    expect(email_alert["description"]).to eq("")
+  end
 end


### PR DESCRIPTION
We've found these to be excessively long leading to emails that don't look right.

[Trello Card](https://trello.com/c/2MgWX34y/642-change-what-we-put-in-travel-advice-updates)