### PR TITLE
Use GdsApi service methods

### DIFF
--- a/app/models/travel_advice_edition.rb
+++ b/app/models/travel_advice_edition.rb
@@ -215,7 +215,7 @@ private
 
       define_method(field) do
         unless self.send("#{field}_id").blank?
-          @attachments[field] ||= TravelAdvicePublisher.asset_api.asset(self.send("#{field}_id"))
+          @attachments[field] ||= GdsApi.asset_manager.asset(self.send("#{field}_id"))
         end
       end
 
@@ -234,7 +234,7 @@ private
 
       define_method("upload_#{field}") do
         begin
-          response = TravelAdvicePublisher.asset_api.create_asset(file: instance_variable_get("@#{field}_file"))
+          response = GdsApi.asset_manager.create_asset(file: instance_variable_get("@#{field}_file"))
           self.send("#{field}_id=", response["id"].match(/\/([^\/]+)\z/) { |m| m[1] })
         rescue GdsApi::BaseError
           errors.add("#{field}_id".to_sym, "could not be uploaded")

--- a/app/notifiers/email_alert_api_notifier.rb
+++ b/app/notifiers/email_alert_api_notifier.rb
@@ -6,7 +6,7 @@ module EmailAlertApiNotifier
       return unless send_alert?(edition)
 
       payload = EmailAlertPresenter.present(edition)
-      api.send_alert(payload)
+      GdsApi.email_alert_api.send_alert(payload)
     end
 
   private
@@ -15,10 +15,6 @@ module EmailAlertApiNotifier
       Rails.application.config.send_email_alerts &&
         edition.state == "published" &&
         !edition.minor_update
-    end
-
-    def api
-      TravelAdvicePublisher.email_alert_api
     end
   end
 end

--- a/app/services/link_check_report_creator.rb
+++ b/app/services/link_check_report_creator.rb
@@ -38,7 +38,7 @@ private
   def call_link_checker_api
     callback = link_checker_api_callback_url(host: CALLBACK_HOST)
 
-    TravelAdvicePublisher.link_checker_api.create_batch(
+    GdsApi.link_checker_api.create_batch(
       uris,
       webhook_uri: callback,
       webhook_secret_token: Rails.application.secrets.link_checker_api_secret_token

--- a/app/workers/email_alert_api_worker.rb
+++ b/app/workers/email_alert_api_worker.rb
@@ -2,16 +2,12 @@ class EmailAlertApiWorker
   include Sidekiq::Worker
 
   def perform(payload, params = {})
-    api.send_alert(payload) if send_alert?
+    GdsApi.email_alert_api.send_alert(payload) if send_alert?
   rescue GdsApi::HTTPConflict
     logger.info("email-alert-api returned 409 conflict for #{payload}")
   end
 
 private
-
-  def api
-    TravelAdvicePublisher.email_alert_api
-  end
 
   def send_alert?
     Rails.application.config.send_email_alerts

--- a/app/workers/publishing_api_worker.rb
+++ b/app/workers/publishing_api_worker.rb
@@ -9,7 +9,7 @@ class PublishingApiWorker
         if endpoint == "send_alert"
           EmailAlertApiWorker.perform_in(CACHE_EXPIRES_IN, payload)
         else
-          api.public_send(endpoint, content_id, payload)
+          GdsApi.publishing_api_v2.public_send(endpoint, content_id, payload)
         end
       rescue StandardError => e
         raise_helpful_error(e, jobs, endpoint, content_id, payload)
@@ -20,10 +20,6 @@ class PublishingApiWorker
 private
 
   CACHE_EXPIRES_IN = 10.seconds
-
-  def api
-    TravelAdvicePublisher.publishing_api_v2
-  end
 
   def raise_helpful_error(e, jobs, endpoint, content_id, payload)
     message = "\n\n=== Job details ==="

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,7 +13,6 @@ require "sprockets/railtie"
 Bundler.require(*Rails.groups)
 
 module TravelAdvicePublisher
-  mattr_accessor :publishing_api_v2
   mattr_accessor :email_alert_api
 
   # Maslow need ID for Travel Advice Publisher

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,7 +15,6 @@ Bundler.require(*Rails.groups)
 module TravelAdvicePublisher
   mattr_accessor :publishing_api_v2
   mattr_accessor :email_alert_api
-  mattr_accessor :link_checker_api
 
   # Maslow need ID for Travel Advice Publisher
   NEED_CONTENT_ID = '5118d7b4-215d-45e6-bd20-15d7bc21314f'.freeze

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,7 +13,6 @@ require "sprockets/railtie"
 Bundler.require(*Rails.groups)
 
 module TravelAdvicePublisher
-  mattr_accessor :asset_api
   mattr_accessor :publishing_api_v2
   mattr_accessor :email_alert_api
   mattr_accessor :link_checker_api

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,8 +13,6 @@ require "sprockets/railtie"
 Bundler.require(*Rails.groups)
 
 module TravelAdvicePublisher
-  mattr_accessor :email_alert_api
-
   # Maslow need ID for Travel Advice Publisher
   NEED_CONTENT_ID = '5118d7b4-215d-45e6-bd20-15d7bc21314f'.freeze
 

--- a/config/initializers/asset_manager.rb
+++ b/config/initializers/asset_manager.rb
@@ -1,9 +1,0 @@
-# This file is overwritten on deploy
-
-require 'gds_api/asset_manager'
-require 'plek'
-
-TravelAdvicePublisher.asset_api = GdsApi::AssetManager.new(
-  Plek.current.find('asset-manager'),
-  bearer_token: ENV.fetch("ASSET_MANAGER_BEARER_TOKEN", "12345678")
-)

--- a/config/initializers/email_alert_api.rb
+++ b/config/initializers/email_alert_api.rb
@@ -1,7 +1,0 @@
-require "gds_api/email_alert_api"
-require "plek"
-
-TravelAdvicePublisher.email_alert_api = GdsApi::EmailAlertApi.new(
-  Plek.current.find("email-alert-api"),
-  bearer_token: ENV.fetch("EMAIL_ALERT_API_BEARER_TOKEN", "bearer_token")
-)

--- a/config/initializers/link_checker_api.rb
+++ b/config/initializers/link_checker_api.rb
@@ -1,7 +1,0 @@
-require "gds_api/link_checker_api"
-require "plek"
-
-TravelAdvicePublisher.link_checker_api = GdsApi::LinkCheckerApi.new(
-  Plek.find("link-checker-api"),
-  bearer_token: ENV['LINK_CHECKER_API_BEARER_TOKEN'],
-)

--- a/config/initializers/publishing_api.rb
+++ b/config/initializers/publishing_api.rb
@@ -1,7 +1,0 @@
-require 'gds_api/publishing_api_v2'
-require 'plek'
-
-TravelAdvicePublisher.publishing_api_v2 = GdsApi::PublishingApiV2.new(
-  Plek.current.find('publishing-api'),
-  bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
-)

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,6 +1,6 @@
 namespace :publishing_api do
   def api_v2
-    TravelAdvicePublisher.publishing_api_v2
+    GdsApi.publishing_api_v2
   end
 
   desc "send index content-item to publishing-api"

--- a/spec/features/edition_edit_spec.rb
+++ b/spec/features/edition_edit_spec.rb
@@ -9,6 +9,9 @@ feature "Edit Edition page", js: true do
     Sidekiq::Testing.fake!
   end
 
+  let(:asset_manager) { double }
+  before { allow(GdsApi).to receive(:asset_manager).and_return(asset_manager) }
+
   def assert_details_contains(content_id, key, expected_value)
     assert_publishing_api_put_content(content_id, ->(response) {
       payload = JSON.parse(response.body)
@@ -536,10 +539,10 @@ feature "Edit Edition page", js: true do
       "content_type" => "image/jpeg",
     }
 
-    expect(TravelAdvicePublisher.asset_api).to receive(:create_asset).and_return(asset_one)
+    expect(asset_manager).to receive(:create_asset).and_return(asset_one)
 
-    allow(TravelAdvicePublisher.asset_api).to receive(:asset).with("an_image_id").and_return(asset_one)
-    allow(TravelAdvicePublisher.asset_api).to receive(:asset).with("another_image_id").and_return(asset_two)
+    allow(asset_manager).to receive(:asset).with("an_image_id").and_return(asset_one)
+    allow(asset_manager).to receive(:asset).with("another_image_id").and_return(asset_two)
 
     visit "/admin/editions/#{@edition.to_param}/edit"
 
@@ -569,7 +572,7 @@ feature "Edit Edition page", js: true do
       "content_type" => "image/jpeg")
 
     # replace image
-    expect(TravelAdvicePublisher.asset_api).to receive(:create_asset).and_return(asset_two)
+    expect(asset_manager).to receive(:create_asset).and_return(asset_two)
 
     attach_file("Upload a new map image", file_two.path)
 
@@ -618,10 +621,10 @@ feature "Edit Edition page", js: true do
       "content_type" => "application/pdf",
     }
 
-    expect(TravelAdvicePublisher.asset_api).to receive(:create_asset).and_return(asset_one)
+    expect(asset_manager).to receive(:create_asset).and_return(asset_one)
 
-    allow(TravelAdvicePublisher.asset_api).to receive(:asset).with("a_document_id").and_return(asset_one)
-    allow(TravelAdvicePublisher.asset_api).to receive(:asset).with("another_document_id").and_return(asset_two)
+    allow(asset_manager).to receive(:asset).with("a_document_id").and_return(asset_one)
+    allow(asset_manager).to receive(:asset).with("another_document_id").and_return(asset_two)
 
     visit "/admin/editions/#{@edition.to_param}/edit"
 
@@ -651,7 +654,7 @@ feature "Edit Edition page", js: true do
       "content_type" => "application/pdf")
 
     # replace document
-    expect(TravelAdvicePublisher.asset_api).to receive(:create_asset).and_return(asset_two)
+    expect(asset_manager).to receive(:create_asset).and_return(asset_two)
 
     attach_file("Upload a new PDF", file_two.path)
 

--- a/spec/services/link_check_report_creator_spec.rb
+++ b/spec/services/link_check_report_creator_spec.rb
@@ -1,9 +1,6 @@
-require "spec_helper"
-
 RSpec.describe LinkCheckReportCreator do
   let(:travel_advice_edition) do
-    FactoryBot.create(:travel_advice_edition,
-                       summary: "[link](http://www.example.com)[link_two](http://www.gov.com)")
+    create(:travel_advice_edition, summary: "[link](http://www.example.com)[link_two](http://www.gov.com)")
   end
 
   let(:completed_at) { Time.now }
@@ -37,14 +34,16 @@ RSpec.describe LinkCheckReportCreator do
   end
 
   let(:link_check_report) do
-    FactoryBot.create(:travel_advice_edition_with_pending_link_checks,
-                       batch_id: 1,
-                       link_uris: ['http://www.example.com', 'http://www.gov.com']).link_check_reports.first
+    create(:travel_advice_edition_with_pending_link_checks,
+           batch_id: 1, link_uris: ['http://www.example.com', 'http://www.gov.com']).link_check_reports.first
   end
 
+  let(:link_checker_api) { double }
+
   before do
-    allow(TravelAdvicePublisher.link_checker_api).to receive(:create_batch).and_return(link_checker_api_response)
+    allow(link_checker_api).to receive(:create_batch).and_return(link_checker_api_response)
     allow(LinkCheckReport).to receive(:new).and_return(link_check_report)
+    allow(GdsApi).to receive(:link_checker_api).and_return(link_checker_api)
   end
 
   subject do
@@ -52,11 +51,10 @@ RSpec.describe LinkCheckReportCreator do
   end
 
   it 'should call the link checker api with a callback url and secret token' do
-    expect(TravelAdvicePublisher.link_checker_api).to receive(:create_batch)
+    expect(link_checker_api).to receive(:create_batch)
 
     subject.call
   end
-
 
   context "when the link checker api is called" do
     it "sets link check api attributes on report" do

--- a/spec/workers/email_alert_api_worker_spec.rb
+++ b/spec/workers/email_alert_api_worker_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe EmailAlertApiWorker, :perform do
     end
 
     it "does not send an alert" do
-      expect(TravelAdvicePublisher.email_alert_api).not_to receive(:send_alert)
+      expect(GdsApi.email_alert_api).not_to receive(:send_alert)
       described_class.new.perform(payload)
     end
   end


### PR DESCRIPTION
gds-api-adapters provides [a common set of service instances](https://github.com/alphagov/gds-api-adapters/blob/master/lib/gds_api.rb) pre-configured with the bearer token from the environment which means we don't need to do the initialisation ourselves in the app.

[Trello Card](https://trello.com/c/YUxGB4tl/980-fix-security-vulnerability-in-travel-advice-publisher)