### PR TITLE
Fix deployment errors due to rubocop

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,18 +2,21 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require File.expand_path("../config/application", __FILE__)
-require "rubocop/rake_task"
-require 'scss_lint/rake_task'
 
 Rails.application.load_tasks
 
-RuboCop::RakeTask.new(:rubocop) do |t|
-  t.patterns = %w(app config lib spec)
-end
+unless Rails.env.production?
+  require "rubocop/rake_task"
+  require 'scss_lint/rake_task'
 
-SCSSLint::RakeTask.new do |t|
-  t.files = Dir.glob(["app/assets/stylesheets"])
-end
+  RuboCop::RakeTask.new(:rubocop) do |t|
+    t.patterns = %w(app config lib spec)
+  end
 
-task default: [:spec, "jasmine:ci", :rubocop, :scss_lint]
-task lint: [:rubocop, :scss_lint]
+  SCSSLint::RakeTask.new do |t|
+    t.files = Dir.glob(["app/assets/stylesheets"])
+  end
+
+  task default: [:spec, "jasmine:ci", :rubocop, :scss_lint]
+  task lint: [:rubocop, :scss_lint]
+end


### PR DESCRIPTION
Fixes error observed in deploy app Jenkins job:

> executing "cd /data/apps/travel-advice-publisher/releases/20191205163704 && govuk_setenv travel-advice-publisher bundle exec rake RAILS_ENV=production RAILS_GROUPS=assets assets:precompile"
> 16:37:05     executing command
> 16:37:08 *** [err :: ip-xxx.compute.internal] rake aborted!
> 16:37:08 *** [err :: ip-xxx.compute.internal] LoadError: cannot load such file -- rubocop/rake_task
(Lines removed for brevity)

(in https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/19875/console for example)

The rubocop gem is only in test/development groups in the gemfile so is unavailable when running the rake task to precompile assets.