### PR TITLE
Add Burma in parenthesis

### DIFF
--- a/lib/data/countries.yml
+++ b/lib/data/countries.yml
@@ -559,7 +559,7 @@
   slug: mozambique
   content_id: eb77a950-bd40-4a8d-8f3b-1f92d126930d
   email_signup_content_id: 753ce9ff-afda-452e-bc9c-0f17d00d162a
-- name: Myanmar
+- name: Myanmar (Burma)
   slug: myanmar
   content_id: ed343e59-83ca-496b-84b1-8f85c71a747d
   email_signup_content_id: 38913925-e2e8-473a-a9ff-012f3eb6f2bf


### PR DESCRIPTION
The department would like to display the word Burma in parenthesis next
to Myanmar.
