### PR TITLE
Clarify edition change form

### DIFF
--- a/app/assets/javascripts/admin/editions/form.js
+++ b/app/assets/javascripts/admin/editions/form.js
@@ -1,0 +1,21 @@
+var adminEditionsForm = {
+  showChangeNotesIfMajorChange: function showChangeNotesIfMajorChange() {
+    var $form                      = $(".js-edition-form");
+    var $fieldset                  = $('.js-change-notes', this.$form);
+    var $radio_buttons             = $('input[type=radio]', $fieldset);
+    var $minor_change_radio_button = $('.js-edition-update-minor', $fieldset);
+    var $change_notes_section      = $('.js-change-notes-section', $fieldset);
+
+    $radio_buttons.change(showOrHideChangeNotes);
+    showOrHideChangeNotes();
+
+    function showOrHideChangeNotes() {
+      if ($minor_change_radio_button.prop('checked')){
+        $change_notes_section.slideUp(200);
+      }
+      else {
+        $change_notes_section.slideDown(200);
+      }
+    }
+  }
+}

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -71,10 +71,7 @@ $(function() {
     $("#clone-edition").submit();
   });
 
-  $("#edition_minor_update").change(function() {
-    TravelAdviceUtils.setChangeDescriptionVisibility($(this));
-  });
-  TravelAdviceUtils.setChangeDescriptionVisibility($("#edition_minor_update"));
+  adminEditionsForm.showChangeNotesIfMajorChange();
 
   $(".js-add-related-item").on("click", function () {
     var relatedItems = $(".js-related-items"),

--- a/app/assets/javascripts/travel_advice_utils.js
+++ b/app/assets/javascripts/travel_advice_utils.js
@@ -2,11 +2,4 @@ var TravelAdviceUtils = {
   convertToSlug: function(title) {
     return title.toLowerCase().replace(/[^\w ]+/g,'').replace(/ +/g,'-');
   },
-  setChangeDescriptionVisibility: function($elem) {
-    if ($elem.is(':checked')) {
-      $("#major_update_input").hide();
-    } else {
-      $("#major_update_input").show();
-    }
-  }
 }

--- a/app/models/travel_advice_edition.rb
+++ b/app/models/travel_advice_edition.rb
@@ -143,6 +143,10 @@ class TravelAdviceEdition
     link_check_reports.last
   end
 
+  def update?
+    version_number > 1
+  end
+
 private
 
   def state_for_slug_unique

--- a/app/views/admin/editions/_change_notes.html.erb
+++ b/app/views/admin/editions/_change_notes.html.erb
@@ -1,0 +1,32 @@
+<fieldset class="js-change-notes">
+  <%= f.inputs :name => "What sort of change are you making?" do %>
+    <% if @edition.update? %>
+      <div class="radio">
+        <%= label_tag do %>
+          <%= f.radio_button(:minor_update, true, class: "js-edition-update-minor") %>
+          <strong>A typo, style change or similar</strong> (no update is sent to email subscribers)
+        <% end %>
+      </div>
+    <% end %>
+
+    <div class="radio">
+      <%= label_tag do %>
+        <%= f.radio_button(:minor_update, false, class: "js-edition-update-major") %>
+        <strong>A significant change, for example a new travel restriction</strong> (sends an email to all subscribers and adds a change note to the summary page)
+      <% end %>
+    </div>
+
+    <div class="form-group js-change-notes-section">
+      <%= f.label :change_description, "Public change note" %>
+      <%= f.text_area(:change_description,
+                      rows: 4,
+                      placeholder: 'For example: "Addition of information and advice about planned protests on 5 January (Summary page)" or "Updated information on passport validity requirements (Entry Requirements page)"',
+                      label_text: "Public change note",
+                      required: true,
+                      class: "form-control",
+                      disabled: ! @edition.draft?) %>
+    </div>
+
+    <p>Read the <a href="https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes" target="_blank">guidance about change notes</a> (opens in a new tab).</p>
+  <% end %>
+</fieldset>

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -10,7 +10,7 @@
   <h1>Editing <%= @country.name %> <small>Version <%= @edition.version_number %></small></h1>
 </div>
 
-<%= semantic_form_for @edition, :url => admin_edition_path(@edition), :as => :edition do |f| %>
+<%= semantic_form_for @edition, :url => admin_edition_path(@edition), :as => :edition, class: "js-edition-form" do |f| %>
   <div class="tabbable">
     <ul class="nav nav-tabs">
       <li class="active"><a href="#edit" data-toggle="tab">Edit</a></li>
@@ -20,22 +20,7 @@
     <div class="tab-content add-bottom-margin">
       <div class="tab-pane active row" id="edit">
         <div class="col-md-8">
-          <%= f.inputs :name => "Type of update" do %>
-            <% unless @edition.version_number == 1 %>
-              <h5>Minor update</h5>
-              <p>Tick the box if the only change you're making is minor (eg fixing a typo or a small change to wording).</p>
-              <%= f.input :minor_update, :as => :boolean, :input_html => { :disabled => ! @edition.draft? } %>
-            <% end %>
-
-            <div id="major_update_input">
-              <h5>Major update</h5>
-              <% unless @edition.version_number == 1 %>
-                <p>If the change is major, leave a description below. An email will be sent to subscribers with your description of the change.</p>
-              <% end %>
-              <%= f.input :change_description, :as => :text, :label => "Change description (plain text)", :required => true, :input_html => {
-                :class => "input-md-8", :rows => 4, :disabled => ! @edition.draft? } %>
-            </div>
-          <% end %>
+          <%= render "change_notes", f: f %>
 
           <%= f.inputs :name => "Metadata" do %>
             <%= f.input :title, :label => "Search title (plain text)", :required => true, :input_html => { :disabled => ! @edition.draft?, :class => "input-md-8" } %>

--- a/spec/features/edition_edit_spec.rb
+++ b/spec/features/edition_edit_spec.rb
@@ -136,10 +136,10 @@ feature "Edit Edition page", js: true do
     within("h1") { expect(page).to have_content "Editing Albania Version 1" }
 
     within "#edit" do
-      within_section "the fieldset labelled Type of update" do
+      within_section "the fieldset labelled What sort of change are you making?" do
         # The first version can't be a minor update...
-        expect(page).not_to have_field("Minor update")
-        expect(page).to have_field("Change description (plain text)")
+        expect(page).not_to have_field("A typo, style change or similar (no update is sent to email subscribers)")
+        expect(page).to have_field("Public change note")
       end
 
       within_section "the fieldset labelled Metadata" do
@@ -168,7 +168,7 @@ feature "Edit Edition page", js: true do
     fill_in "Search title", with: "Travel advice for Albania"
     fill_in "Search description", with: "Read this if you're planning on visiting Albania"
 
-    fill_in "Change description", with: "Made changes to all the stuff"
+    fill_in "Public change note", with: "Made changes to all the stuff"
 
     fill_in "Summary", with: "Summary of the situation in Albania"
 
@@ -241,13 +241,14 @@ feature "Edit Edition page", js: true do
     within("h1") { expect(page).to have_content "Editing Albania Version 2" }
 
     within "#edit" do
-      within_section "the fieldset labelled Type of update" do
-        expect(page).to have_checked_field("Minor update")
+      within_section "the fieldset labelled What sort of change are you making?" do
+        expect(page).to have_checked_field("A typo, style change or similar (no update is sent to email subscribers)")
 
-        expect(page.find_field("Change description", visible: false)).not_to be_visible
+        choose("A typo, style change or similar (no update is sent to email subscribers)")
+        expect(page.find_field("Public change note", visible: false)).not_to be_visible
 
-        uncheck "Minor update"
-        expect(page.find_field("Change description")).to be_visible
+        choose("A significant change, for example a new travel restriction (sends an email to all subscribers and adds a change note to the summary page)")
+        expect(page.find_field("Public change note")).to be_visible
       end
     end
 
@@ -420,7 +421,7 @@ feature "Edit Edition page", js: true do
       visit "/admin/editions/#{@edition.to_param}/edit"
 
       fill_in "Summary", with: "## The summary"
-      check "Minor update"
+      choose "A typo, style change or similar (no update is sent to email subscribers)"
 
       click_on "Save & Publish"
     end

--- a/spec/models/travel_advice_edition_spec.rb
+++ b/spec/models/travel_advice_edition_spec.rb
@@ -659,4 +659,18 @@ describe TravelAdviceEdition do
       expect(edition.latest_link_check_report).to eq(latest_report)
     end
   end
+
+  describe "a first edition" do
+    it "is not an update" do
+      ta = build(:travel_advice_edition, version_number: 1)
+      expect(ta).not_to be_update
+    end
+  end
+
+  describe "subsequent edition" do
+    it "is an update" do
+      ta2 = build(:travel_advice_edition, version_number: 2)
+      expect(ta2).to be_update
+    end
+  end
 end


### PR DESCRIPTION
# What
In tandem with a push to ensure travel advice publishers have clear expectations about when emails will be sent - we can clarify the publishing interface to remind them of guidance / rules.

# Why
We have at least once case study of FCO sending 4 "minor" updates tagged as major to uses in a single day. This is a bad experience for users and leads to thousands of unnecessary emails.

# Solution

Whitehall's admin interface is very clear about when users will receive emails after existing content has been added. This PR brings travel advice publisher into line with Whitehall.

## Before

<img width="656" alt="Screenshot 2020-03-30 at 14 50 37" src="https://user-images.githubusercontent.com/3141541/77920036-d821aa80-7295-11ea-953a-fefcee756275.png">

## After

<img width="654" alt="Screenshot 2020-03-30 at 14 49 39" src="https://user-images.githubusercontent.com/3141541/77919933-b6282800-7295-11ea-9b29-818a51c8d33f.png">


# Checklist

* [x] Confirm copy

---

https://trello.com/c/XwFxyM8X/33-travel-advice-publisher-make-admin-interface-clearer-when-emails-will-be-sent