### PR TITLE
Remove send_email_alerts check

### DIFF
--- a/app/notifiers/email_alert_api_notifier.rb
+++ b/app/notifiers/email_alert_api_notifier.rb
@@ -12,9 +12,7 @@ module EmailAlertApiNotifier
   private
 
     def send_alert?(edition)
-      Rails.application.config.send_email_alerts &&
-        edition.state == "published" &&
-        !edition.is_minor_update?
+      edition.state == "published" && !edition.is_minor_update?
     end
   end
 end

--- a/app/workers/email_alert_api_worker.rb
+++ b/app/workers/email_alert_api_worker.rb
@@ -2,14 +2,8 @@ class EmailAlertApiWorker
   include Sidekiq::Worker
 
   def perform(payload, _params = {})
-    GdsApi.email_alert_api.create_content_change(payload) if send_alert?
+    GdsApi.email_alert_api.create_content_change(payload)
   rescue GdsApi::HTTPConflict
     logger.info("email-alert-api returned 409 conflict for #{payload}")
-  end
-
-private
-
-  def send_alert?
-    Rails.application.config.send_email_alerts
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,9 +43,6 @@ Rails.application.configure do
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
 
-  # We should always send email alerts in test
-  config.send_email_alerts = true
-
   config.after_initialize do
     Timecop.freeze(2011, 11, 11, 11, 11, 11)
   end

--- a/spec/notifiers/email_alert_api_notifier_spec.rb
+++ b/spec/notifiers/email_alert_api_notifier_spec.rb
@@ -37,14 +37,4 @@ RSpec.describe EmailAlertApiNotifier do
       expect(subject.send_alert(edition)).to be_nil
     end
   end
-
-  context "when Rails.config.send_email_alerts is false" do
-    before do
-      allow(Rails.application.config).to receive(:send_email_alerts).and_return(false)
-    end
-
-    it "does nothing" do
-      expect(subject.send_alert(edition)).to be_nil
-    end
-  end
 end

--- a/spec/workers/email_alert_api_worker_spec.rb
+++ b/spec/workers/email_alert_api_worker_spec.rb
@@ -15,18 +15,6 @@ RSpec.describe EmailAlertApiWorker, :perform do
     assert_email_alert_api_content_change_created(payload)
   end
 
-  context "when send_email_alerts is disabled" do
-    before do
-      expect(Rails.application.config).to receive(:send_email_alerts)
-        .and_return(false)
-    end
-
-    it "does not send an alert" do
-      expect(GdsApi.email_alert_api).not_to receive(:create_content_change)
-      described_class.new.perform(payload)
-    end
-  end
-
   context "when a request to the email-alert-api times out" do
     before do
       stub_any_email_alert_api_call.to_timeout


### PR DESCRIPTION
The configuration itself was was accidentally removed in 545c31c1832de8eb1e544bb93fc09b3c081ac34d but we can't think of a good reason for having this check. The application should act the same in all environments.

This should solve: https://sentry.io/organizations/govuk/issues/1813112758/