### PR TITLE
Change recently published time range

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -4,11 +4,11 @@ class HealthcheckController < ApplicationController
   skip_before_action :set_authenticated_user_header
 
   # Renders a JSON array of all travel advice editions published between
-  # 1 hour and 2 days ago. This is used by email-alert-monitoring to ensure
+  # 90 minutes and 2 days ago. This is used by email-alert-monitoring to ensure
   # that all published editions have been sent to publishing-api and triggered
   # an email alert.
   def recently_published_editions
-    editions = editions_published_between_2_days_and_1_hour_ago.each.map do |edition|
+    editions = editions_published_between_2_days_and_90_minutes_ago.each.map do |edition|
       {
         title: edition.title,
         published_at: edition.published_at,
@@ -20,11 +20,11 @@ class HealthcheckController < ApplicationController
 
 private
 
-  def editions_published_between_2_days_and_1_hour_ago
+  def editions_published_between_2_days_and_90_minutes_ago
     TravelAdviceEdition.published.where(
       :published_at.gte => 2.days.ago,
     ).where(
-      :published_at.lte => 1.hour.ago,
+      :published_at.lte => 90.minutes.ago,
     ).order_by(
       published_at: :desc,
     )

--- a/spec/controllers/healthcheck_spec.rb
+++ b/spec/controllers/healthcheck_spec.rb
@@ -2,13 +2,7 @@ describe HealthcheckController, type: :controller do
   include Rails.application.routes.url_helpers
 
   describe "#recently_published_editions" do
-    let(:travel_advice_edition) { create(:travel_advice_edition, published_at: 2.hours.ago) }
-
-    before do
-      controller.stub(:editions_published_between_2_days_and_1_hour_ago) do
-        [travel_advice_edition]
-      end
-    end
+    let!(:travel_advice_edition) { create(:published_travel_advice_edition, published_at: 2.hours.ago) }
 
     it "should return the title and published_at of recently published editions" do
       get :recently_published_editions


### PR DESCRIPTION
This changes the time range used to find recently published documents so only ones that have been published more than 90 minutes ago appear in the list rather than 1 hour as it is currently.

We've been seeing more and more travel advice documents being published and this had to lead to increased latency of emails. This alert fires which means that people get called up, but there's nothing for them to do except wait for the emails to go out. Rather than calling people, we can give the system half an hour longer to send out the emails.