### PR TITLE
Temporarily add update_type to list of fields that can be updated

### DIFF
--- a/app/models/travel_advice_edition.rb
+++ b/app/models/travel_advice_edition.rb
@@ -178,13 +178,13 @@ private
   end
 
   def cannot_edit_published
-    if anything_other_than_state_changed?("reviewed_at") && state_was != "draft"
+    if anything_other_than_state_changed?("reviewed_at", "update_type") && state_was != "draft"
       errors.add(:state, "must be draft to modify")
     end
   end
 
   def cannot_edit_archived
-    if anything_other_than_state_changed?
+    if anything_other_than_state_changed?("update_type")
       errors.add(:state, "must be draft to modify")
     end
   end


### PR DESCRIPTION
This should be removed after https://github.com/alphagov/travel-advice-publisher/pull/911 has run.