### PR TITLE
Change PRIMARY_ORG_CONTENT_ID from FCO to FCDO

### DIFF
--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -9,5 +9,5 @@ module TravelAdvicePublisher
 
   COUNTRY_FORMAT = "travel_advice".freeze
   INDEX_FORMAT = "travel_advice_index".freeze
-  PRIMARY_ORG_CONTENT_ID = "9adfc4ed-9f6c-4976-a6d8-18d34356367c".freeze
+  PRIMARY_ORG_CONTENT_ID = "f9fcf3fe-2751-4dca-97ca-becaeceb4b26".freeze
 end

--- a/spec/presenters/links_presenter_spec.rb
+++ b/spec/presenters/links_presenter_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe LinksPresenter do
       expect(presented_data).to eq(links: {
         parent: %w[08d48cdd-6b50-43ff-a53b-beab47f4aab0],
         meets_user_needs: %w[5118d7b4-215d-45e6-bd20-15d7bc21314f],
-        primary_publishing_organisation: %w[9adfc4ed-9f6c-4976-a6d8-18d34356367c],
-        organisations: %w[9adfc4ed-9f6c-4976-a6d8-18d34356367c],
+        primary_publishing_organisation: %w[f9fcf3fe-2751-4dca-97ca-becaeceb4b26],
+        organisations: %w[f9fcf3fe-2751-4dca-97ca-becaeceb4b26],
       })
     end
   end

--- a/spec/tasks/publishing_api_rake_spec.rb
+++ b/spec/tasks/publishing_api_rake_spec.rb
@@ -39,8 +39,8 @@ describe "publishing_api rake tasks", type: :rake_task do
           links:
             {
               parent: %w[b9849cd6-61a7-42dc-8124-362d2c7d48b0],
-              primary_publishing_organisation: %w[9adfc4ed-9f6c-4976-a6d8-18d34356367c],
-              organisations: %w[9adfc4ed-9f6c-4976-a6d8-18d34356367c],
+              primary_publishing_organisation: %w[f9fcf3fe-2751-4dca-97ca-becaeceb4b26],
+              organisations: %w[f9fcf3fe-2751-4dca-97ca-becaeceb4b26],
             },
         ),
       )


### PR DESCRIPTION
This changes the primary organisation associated with travel advice editions from FCO to FCDO.

This is part of the work around the Machinery of Government changes that will see FCO and DFID merge to become a new department.

Once this code change has been merged and deployed, the `publishing_api:republish_editions` rake task can be run to republish all published travel advice editions. This will make them have the new organisation's `content_id` in their `primary_publishing_organisation` field in `links`.

Trello card: https://trello.com/c/OLlCzb7K/2096-spike-bulk-retagging-travel-advice-organisation-tagging-to-fcdo

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/travel-advice-publisher), after merging.
