### PR TITLE
Revert "Temporarily add update_type to list of fields that can be updated

### DIFF
--- a/app/models/travel_advice_edition.rb
+++ b/app/models/travel_advice_edition.rb
@@ -178,13 +178,13 @@ private
   end
 
   def cannot_edit_published
-    if anything_other_than_state_changed?("reviewed_at", "update_type") && state_was != "draft"
+    if anything_other_than_state_changed?("reviewed_at") && state_was != "draft"
       errors.add(:state, "must be draft to modify")
     end
   end
 
   def cannot_edit_archived
-    if anything_other_than_state_changed?("update_type")
+    if anything_other_than_state_changed?
       errors.add(:state, "must be draft to modify")
     end
   end


### PR DESCRIPTION
This reverts commit e98b83b74ec1532d8f816c9f5e25f6b37e44e1bf.

The value of `update_type` for published editions wasn't really changing.

Rather, it was new and undefined, and therefore being populated with the "major" default.

This temporary fix was necessary until we could migrate all existing records to the new field
in https://github.com/alphagov/travel-advice-publisher/pull/911.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/travel-advice-publisher), after merging.