### PR TITLE
Replace minor_update boolean attribute with update_type of type string

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -71,6 +71,7 @@ private
   def permitted_edition_attributes
     params.fetch(:edition, {}).permit(
       :minor_update,
+      :update_type,
       :change_description,
       :title,
       :overview,

--- a/app/models/travel_advice_edition.rb
+++ b/app/models/travel_advice_edition.rb
@@ -16,7 +16,7 @@ class TravelAdviceEdition
   field :alert_status,         type: Array,     default: []
   field :summary,              type: String,    default: ""
   field :change_description,   type: String
-  field :minor_update,         type: Boolean,   default: false
+  field :minor_update,         type: Boolean
   field :update_type,          type: String,    default: "major"
   field :synonyms,             type: Array,     default: []
   # This is the publicly presented publish time. For minor updates, this will be the publish time of the previous version

--- a/app/notifiers/email_alert_api_notifier.rb
+++ b/app/notifiers/email_alert_api_notifier.rb
@@ -14,7 +14,7 @@ module EmailAlertApiNotifier
     def send_alert?(edition)
       Rails.application.config.send_email_alerts &&
         edition.state == "published" &&
-        !edition.minor_update
+        !edition.is_minor_update?
     end
   end
 end

--- a/app/notifiers/publishing_api_notifier.rb
+++ b/app/notifiers/publishing_api_notifier.rb
@@ -59,7 +59,7 @@ private
   end
 
   def send_alert?(edition)
-    edition.state == "published" && !edition.minor_update
+    edition.state == "published" && !edition.is_minor_update?
   end
 
   def validate_tasks_order

--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -10,7 +10,7 @@ class EditionPresenter
   def update_type
     if @republish
       "republish"
-    elsif edition.minor_update
+    elsif edition.is_minor_update?
       "minor"
     else
       "major"

--- a/app/views/admin/editions/_change_notes.html.erb
+++ b/app/views/admin/editions/_change_notes.html.erb
@@ -3,7 +3,7 @@
     <% if @edition.update? %>
       <div class="radio">
         <%= label_tag do %>
-          <%= f.radio_button(:minor_update, true, class: "js-edition-update-minor") %>
+          <%= f.radio_button(:update_type, "minor", checked: @edition.is_minor_update?, class: "js-edition-update-minor") %>
           <strong>A typo, style change or similar</strong> (no update is sent to email subscribers)
         <% end %>
       </div>
@@ -11,7 +11,7 @@
 
     <div class="radio">
       <%= label_tag do %>
-        <%= f.radio_button(:minor_update, false, class: "js-edition-update-major") %>
+        <%= f.radio_button(:update_type, "major", checked: !@edition.is_minor_update?, class: "js-edition-update-major") %>
         <strong>A significant change, for example a new travel restriction</strong> (sends an email to all subscribers and adds a change note to the summary page)
       <% end %>
     </div>

--- a/spec/features/edition_edit_spec.rb
+++ b/spec/features/edition_edit_spec.rb
@@ -247,7 +247,7 @@ feature "Edit Edition page", js: true do
 
   scenario "Seeing the minor update toggle on the edit form for non-first versions" do
     create(:published_travel_advice_edition, country_slug: "albania")
-    @edition = create(:draft_travel_advice_edition, country_slug: "albania", minor_update: true)
+    @edition = create(:draft_travel_advice_edition, country_slug: "albania", update_type: "minor")
     visit "/admin/editions/#{@edition._id}/edit"
 
     within("h1") { expect(page).to have_content "Editing Albania Version 2" }
@@ -267,7 +267,7 @@ feature "Edit Edition page", js: true do
     click_navbar_button "Save"
 
     @edition.reload
-    expect(@edition.minor_update).to eq(false)
+    expect(@edition.update_type).to eq("major")
   end
 
   scenario "slug for expect(parts).to be automatically generated" do
@@ -386,7 +386,7 @@ feature "Edit Edition page", js: true do
       title: "Albania travel advice",
       alert_status: TravelAdviceEdition::ALERT_STATUSES[1..0],
       change_description: "Stuff changed",
-      minor_update: false,
+      update_type: "major",
       overview: "The overview",
       summary: "## Summary",
     )
@@ -427,7 +427,7 @@ feature "Edit Edition page", js: true do
         country_slug: "albania",
         summary: "## The summaryy",
         change_description: "Some things changed",
-        minor_update: false,
+        update_type: "major",
       )
     end
     travel_to(2.days.ago) do

--- a/spec/models/travel_advice_edition_spec.rb
+++ b/spec/models/travel_advice_edition_spec.rb
@@ -11,7 +11,7 @@ describe TravelAdviceEdition do
       ed.image_id = "id_from_the_asset_manager_for_an_image"
       ed.document_id = "id_from_the_asset_manager_for_a_document"
       ed.published_at = Time.zone.parse("2013-02-21T14:56:22Z")
-      ed.minor_update = true
+      ed.update_type = "minor"
       ed.change_description = "Some things"
       ed.synonyms = %w[Foo Bar]
       ed.parts.build(title: "Part One", slug: "one")
@@ -27,7 +27,7 @@ describe TravelAdviceEdition do
       expect(ed.image_id).to eq("id_from_the_asset_manager_for_an_image")
       expect(ed.document_id).to eq("id_from_the_asset_manager_for_a_document")
       expect(ed.published_at).to eq(Time.zone.parse("2013-02-21T14:56:22Z"))
-      expect(ed.minor_update).to be true
+      expect(ed.update_type).to eql("minor")
       expect(ed.synonyms).to eq(%w[Foo Bar])
       expect(ed.change_description).to eq("Some things")
       expect(ed.parts.first.title).to eq("Part One")
@@ -163,14 +163,14 @@ describe TravelAdviceEdition do
 
     context "on minor update" do
       it "does not allow first version to be minor update" do
-        ta.minor_update = true
+        ta.update_type = "minor"
         expect(ta).not_to be_valid
-        expect(ta.errors.messages[:minor_update]).to include("can't be set for first version")
+        expect(ta.errors.messages[:update_type]).to include("can't be minor for first version")
       end
 
       it "allow other versions to be minor updates" do
         create(:published_travel_advice_edition, country_slug: ta.country_slug)
-        ta.minor_update = true
+        ta.update_type = "minor"
         expect(ta).to be_valid
       end
     end
@@ -189,7 +189,7 @@ describe TravelAdviceEdition do
         ta.version_number = 2
         ta.save!
         ta.change_description = ""
-        ta.minor_update = true
+        ta.update_type = "minor"
         ta.state = "published"
         expect(ta).to be_valid
       end
@@ -260,7 +260,7 @@ describe TravelAdviceEdition do
     end
 
     it "is not minor_update" do
-      expect(TravelAdviceEdition.new.minor_update).to be false
+      expect(TravelAdviceEdition.new.update_type).to_not eql("minor")
     end
   end
 
@@ -345,14 +345,14 @@ describe TravelAdviceEdition do
       end
 
       it "sets the published_at to the previous version's published_at for a minor update" do
-        ed.minor_update = true
+        ed.update_type = "minor"
         ed.publish!
         expect(ed.published_at).to eq(published.published_at)
       end
     end
 
     it "sets the change_description to the previous version's change_description for a minor update" do
-      ed.minor_update = true
+      ed.update_type = "minor"
       ed.publish!
       expect(ed.change_description).to eq(published.change_description)
     end
@@ -376,7 +376,7 @@ describe TravelAdviceEdition do
     end
 
     it "is set to the previous version's reviewed_at when a minor update is published" do
-      @ed.minor_update = true
+      @ed.update_type = "minor"
       @ed.publish!
       expect(@ed.reviewed_at).to eq(@published.reviewed_at)
     end
@@ -390,7 +390,7 @@ describe TravelAdviceEdition do
     end
 
     it "is able to update reviewed_at on a published edition" do
-      @ed.minor_update = true
+      @ed.update_type = "minor"
       @ed.publish!
       travel_to(1.day.from_now) do
         new_time = Time.zone.now
@@ -436,7 +436,7 @@ describe TravelAdviceEdition do
       end
 
       it "adds a 'publish' action with 'Minor update' as comment on publish of a minor_update" do
-        edition.minor_update = true
+        edition.update_type = "minor"
         edition.publish_as(user)
         edition.reload
         expect(edition.actions.size).to eq(1)

--- a/spec/notifiers/email_alert_api_notifier_spec.rb
+++ b/spec/notifiers/email_alert_api_notifier_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe EmailAlertApiNotifier do
 
   context "when the update_type is minor" do
     before do
-      edition.minor_update = true
+      edition.update_type = "minor"
       edition.save!(validate: false)
     end
 

--- a/spec/notifiers/publishing_api_notifier_spec.rb
+++ b/spec/notifiers/publishing_api_notifier_spec.rb
@@ -116,7 +116,7 @@ RSpec.describe PublishingApiNotifier do
 
     context "for a minor update" do
       it "doesn't enqueue anything" do
-        edition.update(minor_update: true)
+        edition.update(update_type: "minor")
 
         subject.send_alert(edition)
         subject.enqueue

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -150,7 +150,7 @@ describe EditionPresenter do
 
     context "when it is a minor update" do
       it "sets update_type to minor for a minor update" do
-        edition.minor_update = true
+        edition.update_type = "minor"
         expect(presented_data["update_type"]).to eq("minor")
       end
     end
@@ -172,7 +172,7 @@ describe EditionPresenter do
       end
 
       it "sets the update_type to 'republish' for a minor update" do
-        edition.minor_update = true
+        edition.update_type = "minor"
         expect(presented_data["update_type"]).to eq("republish")
       end
     end


### PR DESCRIPTION
### What

This PR is to replace `TravelAdviceEdition`'s `minor_update` boolean attribute with an `update_type` of type `string`.

### Why

While I understand why a boolean field can make sense here, it also means we are unable to make full use of some Rails freebies, like validation error messages. `Minor update can't be blank` is indeed somewhat confusing.

This is preparation work for https://github.com/alphagov/travel-advice-publisher/pull/900.