### PR TITLE
Prepare for jQuery removal

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,3 +1,4 @@
+//= require jquery/dist/jquery
 //= require jquery-ui.custom.min
 //= require jquery.mustache
 //= require_tree .

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "author": "Government Digital Service",
   "license": "MIT",
+  "dependencies": {
+    "jquery": "1.12.4"
+  },
   "scripts": {
     "lint": "yarn run lint:js && yarn run lint:scss",
     "lint:js": "standardx 'app/assets/javascripts/**/*.js' 'spec/javascripts/**/*.js'",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1682,6 +1682,11 @@ jasmine-core@^4.0.1:
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-4.0.1.tgz#ea4b0495d82155023bd56c25181d9f9b623f61b8"
   integrity sha512-w+JDABxQCkxbGGxg+a2hUVZyqUS2JKngvIyLGu/xiw2ZwgsoSB0iiecLQsQORSeaKQ6iGrCyWG86RfNDuoA7Lg==
 
+jquery@1.12.4:
+  version "1.12.4"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-1.12.4.tgz#01e1dfba290fe73deba77ceeacb0f9ba2fec9e0c"
+  integrity sha1-AeHfuikP5z3rp3zurLD5ui/sngw=
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
- we're going to be removing jQuery from GOV.UK
- jQuery currently comes from the components gem, included via static for applications
- travel-advice-publisher already includes jQuery UI and jQuery Mustache - thse would be complicated to remove
- therefore I'm proposing that we give travel-advice-publisher its own jQuery, which can be upgraded or removed later without blocking the rest of GOV.UK

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
