### PR TITLE
Just patch links for published editions, in the repatch_links task

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -51,7 +51,7 @@ namespace :publishing_api do
 
   desc "Send patch links requests to the Publishing API for all editions"
   task repatch_links: :environment do
-    TravelAdviceEdition.each do |edition|
+    TravelAdviceEdition.published.each do |edition|
       links_presenter = LinksPresenter.new(edition)
 
       GdsApi.publishing_api.patch_links(links_presenter.content_id, links_presenter.present)


### PR DESCRIPTION
As this ignores archived editions, some of which don't process
correctly.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/travel-advice-publisher), after merging.
