### PR TITLE
Fix missing dependencies with rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,18 +2,6 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require File.expand_path("../config/application", __FILE__)
-require "rubocop/rake_task"
-require 'scss_lint/rake_task'
-
 Rails.application.load_tasks
 
-RuboCop::RakeTask.new(:rubocop) do |t|
-  t.patterns = %w(app config lib spec)
-end
-
-SCSSLint::RakeTask.new do |t|
-  t.files = Dir.glob(["app/assets/stylesheets"])
-end
-
-task default: [:spec, "jasmine:ci", :rubocop, :scss_lint]
-task lint: [:rubocop, :scss_lint]
+task default: [:spec, "jasmine:ci"]

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,15 @@
+unless Rails.env.production?
+  require "rubocop/rake_task"
+  require "scss_lint/rake_task"
+
+  RuboCop::RakeTask.new(:rubocop) do |t|
+    t.patterns = %w(app config lib spec)
+  end
+
+  SCSSLint::RakeTask.new do |t|
+    t.files = Dir.glob(["app/assets/stylesheets"])
+  end
+
+  task lint: %i[rubocop scss_lint]
+  task(:default).prerequisites << task(:lint)
+end


### PR DESCRIPTION
Rake is unable to use the Rakefile when only production dependencies are installed. This is because the Rakefile uses RuboCop and scss_lint to define a rake task and is only available as a test dependency.