### PR TITLE
Update `docs/further-technical-information.md`

### DIFF
--- a/docs/further-technical-information.md
+++ b/docs/further-technical-information.md
@@ -27,8 +27,8 @@ To maintain the history of a country when renaming you will need to perform a [m
 
 If a country's foreign travel advice is being subsumed into another country's page:
 
+1. Run the `publishing_api:unpublish_published_edition_and_email_signup_content_item['country_slug', 'new_country_slug']` rake task, providing the slug of the country being removed, and the slug of the country that it should be redirected to.
 1. Remove the country from the [`lib/data/countries.yml`](../lib/data/countries.yml) file.
-2. Run the `publishing_api:unpublish_published_edition_and_email_signup_content_item['country_slug', 'new_country_slug']` rake task, providing the slug of the country being removed, and the slug of the country that it should be redirected to.
 
 ### Publishing API
 


### PR DESCRIPTION
If we run this rake task after removing the country from the
`lib/data/countries.yml` file, it will fail since it can't instantiate
a Country object for that country.

Read this only if you need/want more context:
When we run `rake 
publishing_api:unpublish_published_edition_and_email_signup_content_item['american-samoa','usa']`
this rake task[1] calls `Country.find_by_slug('american-samoa')`. What
this does is load all the 228 countries that the UK recognises[2], that
can be found in this file[3], instantiate a `Country` object for each
one of them[4] and then find the one that has the `slug` we passed as an
argument to the rake task[5], in our case `american-samoa`. We finally
call `email_signup_content_id` on this found country[6]. At this point
we get `NoMethodError: undefined method 'email_signup_content_id' for 
nil:NilClass`
because country is `nil`, no Country object was found with the slug
`american-samoa`. This is because American Samoa is not present in the
countries file[3]. American Samoa is an Unincorporated territory of the
United States[7], not technically a country or sovereign state (if I
understood the wiki page correctly), therefore it's not present in the
countries file[3], as all the other ones in that list[7].

1: 
https://github.com/alphagov/travel-advice-publisher/blob/master/lib/tasks/publishing_api.rake#L15-L21
2: 
https://github.com/alphagov/travel-advice-publisher/blob/master/app/models/country.rb#L51-L57
3: 
https://github.com/alphagov/travel-advice-publisher/blob/master/lib/data/countries.yml
4: 
https://github.com/alphagov/travel-advice-publisher/blob/master/app/models/country.rb#L43-L45
5: 
https://github.com/alphagov/travel-advice-publisher/blob/master/app/models/country.rb#L47-L49
6: 
https://github.com/alphagov/travel-advice-publisher/blob/master/lib/tasks/publishing_api.rake#L19
7: 
https://en.wikipedia.org/wiki/Unincorporated_territories_of_the_United_States#List_of_unincorporated_territories