### PR TITLE
Fix tracking user needs

### DIFF
--- a/app/presenters/links_presenter.rb
+++ b/app/presenters/links_presenter.rb
@@ -6,7 +6,8 @@ class LinksPresenter
   def present
     {
       links: {
-        parent: [TravelAdvicePublisher::INDEX_CONTENT_ID]
+        parent: [TravelAdvicePublisher::INDEX_CONTENT_ID],
+        meets_user_needs: [TravelAdvicePublisher::NEED_CONTENT_ID]
       }
     }
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,7 +19,7 @@ module TravelAdvicePublisher
   mattr_accessor :link_checker_api
 
   # Maslow need ID for Travel Advice Publisher
-  NEED_ID = '101191'.freeze
+  NEED_CONTENT_ID = '5118d7b4-215d-45e6-bd20-15d7bc21314f'.freeze
 
   INDEX_CONTENT_ID = "08d48cdd-6b50-43ff-a53b-beab47f4aab0".freeze
   INDEX_EMAIL_SIGNUP_CONTENT_ID = "1aebfc97-7723-4cb6-82f4-434639efc185".freeze

--- a/lib/registerable_travel_advice_edition.rb
+++ b/lib/registerable_travel_advice_edition.rb
@@ -27,10 +27,6 @@ class RegisterableTravelAdviceEdition
     country.try(:content_id)
   end
 
-  def need_ids
-    [TravelAdvicePublisher::NEED_ID]
-  end
-
   def paths
     ["/#{slug}", "/#{slug}.atom", "/#{slug}/print"] + part_paths
   end

--- a/spec/lib/registerable_travel_advice_edition_spec.rb
+++ b/spec/lib/registerable_travel_advice_edition_spec.rb
@@ -42,10 +42,6 @@ describe RegisterableTravelAdviceEdition do
       expect(@registerable.title).to eq("Aruba travel advice")
     end
 
-    it "should return ['101191'] for the need_ids" do
-      expect(@registerable.need_ids).to eq(['101191'])
-    end
-
     context "paths" do
       it "should include /<slug>.atom" do
         expect(@registerable.paths).to include("/foreign-travel-advice/#{@edition.country_slug}.atom")

--- a/spec/presenters/links_presenter_spec.rb
+++ b/spec/presenters/links_presenter_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe LinksPresenter do
 
     it "returns travel advice breadcrumbs data" do
       expect(presented_data).to eq(links: {
-        parent: ["08d48cdd-6b50-43ff-a53b-beab47f4aab0"]
+        parent: ["08d48cdd-6b50-43ff-a53b-beab47f4aab0"],
+        meets_user_needs: ["5118d7b4-215d-45e6-bd20-15d7bc21314f"]
       })
     end
   end


### PR DESCRIPTION
It looks like this hasn't been a thing with the Publishing API so
far. Checking in the Publishing API, nothing published by Travel
Advice Publisher has any associated qneed_ids`.

Anyway, needs are tracked with the `meets_user_needs` link type now,
so convert the need id to the corresponding content id (by searching
in Maslow), and send that to the Publishing API.

This doesn't migrate the existing data, maybe that can be done later.