### PR TITLE
Migrate travel advice edition records to new update_type field

### DIFF
--- a/db/migrate/20200623144214_change_minor_update_boolean_to_update_type_string.rb
+++ b/db/migrate/20200623144214_change_minor_update_boolean_to_update_type_string.rb
@@ -1,0 +1,11 @@
+class ChangeMinorUpdateBooleanToUpdateTypeString < Mongoid::Migration
+  def self.up
+    TravelAdviceEdition.where(minor_update: true, update_type: nil).update_all(update_type: "minor")
+    TravelAdviceEdition.where(minor_update: false, update_type: nil).update_all(update_type: "major")
+  end
+
+  def self.down
+    TravelAdviceEdition.where(update_type: "minor").update_all(minor_update: true, update_type: nil)
+    TravelAdviceEdition.where(update_type: "major").update_all(minor_update: false, update_type: nil)
+  end
+end


### PR DESCRIPTION
To be merged and deployed shortly after https://github.com/alphagov/travel-advice-publisher/pull/908.

https://trello.com/c/LWl84KOC/336-dont-pre-check-a-significant-change-for-example-a-new-travel-restriction-when-publishers-create-new-editions