### PR TITLE
Display Myanmar and not Myanmar (Burma) in summary

### DIFF
--- a/lib/data/countries.yml
+++ b/lib/data/countries.yml
@@ -559,7 +559,7 @@
   slug: mozambique
   content_id: eb77a950-bd40-4a8d-8f3b-1f92d126930d
   email_signup_content_id: 753ce9ff-afda-452e-bc9c-0f17d00d162a
-- name: Myanmar (Burma)
+- name: Myanmar
   slug: myanmar
   content_id: ed343e59-83ca-496b-84b1-8f85c71a747d
   email_signup_content_id: 38913925-e2e8-473a-a9ff-012f3eb6f2bf


### PR DESCRIPTION
This updates the summary displayed when signing up to email alerts

Before:
![Screen Shot 2019-07-15 at 16 17 12](https://user-images.githubusercontent.com/6651749/61227480-4b8d8700-a71c-11e9-94ae-b52041c5b1bb.png)

After:
![Screen Shot 2019-07-15 at 16 17 20](https://user-images.githubusercontent.com/6651749/61227486-4f210e00-a71c-11e9-9696-736797ff5c14.png)

Trello: https://trello.com/c/DauneS2z