### PR TITLE
Use MongoDB 3.6 in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 library("govuk")
 
-node('mongodb-2.4') {
+node('mongodb-3.6') {
   govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-travel-advice-publisher")
   govuk.buildProject(
     publishingE2ETests: true,


### PR DESCRIPTION
This application uses MongoDB 3.6 (via DocumentDB) in production

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
