### PR TITLE
Add rake task to republish email signup for a country

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -104,5 +104,19 @@ namespace :publishing_api do
 
       puts
     end
+
+    desc "republish email signup content item for a country"
+    task :country_edition, [:country_slug] => :environment do |_task, args|
+      begin
+        edition = TravelAdviceEdition.published.find_by(country_slug: args[:country_slug])
+        presenter = EmailAlertSignup::EditionPresenter.new(edition)
+
+        api_v2.put_content(presenter.content_id, presenter.content_payload)
+        api_v2.publish(presenter.content_id, presenter.update_type)
+        puts "SUCCEED: The country #{args[:country_slug]} has been republished"
+      rescue Mongoid::Errors::DocumentNotFound
+        puts "ERROR: No published country found for '#{args[:country_slug]}'"
+      end
+    end
   end
 end


### PR DESCRIPTION
We currently have a rake task that republishes email signup content
items for all countries `publishing_api:republish_email_signups:editions`
This isn't necessary to run if only one country's email signup needs to be 
updated.

Part of https://trello.com/c/ySMq2bcm/786-slug-and-tag-changes-country-name-change-macedonia-to-north-macedonia