### PR TITLE
Remove American Samoa

### DIFF
--- a/lib/data/countries.yml
+++ b/lib/data/countries.yml
@@ -11,10 +11,6 @@
   slug: algeria
   content_id: b5c8e64b-3461-4447-9144-1588e4a84fe6
   email_signup_content_id: 19394f01-f611-49da-ab01-09798923b60f
-- name: American Samoa
-  slug: american-samoa
-  content_id: 3b54054f-c22a-4e3a-8c10-19d0667b5718
-  email_signup_content_id: 4f447f20-ab0a-46ae-be1e-8ee07a205134
 - name: Andorra
   slug: andorra
   content_id: 196a0c49-e844-4246-ab7c-a5c4197dfdad

--- a/spec/features/country_index_spec.rb
+++ b/spec/features/country_index_spec.rb
@@ -29,7 +29,6 @@ feature "Country Index" do
       ["Afghanistan",         "advice published"],
       ["Albania",             "no advice published"],
       ["Algeria",             "advice published"],
-      ["American Samoa",      "no advice published"],
       ["Andorra",             "no advice published"],
       ["Angola",              "no advice published"],
       ["Anguilla",            "no advice published"],

--- a/spec/fixtures/data/countries.yml
+++ b/spec/fixtures/data/countries.yml
@@ -11,10 +11,6 @@
   slug: algeria
   content_id: b5c8e64b-3461-4447-9144-1588e4a84fe6
   email_signup_content_id: 19394f01-f611-49da-ab01-09798923b60f
-- name: American Samoa
-  slug: american-samoa
-  content_id: 3b54054f-c22a-4e3a-8c10-19d0667b5718
-  email_signup_content_id: 4f447f20-ab0a-46ae-be1e-8ee07a205134
 - name: Andorra
   slug: andorra
   content_id: 196a0c49-e844-4246-ab7c-a5c4197dfdad

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Country do
   describe "Country.all" do
     it "should return a list of Countries" do
-      expect(Country.all.size).to eq(14)
+      expect(Country.all.size).to eq(13)
       expect(Country.all.first.name).to eq("Afghanistan")
       expect(Country.all.first.slug).to eq("afghanistan")
       expect(Country.all.find { |c| c.slug == "argentina" }.name).to eq("Argentina")


### PR DESCRIPTION
This commit removes American Samoa from the list of countries for foreign travel advice. Travel advice for American Samoa will now be included in USA travel advice.

- [ ] Merge and deploy this PR
- [ ] Run `publishing_api:unpublish_published_edition_and_email_signup_content_item['american-samoa','usa']` rake task

Trello: https://trello.com/c/RkqvdT4z/377-remove-american-samoa-travel-advice