### PR TITLE
Remove redundant RuboCop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,21 +7,11 @@ inherit_mode:
   merge:
     - Exclude
 
-AllCops:
-  Exclude:
-    - db/migrate/201*.rb
-
-
-# Mongoid doesn't support some of the methods that Rubocop prefers
-Rails/FindBy:
-  Enabled: false
-
+# This is not supported for Mongoid
 Rails/FindEach:
   Enabled: false
 
+# This is not supported for Mongoid
 Rails/DynamicFindBy:
   Whitelist:
     - find_by_slug
-
-Rails/OutputSafety:
-  Enabled: false

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,7 +19,7 @@ module ApplicationHelper
   end
 
   def timestamp(time)
-    %(<time datetime="#{time.strftime('%Y-%m-%dT%H:%M:%SZ')}">#{time.strftime('%d/%m/%Y %H:%M %Z')}</time>).html_safe
+    %(<time datetime="#{time.strftime('%Y-%m-%dT%H:%M:%SZ')}">#{time.strftime('%d/%m/%Y %H:%M %Z')}</time>).html_safe # rubocop:disable Rails/OutputSafety
   end
 
   def alert_statuses_with_labels(keys)
@@ -28,6 +28,6 @@ module ApplicationHelper
   end
 
   def diff_html(version1, version2)
-    Diffy::Diff.new(version1, version2, allow_empty_diff: false).to_s(:html).html_safe
+    Diffy::Diff.new(version1, version2, allow_empty_diff: false).to_s(:html).html_safe # rubocop:disable Rails/OutputSafety
   end
 end

--- a/lib/formtastic_extensions.rb
+++ b/lib/formtastic_extensions.rb
@@ -56,7 +56,7 @@ module Formtastic #:nodoc:
       options = args.extract_options!
       css_selector = options.delete(:selector) || ".#{@object.class.name.split('::').last.underscore}"
       link = '<a href="#" class="btn btn-danger pull-right remove-associated" data-selector="' + css_selector + '">Remove part</a>'
-      output = hidden_field(:_destroy) + link.html_safe
+      output = hidden_field(:_destroy) + link.html_safe # rubocop:disable Rails/OutputSafety
       output
     end
 
@@ -69,7 +69,7 @@ module Formtastic #:nodoc:
       form.gsub!(/attributes_(\d+)/, "attributes_{{index}}")
       form.gsub!(/\[(\d+)\]/, "[{{index}}]")
 
-      "<script id='tmpl-#{association}' type='text/x-jquery-tmpl'>#{form}</script>".html_safe
+      "<script id='tmpl-#{association}' type='text/x-jquery-tmpl'>#{form}</script>".html_safe # rubocop:disable Rails/OutputSafety
     end
 
     # Render associated form


### PR DESCRIPTION
https://github.com/alphagov/rubocop-govuk/issues/73

We should avoid disabling Cops for the entire repo; this should be
a last resort when all other methods have been exhausted.