### PR TITLE
Add bearer tokens for link-checker-api authentication

### DIFF
--- a/config/initializers/link_checker_api.rb
+++ b/config/initializers/link_checker_api.rb
@@ -2,5 +2,6 @@ require "gds_api/link_checker_api"
 require "plek"
 
 TravelAdvicePublisher.link_checker_api = GdsApi::LinkCheckerApi.new(
-  Plek.find("link-checker-api")
+  Plek.find("link-checker-api"),
+  bearer_token: ENV['LINK_CHECKER_API_BEARER_TOKEN'],
 )


### PR DESCRIPTION
Trello: https://trello.com/c/2IdzHdtp

Related to: 
* https://github.com/alphagov/govuk-puppet/pull/8488
* https://github.com/alphagov/link-checker-api/pull/227

Passes the bearer token needed to authenticate with link-checker-api using signon.