### PR TITLE
Add missing GOVUK_WEBSITE_ROOT env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN bundle install
 ADD . $APP_HOME
 
 RUN GOVUK_APP_DOMAIN=www.gov.uk \
-  GOVUK_WEBSITE_ROOT==www.gov.uk \
+  GOVUK_WEBSITE_ROOT=www.gov.uk \
   RAILS_ENV=production \
   bundle exec rails assets:precompile
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,10 @@ ADD Gemfile* $APP_HOME/
 RUN bundle install
 ADD . $APP_HOME
 
-RUN GOVUK_APP_DOMAIN=www.gov.uk RAILS_ENV=production bundle exec rails assets:precompile
+RUN GOVUK_APP_DOMAIN=www.gov.uk \
+  GOVUK_WEBSITE_ROOT==www.gov.uk \
+  RAILS_ENV=production \
+  bundle exec rails assets:precompile
 
 HEALTHCHECK CMD curl --silent --fail localhost:$PORT || exit 1
 


### PR DESCRIPTION
The Docker build as part of the Jenkins job requires vertain env vars
to run. This fixes a broken build.