### PR TITLE
Add recently published healthcheck endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,8 +27,10 @@ gem 'slimmer', '~> 13.0'
 
 group :development, :test do
   gem 'govuk-lint', '~> 3.8'
+  gem 'jasmine', '~> 3.2'
   gem 'pry-byebug'
   gem 'pry-rails'
+  gem 'rspec-rails', '~> 3.8'
 end
 
 group :test do
@@ -38,9 +40,7 @@ group :test do
   gem 'factory_bot_rails', '~> 4.11'
   gem 'govuk_test'
   gem 'govuk-content-schema-test-helpers', '~> 1.6'
-  gem 'jasmine', '~> 3.2'
   gem 'rails-controller-testing'
-  gem 'rspec-rails', '~> 3.8'
   gem 'simplecov-rcov', '~> 0.2'
   gem 'test-unit'
   gem 'timecop'

--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -1,0 +1,32 @@
+class HealthcheckController < ApplicationController
+  # These are inherited from ApplicationController but are not valid here
+  skip_before_action :authenticate_user!
+  skip_before_action :set_authenticated_user_header
+
+  # Renders a JSON array of all travel advice editions published between
+  # 1 hour and 2 days ago. This is used by email-alert-monitoring to ensure
+  # that all published editions have been sent to publishing-api and triggered
+  # an email alert.
+  def recently_published_editions
+    editions = editions_published_between_2_days_and_1_hour_ago.each.map do |edition|
+      {
+        title: edition.title,
+        published_at: edition.published_at
+      }
+    end
+
+    render json: { editions: editions }
+  end
+
+private
+
+  def editions_published_between_2_days_and_1_hour_ago
+    TravelAdviceEdition.published.where(
+      :published_at.gte => 2.days.ago
+    ).where(
+      :published_at.lte => 1.hour.ago
+    ).order_by(
+      published_at: :desc
+    )
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,4 +23,6 @@ Rails.application.routes.draw do
   get "/healthcheck", to: GovukHealthcheck.rack_response(
     GovukHealthcheck::SidekiqRedis,
   )
+
+  get "/healthcheck/recently-published-editions" => "healthcheck#recently_published_editions"
 end

--- a/spec/controllers/healthcheck_spec.rb
+++ b/spec/controllers/healthcheck_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+
+describe HealthcheckController, type: :controller do
+  include Rails.application.routes.url_helpers
+
+  describe "#recently_published_editions" do
+    let(:travel_advice_edition) do
+      FactoryBot.create(:travel_advice_edition, published_at: 2.hours.ago)
+    end
+
+    before do
+      controller.stub(:editions_published_between_2_days_and_1_hour_ago) do
+        [travel_advice_edition]
+      end
+    end
+
+    it "should return the title and published_at of recently published editions" do
+      get :recently_published_editions
+      expected_response = {
+        editions: [
+          {
+            title: travel_advice_edition.title,
+            published_at: travel_advice_edition.published_at
+          }
+        ]
+      }.to_json
+      # We compare the JSON-encoded responses here since JSON-encoding the expected
+      # response also transforms the published_at date/time to the correct JSON
+      # format.
+      expect(response.body).to eq(expected_response)
+    end
+  end
+end


### PR DESCRIPTION
This commit adds a new endpoint at `/healthcheck/recently-published-editions` which returns an array of the titles and published times of travel advice published between 2 days and 1 hour ago. This endpoint will be used by email-alert-monitoring to ensure published travel advice has been sent to publishing-api and triggered an email alert.

Trello: https://trello.com/c/GFbBCilR/421-add-upstream-alerting-for-travel-advice-that-has-not-been-sent-to-publishing-api