### PR TITLE
Amend email alerts for Afghanistan travel advice changes

### DIFF
--- a/app/models/afghanistan_links_presenter.rb
+++ b/app/models/afghanistan_links_presenter.rb
@@ -1,0 +1,9 @@
+module AfghanistanLinksPresenter
+  def afganistan_topical_event_payload
+    { topical_events: [afganistan_topical_event_content_id] }
+  end
+
+  def afganistan_topical_event_content_id
+    "39084ee0-b77e-456b-93cb-f95a56f74b50"
+  end
+end

--- a/app/presenters/email_alert_presenter.rb
+++ b/app/presenters/email_alert_presenter.rb
@@ -1,4 +1,6 @@
 class EmailAlertPresenter
+  include AfghanistanLinksPresenter
+
   def self.present(edition)
     new(edition).present
   end
@@ -45,6 +47,12 @@ private
   end
 
   def links
+    return base_links unless country.name == "Afghanistan"
+
+    base_links.merge(afganistan_topical_event_payload)
+  end
+
+  def base_links
     { countries: [content_id] }
   end
 

--- a/spec/presenters/email_alert_presenter_afghanistan_spec.rb
+++ b/spec/presenters/email_alert_presenter_afghanistan_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe EmailAlertPresenter do
+  let(:edition) do
+    create(
+      :published_travel_advice_edition,
+      country_slug: "afghanistan",
+      title: "Afghanistan travel advice",
+      change_description: "Updated image of regions",
+    )
+  end
+
+  let(:links) do
+    {
+      countries: %w[5a292f20-a9b6-46ea-b35f-584f8b3d7392],
+      topical_events: %w[39084ee0-b77e-456b-93cb-f95a56f74b50],
+    }
+  end
+
+  let(:email_alert) { described_class.present(edition) }
+
+  context "Afghanistan travel advice is published" do
+    it "the topical event is added to the payload for email alert api" do
+      expect(email_alert["subject"]).to eq("Afghanistan travel advice")
+      expect(email_alert["tags"]).to eq({})
+      expect(email_alert["document_type"]).to eq("travel_advice")
+      expect(email_alert["links"]).to eq(links)
+    end
+  end
+end


### PR DESCRIPTION
Following an external request, we would like to alert subscribers to the
afghanistan-uk-government-response topical event, when changes are made to
Afghanistan travel advice.

[Trello](https://trello.com/c/wQ5D1xwM/2710-send-afghanistan-travel-advice-emails-to-those-subscribed-to-the-topical-event)

Tested on integration:

- Signed up for email alerts on the [topical event page ](https://www.integration.publishing.service.gov.uk/government/topical-events/afghanistan-uk-government-response)
- Deployed this branch to integration, and published a [travel alert](https://www.integration.publishing.service.gov.uk/foreign-travel-advice/afghanistan?cache=1631881392)
- Email was received to the [google group](https://groups.google.com/a/digital.cabinet-office.gov.uk/g/email-alert-api-integration)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
