### PR TITLE
New travel advice edition has no default update type

### DIFF
--- a/app/assets/javascripts/admin/editions/form.js
+++ b/app/assets/javascripts/admin/editions/form.js
@@ -3,18 +3,17 @@ var adminEditionsForm = {
     var $form                      = $(".js-edition-form");
     var $fieldset                  = $('.js-change-notes', this.$form);
     var $radio_buttons             = $('input[type=radio]', $fieldset);
-    var $minor_change_radio_button = $('.js-edition-update-minor', $fieldset);
+    var $major_change_radio_button = $('.js-edition-update-major', $fieldset);
     var $change_notes_section      = $('.js-change-notes-section', $fieldset);
 
     $radio_buttons.change(showOrHideChangeNotes);
     showOrHideChangeNotes();
 
     function showOrHideChangeNotes() {
-      if ($minor_change_radio_button.prop('checked')){
-        $change_notes_section.slideUp(200);
-      }
-      else {
-        $change_notes_section.slideDown(200);
+      if ($major_change_radio_button.prop('checked')){
+        $change_notes_section.removeClass("js-hidden")
+      } else {
+        $change_notes_section.addClass("js-hidden")
       }
     }
   }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,3 +5,9 @@
 @import "sortable_accordion";
 @import "diff";
 @import "broken_links_report";
+
+.js-hidden {
+  .js & {
+    display: none;
+  }
+}

--- a/app/models/travel_advice_edition.rb
+++ b/app/models/travel_advice_edition.rb
@@ -17,10 +17,9 @@ class TravelAdviceEdition
   field :summary,              type: String,    default: ""
   field :change_description,   type: String
   field :minor_update,         type: Boolean
-  field :update_type,          type: String
-  field :synonyms,             type: Array, default: []
-  # This is the publicly presented publish time. For minor updates, this will be the publish time of the previous version
-  field :published_at,         type: Time
+  field :update_type,          type: String,    default: -> { "major" if first_version? }
+  field :synonyms,             type: Array,     default: []
+  field :published_at,         type: Time # This is the publicly presented publish time. For minor updates, this will be the publish time of the previous version
   field :reviewed_at,          type: Time
 
   embeds_many :actions
@@ -89,7 +88,7 @@ class TravelAdviceEdition
   end
 
   def is_minor_update?
-    update_type == "minor" || minor_update
+    update_type == "minor"
   end
 
   def build_clone(target_class = nil)
@@ -150,8 +149,8 @@ class TravelAdviceEdition
     link_check_reports.last
   end
 
-  def update?
-    version_number > 1
+  def first_version?
+    version_number == 1
   end
 
 private
@@ -201,7 +200,7 @@ private
   end
 
   def first_version_cant_be_minor_update
-    if is_minor_update? && version_number == 1
+    if is_minor_update? && first_version?
       errors.add(:update_type, "can't be minor for first version")
     end
   end

--- a/app/models/travel_advice_edition.rb
+++ b/app/models/travel_advice_edition.rb
@@ -17,8 +17,8 @@ class TravelAdviceEdition
   field :summary,              type: String,    default: ""
   field :change_description,   type: String
   field :minor_update,         type: Boolean
-  field :update_type,          type: String,    default: "major"
-  field :synonyms,             type: Array,     default: []
+  field :update_type,          type: String
+  field :synonyms,             type: Array, default: []
   # This is the publicly presented publish time. For minor updates, this will be the publish time of the previous version
   field :published_at,         type: Time
   field :reviewed_at,          type: Time
@@ -81,6 +81,7 @@ class TravelAdviceEdition
     state :published do
       validate :cannot_edit_published
       validates :change_description, presence: { unless: :is_minor_update?, message: "can't be blank on publish" }
+      validates :update_type, presence: { message: "can't be blank on publish" }
     end
     state :archived do
       validate :cannot_edit_archived

--- a/app/views/admin/editions/_change_notes.html.erb
+++ b/app/views/admin/editions/_change_notes.html.erb
@@ -1,11 +1,31 @@
 <fieldset class="js-change-notes">
   <%= f.inputs :name => "What sort of change are you making?" do %>
+    <% if !@edition.first_version? %>
+      <div class="radio">
+        <%= f.input :update_type,
+          label: false,
+          as: :radio,
+          collection: [
+            [
+              "<strong>A typo, style change or similar</strong> (no update is sent to email subscribers)".html_safe,
+              "minor",
+              { class: "js-edition-update-minor", disabled: !@edition.draft? }
+            ]
+          ]
+        %>
+      </div>
+    <% end %>
+
     <div class="radio">
       <%= f.input :update_type,
+        label: false,
         as: :radio,
         collection: [
-          ["A typo, style change or similar (no update is sent to email subscribers)", "minor", { class: "js-edition-update-minor" }],
-          ["A significant change, for example a new travel restriction (sends an email to all subscribers and adds a change note to the summary page)", "major", { class: "js-edition-update-major" }],
+          [
+            "<strong>A significant change, for example a new travel restriction</strong> (sends an email to all subscribers and adds a change note to the summary page)".html_safe,
+            "major",
+            { class: "js-edition-update-major", disabled: !@edition.draft? }
+          ]
         ]
       %>
     </div>
@@ -16,7 +36,7 @@
         as: :text,
         input_html: { class: "form-control",
                       rows: 4,
-                      disabled: ! @edition.draft?,
+                      disabled: !@edition.draft?,
                       required: true,
                       placeholder: 'For example: "Addition of information and advice about planned protests on 5 January (Summary page)" or "Updated information on passport validity requirements (Entry Requirements page)"' } %>
 

--- a/app/views/admin/editions/_change_notes.html.erb
+++ b/app/views/admin/editions/_change_notes.html.erb
@@ -1,22 +1,16 @@
 <fieldset class="js-change-notes">
   <%= f.inputs :name => "What sort of change are you making?" do %>
-    <% if @edition.update? %>
-      <div class="radio">
-        <%= label_tag do %>
-          <%= f.radio_button(:update_type, "minor", checked: @edition.is_minor_update?, class: "js-edition-update-minor") %>
-          <strong>A typo, style change or similar</strong> (no update is sent to email subscribers)
-        <% end %>
-      </div>
-    <% end %>
-
     <div class="radio">
-      <%= label_tag do %>
-        <%= f.radio_button(:update_type, "major", checked: !@edition.is_minor_update?, class: "js-edition-update-major") %>
-        <strong>A significant change, for example a new travel restriction</strong> (sends an email to all subscribers and adds a change note to the summary page)
-      <% end %>
+      <%= f.input :update_type,
+        as: :radio,
+        collection: [
+          ["A typo, style change or similar (no update is sent to email subscribers)", "minor", { class: "js-edition-update-minor" }],
+          ["A significant change, for example a new travel restriction (sends an email to all subscribers and adds a change note to the summary page)", "major", { class: "js-edition-update-major" }],
+        ]
+      %>
     </div>
 
-    <div class="form-group js-change-notes-section">
+    <div class="form-group js-change-notes-section js-hidden">
       <%= f.input :change_description,
         label: "Public change note",
         as: :text,

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -14,6 +14,7 @@ FactoryBot.define do
     sequence(:title) { |n| "Test Country #{n}" }
     sequence(:summary) { |n| "Travel advice about Test Country #{n}" }
     change_description { "Stuff changed" }
+    update_type { "major" }
   end
 
   # These factories only work when used with FactoryBot.create

--- a/spec/models/travel_advice_edition_spec.rb
+++ b/spec/models/travel_advice_edition_spec.rb
@@ -168,10 +168,17 @@ describe TravelAdviceEdition do
         expect(ta.errors.messages[:update_type]).to include("can't be minor for first version")
       end
 
-      it "allow other versions to be minor updates" do
+      it "allow subsequent versions to be minor updates" do
         create(:published_travel_advice_edition, country_slug: ta.country_slug)
         ta.update_type = "minor"
         expect(ta).to be_valid
+      end
+
+      it "requires a major/minor change flag" do
+        ta = create(:travel_advice_edition, state: "draft", update_type: nil)
+        ta.state = "published"
+        expect(ta).not_to be_valid
+        expect(ta.errors.messages[:update_type]).to include("can't be blank on publish")
       end
     end
 
@@ -230,6 +237,10 @@ describe TravelAdviceEdition do
       expect(TravelAdviceEdition.new).to be_draft
     end
 
+    it "is neither a minor or major update" do
+      expect(TravelAdviceEdition.new.update_type).to be_nil
+    end
+
     context "populating version_number" do
       it "sets version_number to 1 if there are no existing versions for the country" do
         ed = TravelAdviceEdition.new(country_slug: "foo")
@@ -259,7 +270,7 @@ describe TravelAdviceEdition do
       end
     end
 
-    it "is not minor_update" do
+    it "is not a minor update" do
       expect(TravelAdviceEdition.new.update_type).to_not eql("minor")
     end
   end

--- a/spec/models/travel_advice_edition_spec.rb
+++ b/spec/models/travel_advice_edition_spec.rb
@@ -201,7 +201,7 @@ describe TravelAdviceEdition do
         expect(ta).to be_valid
       end
 
-      it "s not required when just saving a draft" do
+      it "is not required when just saving a draft" do
         ta.change_description = ""
         expect(ta).to be_valid
       end
@@ -235,10 +235,6 @@ describe TravelAdviceEdition do
   context "fields on a new edition" do
     it "is in draft state" do
       expect(TravelAdviceEdition.new).to be_draft
-    end
-
-    it "is neither a minor or major update" do
-      expect(TravelAdviceEdition.new.update_type).to be_nil
     end
 
     context "populating version_number" do
@@ -673,17 +669,29 @@ describe TravelAdviceEdition do
     end
   end
 
-  describe "a first edition" do
-    it "is not an update" do
-      ta = build(:travel_advice_edition, version_number: 1)
-      expect(ta).not_to be_update
-    end
-  end
+  describe "the version of an edition" do
+    describe "the first version" do
+      it "is a major update" do
+        ta = TravelAdviceEdition.new(version_number: 1)
+        expect(ta.update_type).to eql("major")
+      end
 
-  describe "subsequent edition" do
-    it "is an update" do
-      ta2 = build(:travel_advice_edition, version_number: 2)
-      expect(ta2).to be_update
+      it "#first_version? is true" do
+        ta = TravelAdviceEdition.new(version_number: 1)
+        expect(ta).to be_first_version
+      end
+    end
+
+    describe "a subsequent version" do
+      it "#first_version? is false for subsequent versions" do
+        ta = TravelAdviceEdition.new(version_number: 2)
+        expect(ta).not_to be_first_version
+      end
+
+      it "is neither a minor or major update" do
+        ta = TravelAdviceEdition.new(version_number: 2)
+        expect(ta.update_type).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
At the moment the "significant change" radio button is pre-checked, which probably encourages publishers to treat this as the default.

We should make it unchecked by default, as per [the design system's guidance on radios](https://design-system.service.gov.uk/components/radios/).

https://trello.com/c/LWl84KOC/336-dont-pre-check-a-significant-change-for-example-a-new-travel-restriction-when-publishers-create-new-editions

## Before

<img width="778" alt="Screenshot 2020-06-17 at 17 07 39" src="https://user-images.githubusercontent.com/3141541/84922095-4cadfd80-b0bd-11ea-951d-10197e509edb.png">

## After

<img width="786" alt="Screenshot 2020-06-25 at 09 59 38" src="https://user-images.githubusercontent.com/3141541/85689524-9e144900-b6ca-11ea-8f08-f8f636751036.png">

Thank you your help @vanitabarrett ! 🎉 