### PR TITLE
Add new design system user permission helper

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,12 @@ class ApplicationController < ActionController::Base
 
 private
 
+  helper_method :preview_design_system_user?
+
+  def preview_design_system_user?
+    current_user.has_permission? "Preview Design System"
+  end
+
   def error(status_code)
     render status: status_code, plain: "#{status_code} error"
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,7 +3,7 @@ if User.where(name: "Test user").blank?
 
   User.create!(
     name: "Test user",
-    permissions: %w[signin gds_editor],
+    permissions: ["signin", "GDS Editor", "Preview Design System"],
     organisation_content_id: gds_organisation_id,
   )
 end


### PR DESCRIPTION
## What

Add new permission to allow users to see the design system.

## Why

This will allow users to test design system changes before we deploy them out to everyone (like a feature flag).

## How to test

To test this you will need to reseed your database, the best way to do this is by the following command (this will reset your db):

```sh
govuk-docker run travel-advice-publisher-app bundle exec rails db:reset
```

https://trello.com/c/jUeXetdL/359-add-new-design-system-user-permission

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
