### PR TITLE
Send change_note with change_description

### DIFF
--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -33,6 +33,7 @@ class EditionPresenter
       "public_updated_at" => public_updated_at.iso8601,
       "update_type" => update_type,
       "details" => details,
+      "change_note" => change_description,
     }
   end
 

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -106,6 +106,7 @@ describe EditionPresenter do
           { "path" => "/foreign-travel-advice/aruba/terrorism", "type" => "exact" },
           { "path" => "/foreign-travel-advice/aruba/safety-and-security", "type" => "exact" },
         ],
+        "change_note" => "Stuff changed",
         "details" => {
           "summary" => [
             { "content_type" => "text/govspeak", "content" => "### Summary" },
@@ -161,6 +162,7 @@ describe EditionPresenter do
         edition.change_description = nil
 
         expect(presented_data["details"]["change_description"]).to eq("Stuff previously changed")
+        expect(presented_data["change_note"]).to eq("Stuff previously changed")
       end
     end
 


### PR DESCRIPTION
This will make sure that history of travel advice documents is correctly stored in the Publishing API and we need this to support sending emails via email-alert-service.