### PR TITLE
Highlight change_description field on validation fail

### DIFF
--- a/app/views/admin/editions/_change_notes.html.erb
+++ b/app/views/admin/editions/_change_notes.html.erb
@@ -17,16 +17,16 @@
     </div>
 
     <div class="form-group js-change-notes-section">
-      <%= f.label :change_description, "Public change note" %>
-      <%= f.text_area(:change_description,
+      <%= f.input :change_description,
+        label: "Public change note",
+        as: :text,
+        input_html: { class: "form-control",
                       rows: 4,
-                      placeholder: 'For example: "Addition of information and advice about planned protests on 5 January (Summary page)" or "Updated information on passport validity requirements (Entry Requirements page)"',
-                      label_text: "Public change note",
+                      disabled: ! @edition.draft?,
                       required: true,
-                      class: "form-control",
-                      disabled: ! @edition.draft?) %>
-    </div>
+                      placeholder: 'For example: "Addition of information and advice about planned protests on 5 January (Summary page)" or "Updated information on passport validity requirements (Entry Requirements page)"' } %>
 
-    <p>Read the <a href="https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes" target="_blank">guidance about change notes</a> (opens in a new tab).</p>
+      <p>Read the <a href="https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes" target="_blank">guidance about change notes</a> (opens in a new tab).</p>
+    </div>
   <% end %>
 </fieldset>


### PR DESCRIPTION
This PR converts the `change_description` field to using the [formtastic gem](https://github.com/formtastic/formtastic), like all the other fields on that page. This ensures we highlight the field in red when a validation error occurs.

## Before

<img width="762" alt="Screenshot 2020-06-22 at 16 58 43" src="https://user-images.githubusercontent.com/3141541/85308984-d8eb6680-b4a9-11ea-850c-57dd83a87227.png">

## After

<img width="767" alt="Screenshot 2020-06-22 at 16 58 12" src="https://user-images.githubusercontent.com/3141541/85308992-db4dc080-b4a9-11ea-8638-f2c29efdabc7.png">