### PR TITLE
Migrate list and show page to GOVUK Design systems

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,1 +1,2 @@
 @import "govuk_publishing_components/all_components";
+@import "./objects/grid";

--- a/app/assets/stylesheets/objects/_grid.scss
+++ b/app/assets/stylesheets/objects/_grid.scss
@@ -1,0 +1,3 @@
+.app-grid-column--align-right {
+  text-align: right;
+}

--- a/app/controllers/admin/countries_controller.rb
+++ b/app/controllers/admin/countries_controller.rb
@@ -1,15 +1,26 @@
 class Admin::CountriesController < ApplicationController
-  layout "legacy"
+  layout :get_layout
   before_action :skip_slimmer
   before_action :load_country, only: [:show]
 
   def index
     @countries = Country.all
+    render "admin/countries/index_legacy" if is_legacy_layout?
   end
 
   def show; end
 
 private
+
+  def is_legacy_layout?
+    !preview_design_system_user?
+  end
+
+  def get_layout
+    return "legacy" if is_legacy_layout? || %(show).include?(action_name)
+
+    "design_system"
+  end
 
   def load_country
     @country = Country.find_by_slug(params[:id]) || error_404

--- a/app/controllers/admin/countries_controller.rb
+++ b/app/controllers/admin/countries_controller.rb
@@ -8,7 +8,9 @@ class Admin::CountriesController < ApplicationController
     render "admin/countries/index_legacy" if is_legacy_layout?
   end
 
-  def show; end
+  def show
+    render "admin/countries/show_legacy" if is_legacy_layout?
+  end
 
 private
 
@@ -17,7 +19,7 @@ private
   end
 
   def get_layout
-    return "legacy" if is_legacy_layout? || %(show).include?(action_name)
+    return "legacy" if is_legacy_layout?
 
     "design_system"
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,6 @@
 module ApplicationHelper
   def edition_edit_link(edition)
-    link_to((edition.draft? ? "edit" : "view details"), edit_admin_edition_path(edition))
+    link_to((edition.draft? ? "edit" : "view details"), edit_admin_edition_path(edition), class: "govuk-link")
   end
 
   def preview_edition_link(edition, short, options = {})
@@ -15,7 +15,7 @@ module ApplicationHelper
       url = admin_edition_historical_edition_path(edition)
     end
     name = name.downcase.split(" ").first if short
-    link_to(name, url, options.merge(target: "blank"))
+    link_to(name, url, options.merge(target: "blank", class: "govuk-link"))
   end
 
   def timestamp(time)

--- a/app/views/admin/countries/index.html.erb
+++ b/app/views/admin/countries/index.html.erb
@@ -1,34 +1,18 @@
-<h1 class="page-title">
-  Countries
-</h1>
+<% content_for :title, "Countries" %>
 
-<table class="table table-striped table-bordered" data-module="filterable-table">
-  <thead>
-    <tr class="table-header">
-      <th>Country</th>
-      <th>Status</th>
-    </tr>
-    <!--[if gte IE 8]><!-->
-    <tr class="if-no-js-hide table-header-secondary">
-      <td colspan="2">
-        <form>
-          <label for="table-filter" class="rm">Filter countries</label>
-          <input id="table-filter" type="text" class="form-control normal js-filter-table-input" placeholder="Filter list of countries">
-        </form>
-      </td>
-    </tr>
-    <!--<![endif]-->
-  </thead>
-  <tbody>
-    <% @countries.each do |country| %>
-      <tr>
-        <td><%= link_to country.name, admin_country_path(country.slug), class: 'js-open-on-submit' %></td>
-        <% if country.has_published_edition? %>
-          <td>advice published</td>
-        <% else %>
-          <td class="text-error">no advice published</td>
-        <% end %>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/table", {
+      head: [
+        { text: "Country" },
+        { text: "Status" }
+      ],
+      rows: @countries.map do |country|
+        [
+          { text: link_to(country.name, admin_country_path(country.slug), class: 'govuk-link') },
+          { text: country.has_published_edition? ? "Advice published" : "No advice published" }
+        ]
+      end
+    } %>
+  </div>
+</div>

--- a/app/views/admin/countries/index_legacy.html.erb
+++ b/app/views/admin/countries/index_legacy.html.erb
@@ -1,0 +1,34 @@
+<h1 class="page-title">
+  Countries
+</h1>
+
+<table class="table table-striped table-bordered" data-module="filterable-table">
+  <thead>
+    <tr class="table-header">
+      <th>Country</th>
+      <th>Status</th>
+    </tr>
+    <!--[if gte IE 8]><!-->
+    <tr class="if-no-js-hide table-header-secondary">
+      <td colspan="2">
+        <form>
+          <label for="table-filter" class="rm">Filter countries</label>
+          <input id="table-filter" type="text" class="form-control normal js-filter-table-input" placeholder="Filter list of countries">
+        </form>
+      </td>
+    </tr>
+    <!--<![endif]-->
+  </thead>
+  <tbody>
+    <% @countries.each do |country| %>
+      <tr>
+        <td><%= link_to country.name, admin_country_path(country.slug), class: 'js-open-on-submit' %></td>
+        <% if country.has_published_edition? %>
+          <td>advice published</td>
+        <% else %>
+          <td class="text-error">no advice published</td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/countries/show.html.erb
+++ b/app/views/admin/countries/show.html.erb
@@ -1,40 +1,53 @@
-<ul class="breadcrumb">
-  <li>
-    <%= link_to "All countries", admin_countries_path %>
-  </li>
-  <li class="active"><%= @country.name %></li>
-</ul>
-
-<h1 class="page-title">
-  <%= @country.name %>
-</h1>
-
-
-<% unless @country.has_draft_edition? %>
-  <%= button_to "Create new edition",
-    admin_country_editions_path(@country.slug),
-    :class => "btn btn-success" %>
+<% content_for :breadcrumbs do %>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    breadcrumbs: [
+      {
+        :title => "All countries",
+        :url => admin_countries_path
+      },
+      {
+        :title => @country.name,
+      },
+    ]
+  } %>
 <% end %>
 
-<table class="table table-bordered table-striped add-top-margin">
-  <thead>
-    <tr class="table-header">
-      <th>Version</th>
-      <th>State</th>
-      <th>Updated</th>
-      <th>Reviewed</th>
-      <th></th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @country.editions.each do |edition| %>
-      <tr>
-        <td>Version <%= edition.version_number %></td>
-        <td><%= edition.state %></td>
-        <td><%= timestamp(edition.updated_at) %></td>
-        <td><%= edition.reviewed_at ? timestamp(edition.reviewed_at) : "N/A" %></td>
-        <td><%= edition_edit_link(edition) %> — <%= preview_edition_link(edition, true, :target => "blank") %></td>
-      </tr>
+<% content_for :title, @country.name %>
+
+<% content_for :title_side do %>
+  <% unless @country.has_draft_edition? %>
+    <form action="<%= admin_country_editions_path(@country.slug) %>" method="POST">
+      <%= render("govuk_publishing_components/components/button", {
+        text: "Create new edition",
+        margin_bottom: true
+      }) %>
+    </form>
+  <% end %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <% if @country.editions.any? %>
+      <%= render "govuk_publishing_components/components/table", {
+        head: [
+          { text: "Version" },
+          { text: "Status" },
+          { text: "Updated" },
+          { text: "Reviewed" },
+          { text: "Action" },
+        ],
+        rows: @country.editions.map do |edition|
+          [
+            { text: "Version #{edition.version_number}" },
+            { text: edition.state },
+            { text: timestamp(edition.updated_at) },
+            { text: edition.reviewed_at ? timestamp(edition.reviewed_at) : "N/A" },
+            { text: edition_edit_link(edition) + " - " + preview_edition_link(edition, true, :target => "blank") },
+          ]
+        end
+      } %>
+    <% else %>
+      <p class="govuk-body">No editions exist for this country</p>
     <% end %>
-  </tbody>
-</table>
+  </div>
+</div>

--- a/app/views/admin/countries/show_legacy.html.erb
+++ b/app/views/admin/countries/show_legacy.html.erb
@@ -1,0 +1,40 @@
+<ul class="breadcrumb">
+  <li>
+    <%= link_to "All countries", admin_countries_path %>
+  </li>
+  <li class="active"><%= @country.name %></li>
+</ul>
+
+<h1 class="page-title">
+  <%= @country.name %>
+</h1>
+
+
+<% unless @country.has_draft_edition? %>
+  <%= button_to "Create new edition",
+    admin_country_editions_path(@country.slug),
+    :class => "btn btn-success" %>
+<% end %>
+
+<table class="table table-bordered table-striped add-top-margin">
+  <thead>
+    <tr class="table-header">
+      <th>Version</th>
+      <th>State</th>
+      <th>Updated</th>
+      <th>Reviewed</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @country.editions.each do |edition| %>
+      <tr>
+        <td>Version <%= edition.version_number %></td>
+        <td><%= edition.state %></td>
+        <td><%= timestamp(edition.updated_at) %></td>
+        <td><%= edition.reviewed_at ? timestamp(edition.reviewed_at) : "N/A" %></td>
+        <td><%= edition_edit_link(edition) %> — <%= preview_edition_link(edition, true, :target => "blank") %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/spec/controllers/admin/countries_controller_spec.rb
+++ b/spec/controllers/admin/countries_controller_spec.rb
@@ -49,7 +49,26 @@ describe Admin::CountriesController do
       it "renders the show view" do
         get :show, params: { id: "australia" }
 
-        expect(response).to render_template :show
+        expect(response).to render_template :show_legacy
+      end
+
+      context "with Preview Design System permission" do
+        it "assigns the request country" do
+          user = create(:user, preview_design_system: true)
+          login_as(user)
+          get :show, params: { id: "australia" }
+
+          expect(assigns(:country).name).to eq("Australia")
+          expect(assigns(:country).slug).to eq("australia")
+        end
+
+        it "renders the show view" do
+          user = create(:user, preview_design_system: true)
+          login_as(user)
+          get :show, params: { id: "australia" }
+
+          expect(response).to render_template :show
+        end
       end
     end
 
@@ -58,6 +77,16 @@ describe Admin::CountriesController do
         get :show, params: { id: "the-shire" }
 
         expect(response).to be_not_found
+      end
+
+      context "with Preview Design System permission" do
+        it "returns a 404" do
+          user = create(:user, preview_design_system: true)
+          login_as(user)
+          get :show, params: { id: "the-shire" }
+
+          expect(response).to be_not_found
+        end
       end
     end
   end

--- a/spec/controllers/admin/countries_controller_spec.rb
+++ b/spec/controllers/admin/countries_controller_spec.rb
@@ -14,7 +14,26 @@ describe Admin::CountriesController do
     it "renders the index view" do
       get :index
 
-      expect(response).to render_template :index
+      expect(response).to render_template :index_legacy
+    end
+
+    context "with Preview Design System permission" do
+      it "populates an array of countries" do
+        user = create(:user, preview_design_system: true)
+        login_as(user)
+        get :index
+
+        expect(assigns(:countries).map(&:slug)).to include("afghanistan", "albania", "algeria")
+        expect(assigns(:countries).map(&:name)).to include("Afghanistan", "Albania", "Algeria")
+      end
+
+      it "renders the index view" do
+        user = create(:user, preview_design_system: true)
+        login_as(user)
+        get :index
+
+        expect(response).to render_template :index
+      end
     end
   end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -3,9 +3,18 @@ FactoryBot.define do
     sequence(:uid) { |n| "uid-#{n}" }
     sequence(:name) { |n| "Joe Bloggs #{n}" }
     sequence(:email) { |n| "joe#{n}@bloggs.com" }
+
+    transient do
+      preview_design_system { false }
+    end
+
     if defined?(GDS::SSO::Config)
-      # Grant permission to signin to the app using the gem
-      permissions { %w[signin] }
+      permissions do
+        [
+          "signin",
+          ("Preview Design System" if preview_design_system),
+        ].compact
+      end
     end
   end
 


### PR DESCRIPTION
## What
Migrate the List and show page to the GOVUK design system

## Why
Migrating to GOVUK Design System will make it easier for users to use, consistent with the rest of GOVUK, and more accessible

## Before

<img width="1268" alt="Screenshot 2022-04-06 at 3 15 53 am" src="https://user-images.githubusercontent.com/4599889/161882440-2de1fd9b-2faa-4d1c-8543-0969cf9863f0.png">
<img width="1232" alt="Screenshot 2022-04-06 at 3 15 40 am" src="https://user-images.githubusercontent.com/4599889/161882453-14661ee5-c868-4585-a874-4c776b744ad2.png">

## After

<img width="1104" alt="Screenshot 2022-04-06 at 3 15 10 am" src="https://user-images.githubusercontent.com/4599889/161882488-7a85a02c-3b20-43ad-a393-427b8e7c5203.png">
<img width="1079" alt="Screenshot 2022-04-06 at 3 15 24 am" src="https://user-images.githubusercontent.com/4599889/161882502-a1e4e088-2fb5-460e-bccf-5a512d23afc9.png">


https://trello.com/c/sFromAP6/352-travel-advice-list-index-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
