### PR TITLE
Add rake task to unpublish and redirect countries

### DIFF
--- a/docs/further-technical-information.md
+++ b/docs/further-technical-information.md
@@ -23,6 +23,13 @@ See [`lib/tasks/publishing_api.rake`](../lib/tasks/publishing_api.rake) for deta
 
 To maintain the history of a country when renaming you will need to perform a [migration](../db/migrate/20160916161059_rename_democratic_republic_of_congo.rb) on TravelAdviceEdition.
 
+### Removing a country
+
+If a country's foreign travel advice is being subsumed into another country's page:
+
+1. Remove the country from the [`lib/data/countries.yml`](../lib/data/countries.yml) file.
+2. Run the `publishing_api:unpublish_published_edition_and_email_signup_content_item['country_slug', 'new_country_slug']` rake task, providing the slug of the country being removed, and the slug of the country that it should be redirected to.
+
 ### Publishing API
 
 Travel advice content reaches the [content-store](https://github.com/alphagov/content-store) via the [publishing-api](https://github.com/alphagov/publishing-api), editorial work is batch-enqueued with Sidekiq for processing out of request.

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -12,6 +12,14 @@ namespace :publishing_api do
     api_v2.publish(presenter.content_id)
   end
 
+  desc "unpublish a published edition and email signup content item for a country and redirect"
+  task :unpublish_published_edition_and_email_signup_content_item, %i(country_slug new_country_slug) => :environment do |_task, args|
+    country = Country.find_by_slug(args[:country_slug])
+    alternative_path = "/foreign-travel-advice/#{args[:new_country_slug]}"
+    api_v2.unpublish(country.email_signup_content_id, type: "redirect", alternative_path: "#{alternative_path}/email-signup")
+    api_v2.unpublish(country.content_id, type: "redirect", alternative_path: alternative_path)
+  end
+
   desc "republish all published editions to publishing-api"
   task republish_editions: :environment do
     TravelAdviceEdition.published.each do |edition|


### PR DESCRIPTION
This commit adds a new rake task which will unpublish and redirect a country’s travel advice and email signup pages to another country’s travel advice page.

Trello: https://trello.com/c/RkqvdT4z/377-remove-american-samoa-travel-advice