### PR TITLE
Return editions published 150 minutes ago or earlier

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -8,7 +8,7 @@ class HealthcheckController < ApplicationController
   # that all published editions have been sent to publishing-api and triggered
   # an email alert.
   def recently_published_editions
-    editions = editions_published_between_2_days_and_90_minutes_ago.each.map do |edition|
+    editions = editions_published_between_2_days_and_150_minutes_ago.each.map do |edition|
       {
         title: edition.title,
         published_at: edition.published_at,
@@ -20,11 +20,11 @@ class HealthcheckController < ApplicationController
 
 private
 
-  def editions_published_between_2_days_and_90_minutes_ago
+  def editions_published_between_2_days_and_150_minutes_ago
     TravelAdviceEdition.published.where(
       :published_at.gte => 2.days.ago,
     ).where(
-      :published_at.lte => 90.minutes.ago,
+      :published_at.lte => 150.minutes.ago,
     ).order_by(
       published_at: :desc,
     )

--- a/spec/controllers/healthcheck_spec.rb
+++ b/spec/controllers/healthcheck_spec.rb
@@ -2,7 +2,7 @@ describe HealthcheckController, type: :controller do
   include Rails.application.routes.url_helpers
 
   describe "#recently_published_editions" do
-    let!(:travel_advice_edition) { create(:published_travel_advice_edition, published_at: 2.hours.ago) }
+    let!(:travel_advice_edition) { create(:published_travel_advice_edition, published_at: 160.minutes.ago) }
 
     it "should return the title and published_at of recently published editions" do
       get :recently_published_editions


### PR DESCRIPTION
We were paged again for travel advice not reaching the courtesy copies
group. This was caused by large queues which had a knock on effect of
causing delays in sending courtesy copies.

Relax our thresholds so we only return editions published more than 150
minutes ago. This will give us 2.5 hours to process queues and get
courtesy copies out which should help ease our out of hours alerts while
we deal with such large amounts of publishing.