### PR TITLE
Fix and create locations

### DIFF
--- a/db/migrate/20180821131601_update_cook_islands.rb
+++ b/db/migrate/20180821131601_update_cook_islands.rb
@@ -1,0 +1,13 @@
+class UpdateCookIslands < Mongoid::Migration
+  def self.up
+    TravelAdviceEdition
+      .where(country_slug: "cook-islands-tokelau-and-nieu")
+      .update_all(country_slug: "cook-islands-tokelau-and-niue")
+  end
+
+  def self.down
+    TravelAdviceEdition
+      .where(country_slug: "cook-islands-tokelau-and-niue")
+      .update_all(country_slug: "cook-islands-tokelau-and-nieu")
+  end
+end

--- a/lib/data/countries.yml
+++ b/lib/data/countries.yml
@@ -767,6 +767,10 @@
   slug: st-lucia
   content_id: 5a9e154c-e1dc-4fde-8182-58c5b6e69efa
   email_signup_content_id: c7113009-92a9-4a6f-8641-b00001588af1
+- name: "St Martin and St Barthélemy"
+  slug: st-martin-and-st-barthelemy
+  content_id: 98c0a9e6-54b0-4c67-8007-43bde256e8ad
+  email_signup_content_id: c41428d3-bc45-4d3c-b07f-049fd72a35a5
 - name: St Maarten
   slug: st-maarten
   content_id: f752255c-de89-4b61-af7a-6233dd44a58a

--- a/lib/data/countries.yml
+++ b/lib/data/countries.yml
@@ -191,8 +191,8 @@
   slug: congo
   content_id: 438a3cd3-5936-462d-b7ed-fff0ea485af1
   email_signup_content_id: 6abaef77-d1f6-4ad8-b955-d96196f66039
-- name: Cook Islands, Tokelau and Nieu
-  slug: cook-islands-tokelau-and-nieu
+- name: Cook Islands, Tokelau and Niue
+  slug: cook-islands-tokelau-and-niue
   content_id: f961f58b-3a4e-439a-b820-7ddab77e3758
   email_signup_content_id: 76e992a5-db34-4c3c-afa6-6ef78bbb611a
 - name: Costa Rica


### PR DESCRIPTION
- Rename Cook Islands to fix typo
- Add "St Martin and St Barthélemy"

Do not merge just yet as I have some questions about the existing country "St Maarten".

https://trello.com/c/X8jOSots/418-create-a-travel-advice-page-for-st-martin-and-st-barth%C3%A9lemy
https://trello.com/c/YSRI7bjs/417-amend-title-of-travel-advice-page-for-cook-islands-tokelau-and-niue