### PR TITLE
Remove redundant GDS SSO initializer

### DIFF
--- a/config/initializers/gds_sso.rb
+++ b/config/initializers/gds_sso.rb
@@ -1,6 +1,0 @@
-GDS::SSO.config do |config|
-  config.user_model   = "User"
-  config.oauth_id     = ENV["OAUTH_ID"] || "abcdefghjasndjkasndtraveladvicepublisher"
-  config.oauth_secret = ENV["OAUTH_SECRET"] || "secret"
-  config.oauth_root_url = Plek.new.external_url_for("signon")
-end


### PR DESCRIPTION
https://trello.com/c/epNWudCR/176-write-an-rfc-for-continuous-deployment-and-seek-review

This was made redundant in [1].

[1]: https://github.com/alphagov/gds-sso/pull/241


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/travel-advice-publisher), after merging.