### PR TITLE
Add missing healthcheck for the database

### DIFF
--- a/app/lib/healthcheck/mongoid.rb
+++ b/app/lib/healthcheck/mongoid.rb
@@ -1,0 +1,14 @@
+module Healthcheck
+  class Mongoid
+    def name
+      :database_connectivity
+    end
+
+    def status
+      ::Mongoid.default_client.database_names.present?
+      GovukHealthcheck::OK
+    rescue StandardError
+      GovukHealthcheck::CRITICAL
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
   get "/healthcheck",
       to: GovukHealthcheck.rack_response(
         GovukHealthcheck::SidekiqRedis,
+        Healthcheck::Mongoid,
       )
 
   get "/healthcheck/recently-published-editions" => "healthcheck#recently_published_editions"

--- a/spec/requests/healthcheck_spec.rb
+++ b/spec/requests/healthcheck_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe "/healthcheck", type: :request do
 
     expect(data.fetch(:checks)).to include(
       redis_connectivity: { status: "ok" },
+      database_connectivity: { status: "ok" },
     )
   end
 end


### PR DESCRIPTION
https://trello.com/c/epNWudCR/176-write-an-rfc-for-continuous-deployment-and-seek-review

    Note that this repo doesn't include ActiveRecord, so we can't use
    our standard check for DB connectivity [1].
    
    [1]: https://github.com/alphagov/govuk_app_config/blob/master/lib/govuk_app_config/govuk_healthcheck/active_record.rb


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/travel-advice-publisher), after merging.