### PR TITLE
[DO NOT MERGE]Update the countries show page to use the GOVUK Design System

### DIFF
--- a/app/controllers/admin/countries_controller.rb
+++ b/app/controllers/admin/countries_controller.rb
@@ -1,5 +1,5 @@
 class Admin::CountriesController < ApplicationController
-  layout "legacy"
+  layout :get_layout
   before_action :skip_slimmer
   before_action :load_country, only: [:show]
 
@@ -10,6 +10,14 @@ class Admin::CountriesController < ApplicationController
   def show; end
 
 private
+
+  def get_layout
+    if action_name == "show"
+      "design_system"
+    else
+      "legacy"
+    end
+  end
 
   def load_country
     @country = Country.find_by_slug(params[:id]) || error_404

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,6 @@
 module ApplicationHelper
   def edition_edit_link(edition)
-    link_to((edition.draft? ? "edit" : "view details"), edit_admin_edition_path(edition))
+    link_to((edition.draft? ? "edit" : "view details"), edit_admin_edition_path(edition), class: "govuk-link")
   end
 
   def preview_edition_link(edition, short, options = {})

--- a/app/views/admin/countries/show.html.erb
+++ b/app/views/admin/countries/show.html.erb
@@ -1,40 +1,46 @@
-<ul class="breadcrumb">
-  <li>
-    <%= link_to "All countries", admin_countries_path %>
-  </li>
-  <li class="active"><%= @country.name %></li>
-</ul>
+<% content_for :breadcrumbs do %>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    breadcrumbs: [
+      {
+        title: 'All countries',
+        url: admin_countries_path,
+      },
+      {
+        title: @country.name,
+      }
 
-<h1 class="page-title">
-  <%= @country.name %>
-</h1>
-
-
-<% unless @country.has_draft_edition? %>
-  <%= button_to "Create new edition",
-    admin_country_editions_path(@country.slug),
-    :class => "btn btn-success" %>
+    ]
+  } %>
 <% end %>
 
-<table class="table table-bordered table-striped add-top-margin">
-  <thead>
-    <tr class="table-header">
-      <th>Version</th>
-      <th>State</th>
-      <th>Updated</th>
-      <th>Reviewed</th>
-      <th></th>
-    </tr>
-  </thead>
-  <tbody>
+<%= content_for :title, @country.name %>
+
+<% unless @country.has_draft_edition? %>
+  <form action="<%= admin_country_editions_path(@country.slug) %>" method="post">
+    <%= render "govuk_publishing_components/components/button", {
+    text: "Create new edition",
+  } %>
+  </form>
+<% end %>
+
+<%= GovukPublishingComponents::AppHelpers::TableHelper.helper(self) do |table| %>
+  <%= table.head do %>
+    <%= table.header "Version" %>
+    <%= table.header "State" %>
+    <%= table.header "Updated" %>
+    <%= table.header "Reviewed" %>
+    <%= table.header "" %>
+  <% end %>
+
+  <%= table.body do %>
     <% @country.editions.each do |edition| %>
-      <tr>
-        <td>Version <%= edition.version_number %></td>
-        <td><%= edition.state %></td>
-        <td><%= timestamp(edition.updated_at) %></td>
-        <td><%= edition.reviewed_at ? timestamp(edition.reviewed_at) : "N/A" %></td>
-        <td><%= edition_edit_link(edition) %> — <%= preview_edition_link(edition, true, :target => "blank") %></td>
-      </tr>
+      <%= table.row do %>
+        <%= table.cell "Version #{edition.version_number}" %>
+        <%= table.cell edition.state %>
+        <%= table.cell timestamp(edition.updated_at) %>
+        <%= table.cell edition.reviewed_at ? timestamp(edition.reviewed_at) : "N/A" %>
+        <%= table.cell edition_edit_link(edition) + " — " + preview_edition_link(edition, true, target: "blank", class: "govuk-link") %>
+      <% end %>
     <% end %>
-  </tbody>
-</table>
+  <% end %>
+<% end %>


### PR DESCRIPTION
### Description 

This ports over the countries show page to use the GOVUK Design System. I've added a partial for breadcrumbs so further pages might want to rebase off of this once it's reviewed to reuse it.

### Screenshots 

|Before|After|
|------------|------------|
|<img width="1065" alt="image" src="https://user-images.githubusercontent.com/42515961/161252395-edf1b81c-b704-4a3b-9e31-eee922657d17.png">|<img width="905" alt="image" src="https://user-images.githubusercontent.com/42515961/161252204-c6de8e96-a4bb-4ab1-88d4-11e975765ee9.png">|

### Trello card 

https://trello.com/c/0E83a9vU/353-travel-advice-country-show-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
