### PR TITLE
Remove `Preview Design System` permission from seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,7 +3,7 @@ if User.where(name: "Test user").blank?
 
   User.create!(
     name: "Test user",
-    permissions: ["signin", "GDS Editor", "Preview Design System"],
+    permissions: ["signin", "GDS Editor"],
     organisation_content_id: gds_organisation_id,
   )
 end


### PR DESCRIPTION
We added a permission for users to be able to see the new flow that uses the GOVUK Design System. We added this to our users generated in the seed data.

This causes the E2E tests to fail as resultantly, they see the new flow.

The simplest fix is to remove it from the seeds and update permissions as required via command line

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
