### PR TITLE
Simplify tests

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,3 @@
---colour --format=d
+--colour
+--format=d
+--require spec_helper

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,7 +46,7 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
     ast (2.4.0)
-    autoprefixer-rails (9.5.0)
+    autoprefixer-rails (9.5.1.1)
       execjs
     aws-xray-sdk (0.10.2)
       oj (~> 3.0)
@@ -55,8 +55,8 @@ GEM
       sassc (>= 2.0.0)
     bson (4.4.2)
     builder (3.2.3)
-    byebug (11.0.0)
-    capybara (3.18.0)
+    byebug (11.0.1)
+    capybara (3.19.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -97,7 +97,7 @@ GEM
       actionpack (>= 3.2.13)
     formtastic-bootstrap (3.1.1)
       formtastic (>= 3.0)
-    gds-api-adapters (59.2.0)
+    gds-api-adapters (59.2.1)
       addressable
       link_header
       null_logger
@@ -135,13 +135,13 @@ GEM
       jquery-rails (~> 4.3.1)
       plek (>= 2.1.0)
       rails (>= 3.2.0)
-    govuk_app_config (1.16.0)
+    govuk_app_config (1.16.1)
       aws-xray-sdk (~> 0.10.0)
       logstasher (~> 1.2.2)
       sentry-raven (~> 2.7.1)
       statsd-ruby (~> 1.4.0)
       unicorn (~> 5.4.0)
-    govuk_frontend_toolkit (8.1.0)
+    govuk_frontend_toolkit (8.2.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
     govuk_publishing_components (16.16.0)
@@ -166,7 +166,7 @@ GEM
       puma
       selenium-webdriver
       webdrivers
-    hashdiff (0.3.7)
+    hashdiff (0.3.9)
     hashie (3.6.0)
     htmlentities (4.3.4)
     http-cookie (1.0.3)
@@ -184,8 +184,8 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.1.0)
-    json-schema (2.8.0)
+    json (2.2.0)
+    json-schema (2.8.1)
       addressable (>= 2.4)
     jwt (2.1.0)
     kgio (2.11.2)
@@ -325,7 +325,7 @@ GEM
       rspec-mocks (~> 3.8.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.2)
+    rspec-expectations (3.8.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-mocks (3.8.0)
@@ -351,7 +351,7 @@ GEM
       rubocop (>= 0.60.0)
     ruby-progressbar (1.10.0)
     rubyzip (1.2.2)
-    safe_yaml (1.0.4)
+    safe_yaml (1.0.5)
     sanitize (5.0.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.8.0)
@@ -373,7 +373,7 @@ GEM
     scss_lint (0.58.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5, >= 3.5.5)
-    selenium-webdriver (3.142.0)
+    selenium-webdriver (3.142.1)
       childprocess (>= 0.5, < 2.0)
       rubyzip (~> 1.2, >= 1.2.2)
     sentry-raven (2.7.4)
@@ -410,14 +410,14 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     state_machines (0.5.0)
-    state_machines-activemodel (0.5.1)
+    state_machines-activemodel (0.6.0)
       activemodel (>= 4.1, < 6.0)
       state_machines (>= 0.5.0)
     state_machines-mongoid (0.2.0)
       mongoid (>= 4.0.0)
       state_machines-activemodel (>= 0.5.0)
     statsd-ruby (1.4.0)
-    test-unit (3.3.2)
+    test-unit (3.3.3)
       power_assert
     thor (0.20.3)
     thread_safe (0.3.6)
@@ -438,7 +438,7 @@ GEM
       rack (>= 2.0.6)
     warden-oauth2 (0.0.1)
       warden
-    webdrivers (3.8.0)
+    webdrivers (3.9.1)
       nokogiri (~> 1.6)
       rubyzip (~> 1.0)
       selenium-webdriver (~> 3.0)
@@ -493,4 +493,4 @@ DEPENDENCIES
   webmock (~> 3.5)
 
 BUNDLED WITH
-   1.16.2
+   1.17.2

--- a/spec/controllers/admin/countries_controller_spec.rb
+++ b/spec/controllers/admin/countries_controller_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Admin::CountriesController do
   before do
     login_as_stub_user

--- a/spec/controllers/admin/editions_controller_spec.rb
+++ b/spec/controllers/admin/editions_controller_spec.rb
@@ -1,6 +1,3 @@
-require 'spec_helper'
-require "sidekiq/testing"
-
 describe Admin::EditionsController do
   include GdsApi::TestHelpers::PublishingApiV2
   render_views

--- a/spec/controllers/admin/editions_controller_spec.rb
+++ b/spec/controllers/admin/editions_controller_spec.rb
@@ -55,7 +55,7 @@ describe Admin::EditionsController do
 
     context "cloning an existing edition" do
       before do
-        @published = FactoryBot.create(:published_travel_advice_edition, country_slug: @country.slug, version_number: 17)
+        @published = create(:published_travel_advice_edition, country_slug: @country.slug, version_number: 17)
       end
 
       it "should build out a clone of the provided edition" do
@@ -74,14 +74,14 @@ describe Admin::EditionsController do
 
     describe "GET to destroy" do
       it "should delete the latest draft edition" do
-        edition = FactoryBot.create(:draft_travel_advice_edition, country_slug: 'aruba')
+        edition = create(:draft_travel_advice_edition, country_slug: 'aruba')
         allow_any_instance_of(TravelAdviceEdition).to receive(:destroy).and_return(true)
         get :destroy, params: { id: edition.id }
         expect(response).to redirect_to(admin_country_path('aruba') + "?alert=Edition+deleted");
       end
 
       it "wont let a published edition be deleted" do
-        edition = FactoryBot.create(:published_travel_advice_edition, country_slug: 'aruba')
+        edition = create(:published_travel_advice_edition, country_slug: 'aruba')
         expect_any_instance_of(TravelAdviceEdition).not_to receive(:destroy)
 
         get :destroy, params: { id: edition.id }
@@ -89,7 +89,7 @@ describe Admin::EditionsController do
       end
 
       it "wont let an archived edition be deleted" do
-        edition = FactoryBot.create(:archived_travel_advice_edition, country_slug: 'aruba')
+        edition = create(:archived_travel_advice_edition, country_slug: 'aruba')
         expect_any_instance_of(TravelAdviceEdition).not_to receive(:destroy)
 
         get :destroy, params: { id: edition.id }
@@ -100,7 +100,7 @@ describe Admin::EditionsController do
   describe "edit, update" do
     before do
       login_as_stub_user
-      @edition = FactoryBot.create(:travel_advice_edition, country_slug: 'aruba')
+      @edition = create(:travel_advice_edition, country_slug: 'aruba')
       @country = Country.find_by_slug('aruba')
     end
 
@@ -199,7 +199,7 @@ describe Admin::EditionsController do
   end
 
   describe "workflow" do
-    let(:draft) { FactoryBot.create(:draft_travel_advice_edition, country_slug: 'aruba') }
+    let(:draft) { create(:draft_travel_advice_edition, country_slug: 'aruba') }
     before do
       login_as_stub_user
     end
@@ -249,7 +249,7 @@ describe Admin::EditionsController do
 
       context "when previous edition exist for the country" do
         before do
-          FactoryBot.create(:published_travel_advice_edition, country_slug: 'aruba')
+          create(:published_travel_advice_edition, country_slug: 'aruba')
           draft.update_attributes(version_number: 2)
         end
 
@@ -273,7 +273,7 @@ describe Admin::EditionsController do
   describe "historical_edition" do
     before do
       login_as_stub_user
-      @edition = FactoryBot.create(:travel_advice_edition, country_slug: 'aruba')
+      @edition = create(:travel_advice_edition, country_slug: 'aruba')
       @country = Country.find_by_slug('aruba')
     end
 

--- a/spec/controllers/healthcheck_spec.rb
+++ b/spec/controllers/healthcheck_spec.rb
@@ -2,9 +2,7 @@ describe HealthcheckController, type: :controller do
   include Rails.application.routes.url_helpers
 
   describe "#recently_published_editions" do
-    let(:travel_advice_edition) do
-      FactoryBot.create(:travel_advice_edition, published_at: 2.hours.ago)
-    end
+    let(:travel_advice_edition) { create(:travel_advice_edition, published_at: 2.hours.ago) }
 
     before do
       controller.stub(:editions_published_between_2_days_and_1_hour_ago) do

--- a/spec/controllers/healthcheck_spec.rb
+++ b/spec/controllers/healthcheck_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe HealthcheckController, type: :controller do
   include Rails.application.routes.url_helpers
 

--- a/spec/controllers/link_check_reports_spec.rb
+++ b/spec/controllers/link_check_reports_spec.rb
@@ -4,8 +4,7 @@ describe LinkCheckReportsController, type: :controller do
 
   describe "#create" do
     let(:travel_advice_edition) do
-      FactoryBot.create(:travel_advice_edition,
-                         summary: "[link](http://www.example.com)[link_two](http://www.gov.uk)")
+      create(:travel_advice_edition, summary: "[link](http://www.example.com)[link_two](http://www.gov.uk)")
     end
 
     before do
@@ -42,9 +41,9 @@ describe LinkCheckReportsController, type: :controller do
     context "#show" do
       let(:travel_advice_edition_id) { "a-edition-id" }
       let(:link_check_report) do
-        FactoryBot.create(:travel_advice_edition_with_broken_links,
-                           batch_id: 5,
-                           link_uris: ["http://www.example.com", "http://www.gov.com"]).link_check_reports.first
+        create(:travel_advice_edition_with_broken_links,
+               batch_id: 5,
+               link_uris: ["http://www.example.com", "http://www.gov.com"]).link_check_reports.first
       end
 
       it "GET redirects back to the edit edition page" do

--- a/spec/controllers/link_check_reports_spec.rb
+++ b/spec/controllers/link_check_reports_spec.rb
@@ -1,6 +1,3 @@
-require "spec_helper"
-require "gds_api/test_helpers/link_checker_api"
-
 describe LinkCheckReportsController, type: :controller do
   include GdsApi::TestHelpers::LinkCheckerApi
   include Rails.application.routes.url_helpers

--- a/spec/controllers/link_checker_api_spec.rb
+++ b/spec/controllers/link_checker_api_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe LinkCheckerApiController, type: :controller do
 
   let(:link_check_report_batch_id) { 5 }
   let!(:link_check_report) do
-    FactoryBot.create(:travel_advice_edition_with_pending_link_checks,
-                       batch_id: 5,
-                       link_uris: ['http://www.example.com', 'http://www.gov.com']).link_check_reports.first
+    create(:travel_advice_edition_with_pending_link_checks,
+           batch_id: 5,
+           link_uris: ['http://www.example.com', 'http://www.gov.com']).link_check_reports.first
   end
 
   let(:post_body) do

--- a/spec/controllers/link_checker_api_spec.rb
+++ b/spec/controllers/link_checker_api_spec.rb
@@ -1,6 +1,3 @@
-require "spec_helper"
-require "gds_api/test_helpers/link_checker_api"
-
 RSpec.describe LinkCheckerApiController, type: :controller do
   include GdsApi::TestHelpers::LinkCheckerApi
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -43,10 +43,7 @@ FactoryBot.define do
     end
 
     link_check_reports do
-      [FactoryBot.build(:link_check_report, :with_pending_links,
-                                             batch_id: batch_id,
-                                             link_uris: link_uris,
-                                             status: status)]
+      [build(:link_check_report, :with_pending_links, batch_id: batch_id, link_uris: link_uris, status: status)]
     end
   end
 
@@ -59,10 +56,7 @@ FactoryBot.define do
     end
 
     link_check_reports do
-      [FactoryBot.build(:link_check_report, :with_broken_links,
-                                             status: status,
-                                             link_uris: link_uris,
-                                             batch_id: batch_id)]
+      [build(:link_check_report, :with_broken_links, status: status, link_uris: link_uris, batch_id: batch_id)]
     end
   end
 
@@ -72,8 +66,7 @@ FactoryBot.define do
     end
 
     link_check_reports do
-      [FactoryBot.build(:link_check_report, :with_caution_links,
-                                             link_uris: link_uris)]
+      [build(:link_check_report, :with_caution_links, link_uris: link_uris)]
     end
   end
 
@@ -93,7 +86,7 @@ FactoryBot.define do
     batch_id { 1 }
     status { "in_progress" }
     completed_at { Time.now }
-    links { [FactoryBot.build(:link)] }
+    links { [build(:link)] }
 
     trait :completed do
       status { "completed" }
@@ -105,7 +98,7 @@ FactoryBot.define do
       end
 
       links do
-        link_uris.map { |uri| FactoryBot.build(:link, :pending, uri: uri) }
+        link_uris.map { |uri| build(:link, :pending, uri: uri) }
       end
     end
 
@@ -115,7 +108,7 @@ FactoryBot.define do
       end
 
       links do
-        link_uris.map { |uri| FactoryBot.build(:link, uri: uri, status: "broken") }
+        link_uris.map { |uri| build(:link, uri: uri, status: "broken") }
       end
     end
 
@@ -125,7 +118,7 @@ FactoryBot.define do
       end
 
       links do
-        link_uris.map { |uri| FactoryBot.build(:link, uri: uri, status: "caution") }
+        link_uris.map { |uri| build(:link, uri: uri, status: "caution") }
       end
     end
   end

--- a/spec/features/country_index_spec.rb
+++ b/spec/features/country_index_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 feature "Country Index" do
   before :each do
     login_as_stub_user

--- a/spec/features/country_index_spec.rb
+++ b/spec/features/country_index_spec.rb
@@ -5,20 +5,20 @@ feature "Country Index" do
   end
 
   scenario "inspecting the country index" do
-    FactoryBot.create(:draft_travel_advice_edition, country_slug: 'albania')
-    FactoryBot.create(:published_travel_advice_edition, country_slug: 'algeria')
-    FactoryBot.create(:archived_travel_advice_edition, country_slug: 'angola')
+    create(:draft_travel_advice_edition, country_slug: 'albania')
+    create(:published_travel_advice_edition, country_slug: 'algeria')
+    create(:archived_travel_advice_edition, country_slug: 'angola')
 
-    FactoryBot.create(:published_travel_advice_edition, country_slug: 'aruba')
-    FactoryBot.create(:draft_travel_advice_edition, country_slug: 'aruba')
+    create(:published_travel_advice_edition, country_slug: 'aruba')
+    create(:draft_travel_advice_edition, country_slug: 'aruba')
 
-    FactoryBot.create(:archived_travel_advice_edition, country_slug: 'afghanistan')
-    FactoryBot.create(:archived_travel_advice_edition, country_slug: 'afghanistan')
-    FactoryBot.create(:published_travel_advice_edition, country_slug: 'afghanistan')
-    FactoryBot.create(:draft_travel_advice_edition, country_slug: 'afghanistan')
+    create(:archived_travel_advice_edition, country_slug: 'afghanistan')
+    create(:archived_travel_advice_edition, country_slug: 'afghanistan')
+    create(:published_travel_advice_edition, country_slug: 'afghanistan')
+    create(:draft_travel_advice_edition, country_slug: 'afghanistan')
 
-    FactoryBot.create(:published_travel_advice_edition, country_slug: 'austria')
-    FactoryBot.create(:archived_travel_advice_edition, country_slug: 'austria')
+    create(:published_travel_advice_edition, country_slug: 'austria')
+    create(:archived_travel_advice_edition, country_slug: 'austria')
 
     visit "/admin/countries"
 

--- a/spec/features/country_version_index_spec.rb
+++ b/spec/features/country_version_index_spec.rb
@@ -1,7 +1,3 @@
-#encoding: utf-8
-
-require 'spec_helper'
-
 feature "Country version index" do
   before do
     login_as_stub_user

--- a/spec/features/country_version_index_spec.rb
+++ b/spec/features/country_version_index_spec.rb
@@ -22,12 +22,12 @@ feature "Country version index" do
 
   specify "viewing a country with published editions and creating a draft" do
     country = Country.find_by_slug('aruba')
-    e1 = FactoryBot.create(:archived_travel_advice_edition, country_slug: "aruba", version_number: 1)
-    e2 = FactoryBot.create(:archived_travel_advice_edition, country_slug: "aruba", version_number: 2)
-    e3 = FactoryBot.build(:travel_advice_edition, country_slug: "aruba", version_number: 3,
-                            title: "Aruba extra special travel advice", summary: "## This is the summary",
-                            overview: "Search description about Aruba",
-                            alert_status: [TravelAdviceEdition::ALERT_STATUSES.first])
+    e1 = create(:archived_travel_advice_edition, country_slug: "aruba", version_number: 1)
+    e2 = create(:archived_travel_advice_edition, country_slug: "aruba", version_number: 2)
+    e3 = build(:travel_advice_edition, country_slug: "aruba", version_number: 3,
+               title: "Aruba extra special travel advice", summary: "## This is the summary",
+               overview: "Search description about Aruba",
+               alert_status: [TravelAdviceEdition::ALERT_STATUSES.first])
     e3.parts.build(title: "Part One", slug: "part-one", body: "Some text")
     e3.parts.build(title: "Part Two", slug: "part-2", body: "Some more text")
     e3.save!

--- a/spec/features/edition_comparison_spec.rb
+++ b/spec/features/edition_comparison_spec.rb
@@ -1,7 +1,3 @@
-# encoding: UTF-8
-
-require 'spec_helper'
-
 feature "Comparing two editions", js: true do
   before :each do
     login_as stub_user

--- a/spec/features/edition_comparison_spec.rb
+++ b/spec/features/edition_comparison_spec.rb
@@ -1,10 +1,9 @@
 feature "Comparing two editions", js: true do
   before :each do
     login_as stub_user
-    @edition1 = FactoryBot.create(:published_travel_advice_edition,
-                                    country_slug: "aruba",
-                                    summary: 'Advice summray',
-                                    version_number: 1)
+    @edition1 = create(:published_travel_advice_edition,
+                       country_slug: "aruba", summary: 'Advice summray',
+                       version_number: 1)
     @edition2 = @edition1.build_clone
     @edition2.summary = "Advice summary"
     @edition2.change_description = "Corrected typo in the summary"

--- a/spec/features/edition_edit_spec.rb
+++ b/spec/features/edition_edit_spec.rb
@@ -57,7 +57,7 @@ feature "Edit Edition page", js: true do
     end
 
     scenario "create an edition from an archived edition" do
-      @edition = FactoryBot.create(:archived_travel_advice_edition, country_slug: "albania", title: "An archived title")
+      @edition = create(:archived_travel_advice_edition, country_slug: "albania", title: "An archived title")
 
       visit "/admin/editions/#{@edition._id}/edit"
 
@@ -75,7 +75,7 @@ feature "Edit Edition page", js: true do
     end
 
     scenario "create an edition from a published edition" do
-      @edition = FactoryBot.create(:published_travel_advice_edition, country_slug: "albania", title: "A published title")
+      @edition = create(:published_travel_advice_edition, country_slug: "albania", title: "A published title")
       @edition.actions.build(request_type: Action::NEW_VERSION)
       @edition.actions.build(request_type: Action::PUBLISH, requester: User.first, comment: "Made some changes...")
       @edition.save(validate: false)
@@ -106,8 +106,8 @@ feature "Edit Edition page", js: true do
     end
 
     scenario "should not allow creation of drafts if draft already exists" do
-      @edition = FactoryBot.create(:published_travel_advice_edition, country_slug: "albania", title: "A published title")
-      @draft = FactoryBot.create(:travel_advice_edition, country_slug: 'albania', state: "draft")
+      @edition = create(:published_travel_advice_edition, country_slug: "albania", title: "A published title")
+      @draft = create(:travel_advice_edition, country_slug: 'albania', state: "draft")
 
       visit "/admin/editions/#{@edition._id}/edit"
 
@@ -117,7 +117,7 @@ feature "Edit Edition page", js: true do
     end
 
     scenario "preventing double submits by using the Rails 'disable_with' feature" do
-      @edition = FactoryBot.create(:published_travel_advice_edition, country_slug: "albania", title: "A published title")
+      @edition = create(:published_travel_advice_edition, country_slug: "albania", title: "A published title")
 
       visit "/admin/editions/#{@edition._id}/edit"
 
@@ -127,7 +127,7 @@ feature "Edit Edition page", js: true do
   end
 
   scenario "inspecting the edit form, and adding content" do
-    @edition = FactoryBot.create(:draft_travel_advice_edition, country_slug: 'albania')
+    @edition = create(:draft_travel_advice_edition, country_slug: 'albania')
     visit "/admin/editions/#{@edition._id}/edit"
 
     within('h1') { expect(page).to have_content "Editing Albania Version 1" }
@@ -218,7 +218,7 @@ feature "Edit Edition page", js: true do
 
   scenario "Updating the reviewed at date for a published edition" do
     travel_to(Time.current) do
-      @edition = FactoryBot.create(:published_travel_advice_edition, country_slug: 'albania')
+      @edition = create(:published_travel_advice_edition, country_slug: 'albania')
       visit "/admin/editions/#{@edition._id}/edit"
       click_on "Update review date"
       @edition.reload
@@ -231,8 +231,8 @@ feature "Edit Edition page", js: true do
   end
 
   scenario "Seeing the minor update toggle on the edit form for non-first versions" do
-    FactoryBot.create(:published_travel_advice_edition, country_slug: 'albania')
-    @edition = FactoryBot.create(:draft_travel_advice_edition, country_slug: 'albania', minor_update: true)
+    create(:published_travel_advice_edition, country_slug: 'albania')
+    @edition = create(:draft_travel_advice_edition, country_slug: 'albania', minor_update: true)
     visit "/admin/editions/#{@edition._id}/edit"
 
     within('h1') { expect(page).to have_content "Editing Albania Version 2" }
@@ -255,7 +255,7 @@ feature "Edit Edition page", js: true do
   end
 
   scenario "slug for expect(parts).to be automatically generated" do
-    @edition = FactoryBot.create(:travel_advice_edition, country_slug: 'albania', state: 'draft')
+    @edition = create(:travel_advice_edition, country_slug: 'albania', state: 'draft')
     visit "/admin/editions/#{@edition._id}/edit"
 
     click_on 'Add new part'
@@ -268,7 +268,7 @@ feature "Edit Edition page", js: true do
   end
 
   scenario "removing a part from an edition" do
-    @edition = FactoryBot.build(:travel_advice_edition, country_slug: 'albania', state: 'draft')
+    @edition = build(:travel_advice_edition, country_slug: 'albania', state: 'draft')
     @edition.parts.build(title: 'Part One', body: 'Body text', slug: 'part-one')
     @edition.parts.build(title: 'Part Two', body: 'Body text', slug: 'part-two')
     @edition.save!
@@ -314,7 +314,7 @@ feature "Edit Edition page", js: true do
   end
 
   scenario "adding an invalid part" do
-    @edition = FactoryBot.create(:travel_advice_edition, country_slug: 'albania', state: 'draft')
+    @edition = create(:travel_advice_edition, country_slug: 'albania', state: 'draft')
     visit "/admin/editions/#{@edition._id}/edit"
 
     click_on "Add new part"
@@ -329,7 +329,7 @@ feature "Edit Edition page", js: true do
   end
 
   scenario "updating the parts sort order" do
-    @edition = FactoryBot.create(:travel_advice_edition, country_slug: 'albania', state: 'draft')
+    @edition = create(:travel_advice_edition, country_slug: 'albania', state: 'draft')
 
     @edition.parts << Part.new(title: "Wallace", slug: "wallace", order: 1)
     @edition.parts << Part.new(title: "Gromit", slug: "gromit", order: 2)
@@ -359,8 +359,8 @@ feature "Edit Edition page", js: true do
     allow(GdsApi::GovukHeaders).to receive(:headers)
       .and_return(govuk_request_id: "25108-1461151489.528-10.3.3.1-1066")
 
-    @old_edition = FactoryBot.create(:published_travel_advice_edition, country_slug: 'albania')
-    @edition = FactoryBot.create(
+    @old_edition = create(:published_travel_advice_edition, country_slug: 'albania')
+    @edition = create(
       :draft_travel_advice_edition,
       country_slug: 'albania',
       title: 'Albania travel advice',
@@ -402,16 +402,16 @@ feature "Edit Edition page", js: true do
 
   scenario "save and publish a minor update to an edition" do
     travel_to(3.days.ago) do
-      @old_edition = FactoryBot.create(:published_travel_advice_edition, country_slug: 'albania',
-                                        summary: "## The summaryy",
-                                        change_description: "Some things changed", minor_update: false)
+      @old_edition = create(:published_travel_advice_edition, country_slug: 'albania',
+                            summary: "## The summaryy", change_description: "Some things changed",
+                            minor_update: false)
     end
     travel_to(2.days.ago) do
       @old_edition.reviewed_at = Time.zone.now.utc
       @old_edition.save!
       @old_edition.reload
     end
-    @edition = FactoryBot.create(:draft_travel_advice_edition, country_slug: 'albania')
+    @edition = create(:draft_travel_advice_edition, country_slug: 'albania')
 
     travel_to(Time.current) do
       visit "/admin/editions/#{@edition.to_param}/edit"
@@ -440,8 +440,8 @@ feature "Edit Edition page", js: true do
   end
 
   scenario "attempting to edit a published edition" do
-    @edition = FactoryBot.create(:published_travel_advice_edition, country_slug: 'albania')
-    @draft = FactoryBot.create(:draft_travel_advice_edition, country_slug: 'albania')
+    @edition = create(:published_travel_advice_edition, country_slug: 'albania')
+    @draft = create(:draft_travel_advice_edition, country_slug: 'albania')
 
     visit "/admin/editions/#{@edition.to_param}/edit"
 
@@ -454,14 +454,14 @@ feature "Edit Edition page", js: true do
   end
 
   scenario "preview an edition" do
-    @edition = FactoryBot.create(:published_travel_advice_edition, country_slug: 'albania')
+    @edition = create(:published_travel_advice_edition, country_slug: 'albania')
     visit "/admin/editions/#{@edition.to_param}/edit"
 
     expect(page).to have_selector("a[href^='http://www.dev.gov.uk/foreign-travel-advice/albania?cache=']", text: "View on site")
   end
 
   scenario "create a note" do
-    @edition = FactoryBot.create(:travel_advice_edition, country_slug: 'australia', state: 'draft')
+    @edition = create(:travel_advice_edition, country_slug: 'australia', state: 'draft')
     visit "/admin/editions/#{@edition.to_param}/edit"
 
     within(:css, ".tabbable .nav") do
@@ -478,7 +478,7 @@ feature "Edit Edition page", js: true do
   end
 
   scenario "Set the alert status for an edition" do
-    @edition = FactoryBot.create(:travel_advice_edition, country_slug: 'australia', state: 'draft')
+    @edition = create(:travel_advice_edition, country_slug: 'australia', state: 'draft')
     visit "/admin/editions/#{@edition.to_param}/edit"
 
     expect(page).to have_unchecked_field("The FCO advise against all but essential travel to parts of the country")
@@ -519,7 +519,7 @@ feature "Edit Edition page", js: true do
   end
 
   scenario "managing images for an edition" do
-    @edition = FactoryBot.create(:travel_advice_edition, country_slug: 'australia', state: 'draft')
+    @edition = create(:travel_advice_edition, country_slug: 'australia', state: 'draft')
 
     file_one = File.open(Rails.root.join("spec", "fixtures", "uploads", "image.jpg"))
     file_two = File.open(Rails.root.join("spec", "fixtures", "uploads", "image_two.jpg"))
@@ -599,7 +599,7 @@ feature "Edit Edition page", js: true do
   end
 
   scenario "managing documents for an edition" do
-    @edition = FactoryBot.create(:travel_advice_edition, country_slug: 'australia', state: 'draft')
+    @edition = create(:travel_advice_edition, country_slug: 'australia', state: 'draft')
 
     file_one = File.open(Rails.root.join("spec", "fixtures", "uploads", "document.pdf"))
     file_two = File.open(Rails.root.join("spec", "fixtures", "uploads", "document_two.pdf"))
@@ -682,20 +682,20 @@ feature "Edit Edition page", js: true do
 
   context "workflow 'Save & Publish' button" do
     scenario "does not appear for archived editions" do
-      @edition = FactoryBot.create(:archived_travel_advice_edition, country_slug: 'albania')
+      @edition = create(:archived_travel_advice_edition, country_slug: 'albania')
       visit "/admin/editions/#{@edition.to_param}/edit"
       expect(page).not_to have_button("Save & Publish")
     end
 
     scenario "does not appear for published editions" do
-      @edition = FactoryBot.create(:published_travel_advice_edition, country_slug: 'albania')
+      @edition = create(:published_travel_advice_edition, country_slug: 'albania')
       visit "/admin/editions/#{@edition.to_param}/edit"
       expect(page).not_to have_button("Save & Publish")
     end
   end
 
   scenario "disallowing hover text on links in govspeak fields" do
-    @edition = FactoryBot.create(:draft_travel_advice_edition, country_slug: "albania")
+    @edition = create(:draft_travel_advice_edition, country_slug: "albania")
     visit "/admin/editions/#{@edition.to_param}/edit"
 
     fill_in "Summary", with: "Some things changed on [GOV.UK](https://www.gov.uk/ \"GOV.UK\")"

--- a/spec/features/edition_edit_spec.rb
+++ b/spec/features/edition_edit_spec.rb
@@ -1,8 +1,3 @@
-# encoding: UTF-8
-
-require 'spec_helper'
-require 'govuk_sidekiq/testing'
-
 feature "Edit Edition page", js: true do
   before do
     login_as_stub_user

--- a/spec/lib/publication_check/content_store_check_spec.rb
+++ b/spec/lib/publication_check/content_store_check_spec.rb
@@ -1,12 +1,9 @@
 module PublicationCheck
   describe ContentStoreCheck do
-    let(:edition) {
-      FactoryBot.create(
-        :published_travel_advice_edition,
-        country_slug: "andorra",
-        version_number: 2
-      )
-    }
+    let(:edition) do
+      create(:published_travel_advice_edition, country_slug: "andorra", version_number: 2)
+    end
+
     let(:publish_request) {
       PublishRequest.new(
         request_id: "25107-1461581820.634-185.22.224.96-13641",

--- a/spec/lib/publication_check/content_store_check_spec.rb
+++ b/spec/lib/publication_check/content_store_check_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module PublicationCheck
   describe ContentStoreCheck do
     let(:edition) {

--- a/spec/lib/publication_check/result_spec.rb
+++ b/spec/lib/publication_check/result_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module PublicationCheck
   describe Result do
     describe "#failed?" do

--- a/spec/lib/publication_check/runner_spec.rb
+++ b/spec/lib/publication_check/runner_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module PublicationCheck
   describe Runner do
     let(:request_one) { double(register_check_attempt!: nil) }

--- a/spec/lib/registerable_travel_advice_edition_spec.rb
+++ b/spec/lib/registerable_travel_advice_edition_spec.rb
@@ -1,7 +1,7 @@
 describe RegisterableTravelAdviceEdition do
   describe "state" do
     before :each do
-      @edition = FactoryBot.build(:travel_advice_edition)
+      @edition = build(:travel_advice_edition)
     end
 
     it "should be 'live' for a published edition" do
@@ -22,7 +22,7 @@ describe RegisterableTravelAdviceEdition do
 
   describe "simple fields" do
     before :each do
-      @edition = FactoryBot.build(:travel_advice_edition)
+      @edition = build(:travel_advice_edition)
       @registerable = RegisterableTravelAdviceEdition.new(@edition)
     end
 
@@ -66,7 +66,7 @@ describe RegisterableTravelAdviceEdition do
 
   describe "content_id" do
     before :each do
-      @edition = FactoryBot.build(:travel_advice_edition)
+      @edition = build(:travel_advice_edition)
       @registerable = RegisterableTravelAdviceEdition.new(@edition)
     end
 

--- a/spec/lib/registerable_travel_advice_edition_spec.rb
+++ b/spec/lib/registerable_travel_advice_edition_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe RegisterableTravelAdviceEdition do
   describe "state" do
     before :each do

--- a/spec/migrations/user_migration_spec.rb
+++ b/spec/migrations/user_migration_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require Rails.root.join('db', 'migrate', '20190227101824_archive_american_samoa.rb')
 
 describe ArchiveAmericanSamoa, type: :migration do

--- a/spec/migrations/user_migration_spec.rb
+++ b/spec/migrations/user_migration_spec.rb
@@ -2,7 +2,7 @@ require Rails.root.join('db', 'migrate', '20190227101824_archive_american_samoa.
 
 describe ArchiveAmericanSamoa, type: :migration do
   it 'archives American Samoa TravelAdviceEditions' do
-    travel_advice_edition = FactoryBot.create(
+    travel_advice_edition = create(
       :published_travel_advice_edition,
       country_slug: 'american-samoa'
     )

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe Country do
   describe "Country.all" do
     it "should return a list of Countries" do

--- a/spec/models/country_spec.rb
+++ b/spec/models/country_spec.rb
@@ -30,17 +30,17 @@ describe Country do
     end
 
     it "should return all TravelAdviceEditions with the matching country_slug" do
-      e1 = FactoryBot.create(:archived_travel_advice_edition, country_slug: @country.slug)
-      _e2 = FactoryBot.create(:archived_travel_advice_edition, country_slug: "wibble")
-      e3 = FactoryBot.create(:archived_travel_advice_edition, country_slug: @country.slug)
+      e1 = create(:archived_travel_advice_edition, country_slug: @country.slug)
+      _e2 = create(:archived_travel_advice_edition, country_slug: "wibble")
+      e3 = create(:archived_travel_advice_edition, country_slug: @country.slug)
 
       expect(@country.editions.to_a).to match_array([e1, e3])
     end
 
     it "should order them by descending version_number" do
-      e1 = FactoryBot.create(:archived_travel_advice_edition, country_slug: @country.slug, version_number: 1)
-      e3 = FactoryBot.create(:archived_travel_advice_edition, country_slug: @country.slug, version_number: 3)
-      e2 = FactoryBot.create(:archived_travel_advice_edition, country_slug: @country.slug, version_number: 2)
+      e1 = create(:archived_travel_advice_edition, country_slug: @country.slug, version_number: 1)
+      e3 = create(:archived_travel_advice_edition, country_slug: @country.slug, version_number: 3)
+      e2 = create(:archived_travel_advice_edition, country_slug: @country.slug, version_number: 2)
 
       expect(@country.editions.to_a).to eq([e3, e2, e1])
     end
@@ -50,9 +50,9 @@ describe Country do
     before do
       @country = Country.all.first
 
-      @archived = FactoryBot.create(:archived_travel_advice_edition, country_slug: @country.slug, version_number: 1)
-      @published = FactoryBot.create(:published_travel_advice_edition, country_slug: @country.slug, version_number: 2)
-      @draft = FactoryBot.create(:draft_travel_advice_edition, country_slug: @country.slug, version_number: 3)
+      @archived = create(:archived_travel_advice_edition, country_slug: @country.slug, version_number: 1)
+      @published = create(:published_travel_advice_edition, country_slug: @country.slug, version_number: 2)
+      @draft = create(:draft_travel_advice_edition, country_slug: @country.slug, version_number: 3)
     end
 
     it "should return the last published edition for the country" do
@@ -81,19 +81,19 @@ describe Country do
     end
 
     it "should match published editions correctly" do
-      FactoryBot.create(:published_travel_advice_edition, country_slug: @country.slug)
+      create(:published_travel_advice_edition, country_slug: @country.slug)
       expect(@country.has_published_edition?).to eq(true)
       expect(@country.has_draft_edition?).to eq(false)
     end
 
     it "should match draft editions correctly" do
-      FactoryBot.create(:draft_travel_advice_edition, country_slug: @country.slug)
+      create(:draft_travel_advice_edition, country_slug: @country.slug)
       expect(@country.has_published_edition?).to eq(false)
       expect(@country.has_draft_edition?).to eq(true)
     end
 
     it "should be false with editions in other states" do
-      FactoryBot.create(:archived_travel_advice_edition, country_slug: @country.slug)
+      create(:archived_travel_advice_edition, country_slug: @country.slug)
       expect(@country.has_published_edition?).to eq(false)
       expect(@country.has_draft_edition?).to eq(false)
     end
@@ -105,9 +105,9 @@ describe Country do
     end
 
     it "should build a clone of the latest edition if present" do
-      ed1 = FactoryBot.build(:travel_advice_edition)
-      ed2 = FactoryBot.build(:travel_advice_edition)
-      ed3 = FactoryBot.build(:travel_advice_edition)
+      ed1 = build(:travel_advice_edition)
+      ed2 = build(:travel_advice_edition)
+      ed3 = build(:travel_advice_edition)
       allow(@country).to receive(:editions).and_return([ed3, ed2, ed1])
       expect(ed3).to receive(:build_clone).and_return(:a_new_edition)
 
@@ -124,7 +124,7 @@ describe Country do
 
   describe "build_new_edition_as" do
     before :each do
-      @user = FactoryBot.create(:user)
+      @user = create(:user)
       @country = Country.find_by_slug('aruba')
     end
 
@@ -138,9 +138,10 @@ describe Country do
 
     describe "providing an optional edition parameter" do
       before :each do
-        @edition = FactoryBot.create(:archived_travel_advice_edition,
-          country_slug: @country.slug, title: "A test title",
-          overview: "Meh")
+        @edition = create(
+          :archived_travel_advice_edition, country_slug: @country.slug,
+          title: "A test title", overview: "Meh"
+        )
       end
 
       it "should build a clone of the provided edition" do

--- a/spec/models/link_check_report_spec.rb
+++ b/spec/models/link_check_report_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe LinkCheckReport, type: :model do
   context "validations" do
     let(:attributes) do

--- a/spec/models/link_check_report_spec.rb
+++ b/spec/models/link_check_report_spec.rb
@@ -45,31 +45,31 @@ describe LinkCheckReport, type: :model do
 
   context "#completed?" do
     it "should return true when completed" do
-      link_check_report = FactoryBot.create(:travel_advice_edition_with_pending_link_checks,
-                                             link_uris: ["http://www.example.com", "http://www.gov.com"],
-                                             status: "completed").link_check_reports.first
+      link_check_report = create(:travel_advice_edition_with_pending_link_checks,
+                                 link_uris: ["http://www.example.com", "http://www.gov.com"],
+                                 status: "completed").link_check_reports.first
       expect(link_check_report.completed?).to eq true
     end
 
     it "should return false when not complete" do
-      link_check_report = FactoryBot.create(:travel_advice_edition_with_pending_link_checks,
-                                             link_uris: ["http://www.example.com", "http://www.gov.com"]).link_check_reports.first
+      link_check_report = create(:travel_advice_edition_with_pending_link_checks,
+                                 link_uris: ["http://www.example.com", "http://www.gov.com"]).link_check_reports.first
       expect(link_check_report.completed?).to eq false
     end
   end
 
   context "#in_progress?" do
     it "should return true when still in progress" do
-      link_check_report = FactoryBot.create(:travel_advice_edition_with_pending_link_checks,
-                                             link_uris: ["http://www.example.com", "http://www.gov.com"]).link_check_reports.first
+      link_check_report = create(:travel_advice_edition_with_pending_link_checks,
+                                 link_uris: ["http://www.example.com", "http://www.gov.com"]).link_check_reports.first
       expect(link_check_report.in_progress?).to eq true
     end
   end
 
   context "#broken_links" do
     it "should return an array of broken links" do
-      link_check_report = FactoryBot.create(:travel_advice_edition_with_broken_links,
-                                             link_uris: ["http://www.example.com", "http://www.gov.com"]).link_check_reports.first
+      link_check_report = create(:travel_advice_edition_with_broken_links,
+                                 link_uris: ["http://www.example.com", "http://www.gov.com"]).link_check_reports.first
 
       expect(link_check_report.broken_links.first.uri).to eq("http://www.example.com")
       expect(link_check_report.broken_links.last.uri).to eq("http://www.gov.com")
@@ -79,8 +79,8 @@ describe LinkCheckReport, type: :model do
 
   context "#caution_links" do
     it "should return an array of links with cautions" do
-      link_check_report = FactoryBot.create(:travel_advice_edition_with_caution_links,
-                                             link_uris: ["http://www.example.com", "http://www.gov.com"]).link_check_reports.first
+      link_check_report = create(:travel_advice_edition_with_caution_links,
+                                 link_uris: ["http://www.example.com", "http://www.gov.com"]).link_check_reports.first
 
       expect(link_check_report.caution_links.first.uri).to eq("http://www.example.com")
       expect(link_check_report.caution_links.last.uri).to eq("http://www.gov.com")

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe Link do
   let(:attributes) {
     {

--- a/spec/models/publish_request_spec.rb
+++ b/spec/models/publish_request_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe PublishRequest do
   describe "#check_count" do
     let(:publish_request) { PublishRequest.new }

--- a/spec/models/travel_advice_edition_spec.rb
+++ b/spec/models/travel_advice_edition_spec.rb
@@ -1,7 +1,3 @@
-require 'spec_helper'
-require "gds_api/asset_manager"
-require "gds_api/exceptions"
-
 describe TravelAdviceEdition do
   describe('fields') do
     it "has correct fields" do

--- a/spec/models/travel_advice_edition_spec.rb
+++ b/spec/models/travel_advice_edition_spec.rb
@@ -35,7 +35,7 @@ describe TravelAdviceEdition do
   end
 
   describe "validations" do
-    let(:ta) { FactoryBot.build(:travel_advice_edition) }
+    let(:ta) { build(:travel_advice_edition) }
 
     it "requires a country slug" do
       ta.country_slug = ""
@@ -51,21 +51,21 @@ describe TravelAdviceEdition do
 
     context "on state" do
       it "only allows one edition in draft per slug" do
-        FactoryBot.create(:travel_advice_edition, country_slug: ta.country_slug)
+        create(:travel_advice_edition, country_slug: ta.country_slug)
         ta.state = "draft"
         expect(ta).not_to be_valid
         expect(ta.errors.messages[:state]).to include("is already taken")
       end
 
       it "only allows one edition in published per slug" do
-        FactoryBot.create(:published_travel_advice_edition, country_slug: ta.country_slug)
+        create(:published_travel_advice_edition, country_slug: ta.country_slug)
         ta.state = "published"
         expect(ta).not_to be_valid
         expect(ta.errors.messages[:state]).to include("is already taken")
       end
 
       it "allows multiple editions in archived per slug" do
-        FactoryBot.create(:archived_travel_advice_edition, country_slug: ta.country_slug)
+        create(:archived_travel_advice_edition, country_slug: ta.country_slug)
         ta.save!
         ta.state = "archived"
         expect(ta).to be_valid
@@ -80,37 +80,37 @@ describe TravelAdviceEdition do
 
     context "preventing editing of non-draft" do
       it "does not allow published editions to be edited" do
-        ta = FactoryBot.create(:published_travel_advice_edition)
+        ta = create(:published_travel_advice_edition)
         ta.title = "Fooey"
         expect(ta).not_to be_valid
         expect(ta.errors.messages[:state]).to include("must be draft to modify")
       end
 
       it "does not allow archived editions to be edited" do
-        ta = FactoryBot.create(:archived_travel_advice_edition)
+        ta = create(:archived_travel_advice_edition)
         ta.title = "Fooey"
         expect(ta).not_to be_valid
         expect(ta.errors.messages[:state]).to include("must be draft to modify")
       end
 
       it "allows publishing draft editions" do
-        ta = FactoryBot.create(:travel_advice_edition)
+        ta = create(:travel_advice_edition)
         expect(ta.publish).to be true
       end
 
       it "allows 'save & publish'" do
-        ta = FactoryBot.create(:travel_advice_edition)
+        ta = create(:travel_advice_edition)
         ta.title = "Foo"
         expect(ta.publish).to be true
       end
 
       it "allows archiving published editions" do
-        ta = FactoryBot.create(:published_travel_advice_edition)
+        ta = create(:published_travel_advice_edition)
         expect(ta.archive).to be true
       end
 
       it "does NOT allow 'save & archive'" do
-        ta = FactoryBot.create(:published_travel_advice_edition)
+        ta = create(:published_travel_advice_edition)
         ta.title = "Foo"
         expect(ta.archive).to be false
         expect(ta.errors.messages[:state]).to include("must be draft to modify")
@@ -148,14 +148,14 @@ describe TravelAdviceEdition do
       end
 
       it "requires a unique version_number per slug" do
-        FactoryBot.create(:archived_travel_advice_edition, country_slug: ta.country_slug, version_number: 3)
+        create(:archived_travel_advice_edition, country_slug: ta.country_slug, version_number: 3)
         ta.version_number = 3
         expect(ta).not_to be_valid
         expect(ta.errors.messages[:version_number]).to include("is already taken")
       end
 
       it "allows matching version_numbers for different slugs" do
-        FactoryBot.create(:archived_travel_advice_edition, country_slug: "wibble", version_number: 3)
+        create(:archived_travel_advice_edition, country_slug: "wibble", version_number: 3)
         ta.version_number = 3
         expect(ta).to be_valid
       end
@@ -169,7 +169,7 @@ describe TravelAdviceEdition do
       end
 
       it "allow other versions to be minor updates" do
-        FactoryBot.create(:published_travel_advice_edition, country_slug: ta.country_slug)
+        create(:published_travel_advice_edition, country_slug: ta.country_slug)
         ta.minor_update = true
         expect(ta).to be_valid
       end
@@ -185,7 +185,7 @@ describe TravelAdviceEdition do
       end
 
       it "is not required on publish for a minor update" do
-        FactoryBot.create(:archived_travel_advice_edition, country_slug: ta.country_slug)
+        create(:archived_travel_advice_edition, country_slug: ta.country_slug)
         ta.version_number = 2
         ta.save!
         ta.change_description = ""
@@ -202,10 +202,10 @@ describe TravelAdviceEdition do
   end
 
   it "has a published scope" do
-    _e1 = FactoryBot.create(:draft_travel_advice_edition)
-    e2 = FactoryBot.create(:published_travel_advice_edition)
-    _e3 = FactoryBot.create(:archived_travel_advice_edition)
-    e4 = FactoryBot.create(:published_travel_advice_edition)
+    _e1 = create(:draft_travel_advice_edition)
+    e2 = create(:published_travel_advice_edition)
+    _e3 = create(:archived_travel_advice_edition)
+    e4 = create(:published_travel_advice_edition)
     expect(TravelAdviceEdition.published.to_a.sort).to eq([e2, e4].sort)
   end
 
@@ -222,9 +222,9 @@ describe TravelAdviceEdition do
       end
 
       it "sets version_number to the next available version" do
-        FactoryBot.create(:archived_travel_advice_edition, country_slug: "foo", version_number: 1)
-        FactoryBot.create(:archived_travel_advice_edition, country_slug: "foo", version_number: 2)
-        FactoryBot.create(:published_travel_advice_edition, country_slug: "foo", version_number: 4)
+        create(:archived_travel_advice_edition, country_slug: "foo", version_number: 1)
+        create(:archived_travel_advice_edition, country_slug: "foo", version_number: 2)
+        create(:published_travel_advice_edition, country_slug: "foo", version_number: 4)
         ed = TravelAdviceEdition.new(country_slug: "foo")
         ed.valid?
         expect(ed.version_number).to eq(5)
@@ -249,9 +249,16 @@ describe TravelAdviceEdition do
   end
 
   context "building a new version" do
-    let(:ed) {
-      FactoryBot.create(:travel_advice_edition, title: "Aruba", overview: "Aruba is not near Wales", country_slug: "aruba", summary: "## The summary", alert_status: %w(avoid_all_but_essential_travel_to_whole_country avoid_all_travel_to_parts), image_id: "id_from_the_asset_manager_for_an_image", document_id: "id_from_the_asset_manager_for_a_document")
-    }
+    let(:ed) do
+      create(
+        :travel_advice_edition, title: "Aruba",
+        overview: "Aruba is not near Wales", country_slug: "aruba",
+        summary: "## The summary",
+        alert_status: %w(avoid_all_but_essential_travel_to_whole_country avoid_all_travel_to_parts),
+        image_id: "id_from_the_asset_manager_for_an_image",
+        document_id: "id_from_the_asset_manager_for_a_document"
+      )
+    end
 
     before do
       ed.parts.build(title: "Fooey", slug: "fooey", body: "It's all about Fooey")
@@ -280,9 +287,9 @@ describe TravelAdviceEdition do
   end
 
   context "previous_version" do
-    let!(:ed1) { FactoryBot.create(:archived_travel_advice_edition, country_slug: "foo") }
-    let!(:ed2) { FactoryBot.create(:archived_travel_advice_edition, country_slug: "foo") }
-    let!(:ed3) { FactoryBot.create(:archived_travel_advice_edition, country_slug: "foo") }
+    let!(:ed1) { create(:archived_travel_advice_edition, country_slug: "foo") }
+    let!(:ed2) { create(:archived_travel_advice_edition, country_slug: "foo") }
+    let!(:ed3) { create(:archived_travel_advice_edition, country_slug: "foo") }
 
     it "returns the previous version" do
       expect(ed3.previous_version).to eq(ed2)
@@ -295,12 +302,11 @@ describe TravelAdviceEdition do
   end
 
   context "publishing" do
-    let!(:published) {
-      FactoryBot.create(:published_travel_advice_edition, country_slug: "aruba", published_at: 3.days.ago, change_description: "Stuff changed")
-    }
-    let!(:ed) {
-      FactoryBot.create(:travel_advice_edition, country_slug: "aruba")
-    }
+    let!(:published) do
+      create(:published_travel_advice_edition, country_slug: "aruba", published_at: 3.days.ago, change_description: "Stuff changed")
+    end
+    let!(:ed) { create(:travel_advice_edition, country_slug: "aruba") }
+
     before do
       published.reload
     end
@@ -336,12 +342,12 @@ describe TravelAdviceEdition do
 
   context "setting the reviewed at date" do
     before do
-      @published = FactoryBot.create(:published_travel_advice_edition, country_slug: "aruba", published_at: 3.days.ago, change_description: "Stuff changed")
+      @published = create(:published_travel_advice_edition, country_slug: "aruba", published_at: 3.days.ago, change_description: "Stuff changed")
       @published.reviewed_at = 2.days.ago
       @published.save!
       @published.reload
       travel_to(1.days.ago) do
-        @ed = FactoryBot.create(:travel_advice_edition, country_slug: "aruba")
+        @ed = create(:travel_advice_edition, country_slug: "aruba")
       end
     end
 
@@ -378,9 +384,9 @@ describe TravelAdviceEdition do
   end
 
   context "actions" do
-    let!(:user) { FactoryBot.create(:user) }
-    let!(:old) { FactoryBot.create(:archived_travel_advice_edition, country_slug: "foo") }
-    let!(:edition) { FactoryBot.create(:draft_travel_advice_edition, country_slug: "foo") }
+    let!(:user) { create(:user) }
+    let!(:old) { create(:archived_travel_advice_edition, country_slug: "foo") }
+    let!(:edition) { create(:draft_travel_advice_edition, country_slug: "foo") }
 
     it "does not have any actions by default" do
       expect(edition.actions.size).to eq(0)
@@ -425,7 +431,7 @@ describe TravelAdviceEdition do
 
   context "parts" do
     it "should merge part validation errors with parent document's errors" do
-      edition = FactoryBot.create(:travel_advice_edition)
+      edition = create(:travel_advice_edition)
       edition.parts.build(_id: '54c10d4d759b743528000010', order: '1', title: "", slug: "overview")
       edition.parts.build(_id: '54c10d4d759b743528000011', order: '2', title: "Prepare for your appointment", slug: "")
       edition.parts.build(_id: '54c10d4d759b743528000012', order: '3', title: "Valid", slug: "valid")
@@ -436,7 +442,7 @@ describe TravelAdviceEdition do
     end
 
     it "#whole_body returns ordered parts" do
-      edition = FactoryBot.create(:travel_advice_edition)
+      edition = create(:travel_advice_edition)
       edition.parts.build(_id: '54c10d4d759b743528000010', order: '1', title: "Part 1", slug: "part_1")
       edition.parts.build(_id: '54c10d4d759b743528000011', order: '3', title: "Part 3", slug: "part_3")
       edition.parts.build(_id: '54c10d4d759b743528000012', order: '2', title: "Part 2", slug: "part_2")
@@ -446,12 +452,12 @@ describe TravelAdviceEdition do
 
   context "link_check_reports" do
     it "does not have any link_check_reports by default" do
-      edition = FactoryBot.create(:travel_advice_edition)
+      edition = create(:travel_advice_edition)
       expect(edition.link_check_reports.size).to eq(0)
     end
 
     it "adds a new link_check_report" do
-      edition = FactoryBot.create(:travel_advice_edition)
+      edition = create(:travel_advice_edition)
       edition.link_check_reports.build(
         links: [{ uri: "http://www.example.com", status: "error" }],
         batch_id: 1,
@@ -515,7 +521,7 @@ describe TravelAdviceEdition do
 
   describe "attached fields" do
     it "retrieves the asset from the api" do
-      ed = FactoryBot.create(:travel_advice_edition, state: 'draft', image_id: "an_image_id")
+      ed = create(:travel_advice_edition, state: 'draft', image_id: "an_image_id")
 
       asset = {
         "file_url" => "/path/to/image"
@@ -526,7 +532,7 @@ describe TravelAdviceEdition do
     end
 
     it "caches the asset from the api" do
-      ed = FactoryBot.create(:travel_advice_edition, state: 'draft', image_id: "an_image_id")
+      ed = create(:travel_advice_edition, state: 'draft', image_id: "an_image_id")
 
       asset = {
         "something" => "one",
@@ -540,14 +546,14 @@ describe TravelAdviceEdition do
 
     it "assigns a file and detects it has changed" do
       file = File.open(Rails.root.join("spec/fixtures/uploads/image.jpg"))
-      ed = FactoryBot.create(:travel_advice_edition, state: 'draft')
+      ed = create(:travel_advice_edition, state: 'draft')
 
       ed.image = file
       expect(ed.image_has_changed?).to be true
     end
 
     it "does not upload an asset if it has not changed" do
-      ed = FactoryBot.create(:travel_advice_edition, state: 'draft')
+      ed = create(:travel_advice_edition, state: 'draft')
       expect_any_instance_of(TravelAdviceEdition).not_to receive(:upload_image)
 
       ed.save!
@@ -555,7 +561,7 @@ describe TravelAdviceEdition do
 
     describe "saving an edition" do
       before do
-        @ed = FactoryBot.create(:travel_advice_edition, state: 'draft')
+        @ed = create(:travel_advice_edition, state: 'draft')
         @file = File.open(Rails.root.join("spec/fixtures/uploads/image.jpg"))
 
         @asset = { "id" => 'http://asset-manager.dev.gov.uk/assets/an_image_id' }
@@ -604,7 +610,7 @@ describe TravelAdviceEdition do
 
     describe "removing an asset" do
       it "removes an asset when remove_* set to true" do
-        ed = FactoryBot.create(:travel_advice_edition, state: 'draft', image_id: "an_image_id")
+        ed = create(:travel_advice_edition, state: 'draft', image_id: "an_image_id")
         ed.remove_image = true
         ed.save!
 
@@ -612,7 +618,7 @@ describe TravelAdviceEdition do
       end
 
       it "doesn't remove an asset when remove_* set to false or empty" do
-        ed = FactoryBot.create(:travel_advice_edition, state: 'draft', image_id: "an_image_id")
+        ed = create(:travel_advice_edition, state: 'draft', image_id: "an_image_id")
         ed.remove_image = false
         ed.remove_image = ""
         ed.remove_image = nil
@@ -625,12 +631,12 @@ describe TravelAdviceEdition do
 
   context "latest_link_check_report" do
     it "should be nil for no reports" do
-      edition = FactoryBot.create(:published_travel_advice_edition)
+      edition = create(:published_travel_advice_edition)
       expect(edition.latest_link_check_report).to eq(nil)
     end
 
     it "should return the last report created" do
-      edition = FactoryBot.create(:published_travel_advice_edition)
+      edition = create(:published_travel_advice_edition)
       edition.link_check_reports.create(FactoryBot.attributes_for(:link_check_report))
       latest_report = edition.link_check_reports.create(FactoryBot.attributes_for(:link_check_report, batch_id: 2))
 

--- a/spec/notifiers/email_alert_api_notifier_spec.rb
+++ b/spec/notifiers/email_alert_api_notifier_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe EmailAlertApiNotifier do
   end
 
   let(:edition) do
-    FactoryBot.create(
+    create(
       :published_travel_advice_edition,
       country_slug: "albania",
       title: "Albania travel advice",
@@ -20,7 +20,7 @@ RSpec.describe EmailAlertApiNotifier do
   end
 
   context "when the edition is a draft" do
-    let(:edition) { FactoryBot.create(:draft_travel_advice_edition) }
+    let(:edition) { create(:draft_travel_advice_edition) }
 
     it "does nothing" do
       expect(subject.send_alert(edition)).to be_nil

--- a/spec/notifiers/email_alert_api_notifier_spec.rb
+++ b/spec/notifiers/email_alert_api_notifier_spec.rb
@@ -1,6 +1,3 @@
-require "spec_helper"
-require "gds_api/test_helpers/email_alert_api"
-
 RSpec.describe EmailAlertApiNotifier do
   include GdsApiHelpers
   include GdsApi::TestHelpers::EmailAlertApi

--- a/spec/notifiers/publishing_api_notifier_spec.rb
+++ b/spec/notifiers/publishing_api_notifier_spec.rb
@@ -1,6 +1,3 @@
-require "spec_helper"
-require "sidekiq/testing"
-
 RSpec.describe PublishingApiNotifier do
   include GdsApiHelpers
 

--- a/spec/notifiers/publishing_api_notifier_spec.rb
+++ b/spec/notifiers/publishing_api_notifier_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe PublishingApiNotifier do
 
   subject { PublishingApiNotifier.new }
 
-  let(:edition) { FactoryBot.create(:travel_advice_edition, country_slug: "aruba") }
+  let(:edition) { create(:travel_advice_edition, country_slug: "aruba") }
 
   describe "put_content and enqueue" do
     let(:presenter) { EditionPresenter.new(edition) }

--- a/spec/presenters/asset_presenter_spec.rb
+++ b/spec/presenters/asset_presenter_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 RSpec.describe AssetPresenter do
   let(:asset) do
     {

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe EditionPresenter do
   let(:user) { FactoryBot.create(:user) }
 

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -1,8 +1,8 @@
 describe EditionPresenter do
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { create(:user) }
 
   let(:edition) {
-    edition = FactoryBot.build(
+    edition = build(
       :travel_advice_edition,
       country_slug: "aruba",
       title: "Aruba travel advice",
@@ -36,7 +36,7 @@ describe EditionPresenter do
   }
 
   let(:previous) {
-    previous = FactoryBot.create(
+    previous = create(
       :travel_advice_edition,
       country_slug: "aruba",
       change_description: "Stuff previously changed"

--- a/spec/presenters/email_alert_presenter_spec.rb
+++ b/spec/presenters/email_alert_presenter_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe EmailAlertPresenter do
   include GdsApiHelpers
 
   let(:edition) do
-    FactoryBot.create(
+    create(
       :published_travel_advice_edition,
       country_slug: "algeria",
       title: "Algeria travel advice",

--- a/spec/presenters/email_alert_presenter_spec.rb
+++ b/spec/presenters/email_alert_presenter_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 RSpec.describe EmailAlertPresenter do
   include GdsApiHelpers
 

--- a/spec/presenters/email_alert_signup/edition_presenter_spec.rb
+++ b/spec/presenters/email_alert_signup/edition_presenter_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 RSpec.describe EmailAlertSignup::EditionPresenter do
   let(:edition) do
     FactoryBot.build(

--- a/spec/presenters/email_alert_signup/edition_presenter_spec.rb
+++ b/spec/presenters/email_alert_signup/edition_presenter_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe EmailAlertSignup::EditionPresenter do
   let(:edition) do
-    FactoryBot.build(
+    build(
       :travel_advice_edition,
       country_slug: "aruba",
       title: "Aruba Travel Advice",

--- a/spec/presenters/historical_edition_presenter_spec.rb
+++ b/spec/presenters/historical_edition_presenter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe HistoricalEditionPresenter do
   let(:country) {
     Country.new(

--- a/spec/presenters/historical_edition_presenter_spec.rb
+++ b/spec/presenters/historical_edition_presenter_spec.rb
@@ -9,7 +9,7 @@ describe HistoricalEditionPresenter do
   }
 
   let(:edition) {
-    FactoryBot.build(
+    build(
       :travel_advice_edition,
       country_slug: 'aruba',
       title: "Aruba travel advice",

--- a/spec/presenters/index_presenter_spec.rb
+++ b/spec/presenters/index_presenter_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 describe IndexPresenter do
   include GdsApiHelpers
 

--- a/spec/presenters/links_presenter_spec.rb
+++ b/spec/presenters/links_presenter_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 RSpec.describe LinksPresenter do
   let(:edition) { FactoryBot.build(:travel_advice_edition, country_slug: 'aruba') }
 

--- a/spec/presenters/links_presenter_spec.rb
+++ b/spec/presenters/links_presenter_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe LinksPresenter do
-  let(:edition) { FactoryBot.build(:travel_advice_edition, country_slug: 'aruba') }
+  let(:edition) { build(:travel_advice_edition, country_slug: 'aruba') }
 
   subject { described_class.new(edition) }
 

--- a/spec/presenters/part_presenter_spec.rb
+++ b/spec/presenters/part_presenter_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe PartPresenter do
-  let(:edition) { FactoryBot.build(:travel_advice_edition) }
+  let(:edition) { build(:travel_advice_edition) }
   let(:parts) { edition.parts }
 
   before do

--- a/spec/presenters/part_presenter_spec.rb
+++ b/spec/presenters/part_presenter_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 RSpec.describe PartPresenter do
   let(:edition) { FactoryBot.build(:travel_advice_edition) }
   let(:parts) { edition.parts }

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 RSpec.describe "/healthcheck", type: :request do
   def data(body = response.body)
     JSON.parse(body).deep_symbolize_keys

--- a/spec/requests/request_tracing_spec.rb
+++ b/spec/requests/request_tracing_spec.rb
@@ -1,7 +1,3 @@
-require "spec_helper"
-require 'govuk_sidekiq/testing'
-require "gds_api/test_helpers/email_alert_api"
-
 RSpec.describe "Request tracing", type: :request do
   include GdsApi::TestHelpers::PublishingApiV2
   include GdsApi::TestHelpers::EmailAlertApi

--- a/spec/requests/request_tracing_spec.rb
+++ b/spec/requests/request_tracing_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe "Request tracing", type: :request do
 
   let(:govuk_request_id) { "12345-67890" }
   let(:govuk_authenticated_user) { "0a1b2c3d4e5f" }
-  let(:edition) { FactoryBot.create(:travel_advice_edition, country_slug: "aruba") }
+  let(:edition) { create(:travel_advice_edition, country_slug: "aruba") }
 
   before do
-    user = FactoryBot.create(:user, uid: govuk_authenticated_user)
+    user = create(:user, uid: govuk_authenticated_user)
     login_as(user)
     stub_any_publishing_api_call
     stub_any_email_alert_api_call

--- a/spec/services/edition_link_extractor_spec.rb
+++ b/spec/services/edition_link_extractor_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe EditionLinkExtractor do
   context ".call" do
-    let(:edition_with_no_links) { FactoryBot.create(:travel_advice_edition) }
-    let(:edition_with_links_in_govspeak_fields) { FactoryBot.create(:travel_advice_edition, summary: "This is a [link](https://www.example.com)") }
-    let(:edition_with_links_in_parts) { FactoryBot.create(:travel_advice_edition_with_parts) }
-    let(:edition_with_absolute_paths_in_govspeak_fields) { FactoryBot.create(:travel_advice_edition, summary: "This is a [link](https://www.example.com). This is an absolute [path](/id-for-driving-licence)") }
+    let(:edition_with_no_links) { create(:travel_advice_edition) }
+    let(:edition_with_links_in_govspeak_fields) { create(:travel_advice_edition, summary: "This is a [link](https://www.example.com)") }
+    let(:edition_with_links_in_parts) { create(:travel_advice_edition_with_parts) }
+    let(:edition_with_absolute_paths_in_govspeak_fields) { create(:travel_advice_edition, summary: "This is a [link](https://www.example.com). This is an absolute [path](/id-for-driving-licence)") }
 
     it "should not error when edition has no links" do
       result = call_edition_link_extractor(edition_with_no_links)

--- a/spec/services/edition_link_extractor_spec.rb
+++ b/spec/services/edition_link_extractor_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 RSpec.describe EditionLinkExtractor do
   context ".call" do
     let(:edition_with_no_links) { FactoryBot.create(:travel_advice_edition) }

--- a/spec/services/link_check_report_updater_spec.rb
+++ b/spec/services/link_check_report_updater_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 RSpec.describe LinkCheckReportUpdater do
   let(:link_check_report) do
     FactoryBot.create(:travel_advice_edition_with_pending_link_checks,

--- a/spec/services/link_check_report_updater_spec.rb
+++ b/spec/services/link_check_report_updater_spec.rb
@@ -1,8 +1,7 @@
 RSpec.describe LinkCheckReportUpdater do
   let(:link_check_report) do
-    FactoryBot.create(:travel_advice_edition_with_pending_link_checks,
-                       batch_id: 1,
-                       link_uris: ['http://www.example.com', 'http://www.gov.com']).link_check_reports.first
+    create(:travel_advice_edition_with_pending_link_checks,
+           batch_id: 1, link_uris: ['http://www.example.com', 'http://www.gov.com']).link_check_reports.first
   end
 
   let(:completed_at) { Time.now }

--- a/spec/support/authentication.rb
+++ b/spec/support/authentication.rb
@@ -8,7 +8,7 @@ module AuthenticationControllerHelpers
   end
 
   def stub_user
-    FactoryBot.create(:user)
+    create(:user)
   end
 
   def login_as_stub_user
@@ -23,7 +23,7 @@ module AuthenticationFeatureHelpers
   end
 
   def stub_user
-    FactoryBot.create(:user)
+    create(:user)
   end
 
   def login_as_stub_user

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end

--- a/spec/support/gds_api.rb
+++ b/spec/support/gds_api.rb
@@ -18,3 +18,9 @@ RSpec.configuration.before :each, type: :feature do
 end
 
 RSpec.configuration.include GdsApiHelpers, type: :rake_task
+
+require "gds_api/asset_manager"
+require "gds_api/exceptions"
+require "gds_api/test_helpers/email_alert_api"
+require "gds_api/test_helpers/link_checker_api"
+require "gds_api/test_helpers/publishing_api_v2"

--- a/spec/support/govuk_sidekiq.rb
+++ b/spec/support/govuk_sidekiq.rb
@@ -1,0 +1,1 @@
+require "govuk_sidekiq/testing"

--- a/spec/tasks/email_alerts_rake_spec.rb
+++ b/spec/tasks/email_alerts_rake_spec.rb
@@ -14,7 +14,7 @@ describe "Email alert rake tasks", type: :rake_task do
     let(:country_slug) { "aruba" }
 
     it "triggers an email notification for the given edition ID" do
-      edition = FactoryBot.create(:published_travel_advice_edition, country_slug: country_slug)
+      edition = create(:published_travel_advice_edition, country_slug: country_slug)
 
       task.invoke(edition.id)
 

--- a/spec/tasks/email_alerts_rake_spec.rb
+++ b/spec/tasks/email_alerts_rake_spec.rb
@@ -1,4 +1,3 @@
-require "spec_helper"
 require "rake"
 
 describe "Email alert rake tasks", type: :rake_task do

--- a/spec/tasks/publishing_api_rake_spec.rb
+++ b/spec/tasks/publishing_api_rake_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'rake'
 
 describe "publishing_api rake tasks", type: :rake_task do

--- a/spec/tasks/publishing_api_rake_spec.rb
+++ b/spec/tasks/publishing_api_rake_spec.rb
@@ -48,7 +48,7 @@ describe "publishing_api rake tasks", type: :rake_task do
     let(:task) { Rake::Task['publishing_api:republish_edition'] }
 
     it "sends the published edition to the publishing_api with update_type of 'republish'" do
-      edition = FactoryBot.create(:published_travel_advice_edition, country_slug: 'aruba')
+      edition = create(:published_travel_advice_edition, country_slug: 'aruba')
 
       task.invoke(country.slug)
 
@@ -66,7 +66,7 @@ describe "publishing_api rake tasks", type: :rake_task do
     end
 
     it 'ignore draft items' do
-      FactoryBot.create(:draft_travel_advice_edition, country_slug: country.slug)
+      create(:draft_travel_advice_edition, country_slug: country.slug)
 
       task.invoke(country.slug)
 
@@ -82,8 +82,8 @@ describe "publishing_api rake tasks", type: :rake_task do
     let(:task) { Rake::Task['publishing_api:republish_editions'] }
 
     it "sends all published editions to the publishing_api with update_type of 'republish'" do
-      aruba = FactoryBot.create(:published_travel_advice_edition, country_slug: 'aruba', published_at: 10.minutes.ago)
-      algeria = FactoryBot.create(:published_travel_advice_edition, country_slug: 'algeria', published_at: 5.minutes.ago)
+      aruba = create(:published_travel_advice_edition, country_slug: 'aruba', published_at: 10.minutes.ago)
+      algeria = create(:published_travel_advice_edition, country_slug: 'algeria', published_at: 5.minutes.ago)
 
       task.invoke
 
@@ -111,8 +111,8 @@ describe "publishing_api rake tasks", type: :rake_task do
     end
 
     it "ignores draft items" do
-      FactoryBot.create(:draft_travel_advice_edition, country_slug: 'aruba', published_at: 10.minutes.ago)
-      FactoryBot.create(:published_travel_advice_edition, country_slug: 'algeria', published_at: 5.minutes.ago)
+      create(:draft_travel_advice_edition, country_slug: 'aruba', published_at: 10.minutes.ago)
+      create(:published_travel_advice_edition, country_slug: 'algeria', published_at: 5.minutes.ago)
 
       task.invoke
 

--- a/spec/validators/link_validator_spec.rb
+++ b/spec/validators/link_validator_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe LinkValidator do
   class LinkValidatorDummy
     include Mongoid::Document

--- a/spec/validators/safe_html_validator_spec.rb
+++ b/spec/validators/safe_html_validator_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe SafeHtml do
   class Dummy
     include Mongoid::Document

--- a/spec/workers/email_alert_api_worker_spec.rb
+++ b/spec/workers/email_alert_api_worker_spec.rb
@@ -1,7 +1,3 @@
-require "spec_helper"
-require "sidekiq/testing"
-require "gds_api/test_helpers/email_alert_api"
-
 RSpec.describe EmailAlertApiWorker, :perform do
   include GdsApi::TestHelpers::EmailAlertApi
 

--- a/spec/workers/publishing_api_worker_spec.rb
+++ b/spec/workers/publishing_api_worker_spec.rb
@@ -1,8 +1,3 @@
-require "spec_helper"
-require "gds_api/test_helpers/email_alert_api"
-require "gds_api/test_helpers/publishing_api_v2"
-require "sidekiq/testing"
-
 RSpec.describe PublishingApiWorker, :perform do
   include GdsApi::TestHelpers::EmailAlertApi
   include GdsApi::TestHelpers::PublishingApiV2

--- a/spec/workers/worker_error_spec.rb
+++ b/spec/workers/worker_error_spec.rb
@@ -1,5 +1,3 @@
-require "spec_helper"
-
 describe WorkerError do
   let(:instance) { Object.new }
   let(:error) { StandardError.new("some error message") }


### PR DESCRIPTION
This auto-requires `spec_helper` to avoid include it in every file and removes the need for `FactoryBot.` prefix similar to what we've done in other apps.

I've also done a bundle update so we have the latest Gems.

[Trello Card](https://trello.com/c/YUxGB4tl/980-fix-security-vulnerability-in-travel-advice-publisher)