### PR TITLE
Add review functionality for viewing archived and published parts

### DIFF
--- a/app/controllers/admin/parts_controller.rb
+++ b/app/controllers/admin/parts_controller.rb
@@ -1,7 +1,7 @@
 class Admin::PartsController < ApplicationController
   before_action :skip_slimmer
   before_action :load_country_and_edition
-  before_action :redirect_to_edit_edition_unless_draft_edition
+  before_action :redirect_to_edit_edition_unless_draft_edition, except: %i[review edit]
   layout "design_system"
 
   def new
@@ -25,6 +25,7 @@ class Admin::PartsController < ApplicationController
 
   def edit
     @part = @edition.parts.find(params[:id])
+    redirect_to review_admin_country_edition_part_path(@edition.country_slug, @edition, @part) unless @edition.draft?
   end
 
   def update
@@ -40,6 +41,11 @@ class Admin::PartsController < ApplicationController
     else
       render "edit"
     end
+  end
+
+  def review
+    @part = @edition.parts.find(params[:id])
+    redirect_to edit_admin_country_edition_part_path(@edition.country_slug, @edition, @part) if @edition.draft?
   end
 
 private

--- a/app/views/admin/editions/_parts.html.erb
+++ b/app/views/admin/editions/_parts.html.erb
@@ -10,8 +10,8 @@
           field: part.title,
           value: part.slug,
           edit: {
-            href: edit_admin_country_edition_part_path(@country.slug, @edition, part),
-            link_text: "Change"
+            href: @edition.draft? ? edit_admin_country_edition_part_path(@country.slug, @edition, part) : review_admin_country_edition_part_path(@country.slug, @edition, part),
+            link_text: @edition.draft? ? "Change" : "View",
           }
         }
       end

--- a/app/views/admin/parts/review.html.erb
+++ b/app/views/admin/parts/review.html.erb
@@ -1,0 +1,42 @@
+<% content_for :breadcrumbs do %>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    breadcrumbs: [
+      {
+        title: 'All countries',
+        url: admin_countries_path,
+      },
+      {
+        title: @country.name,
+        url: admin_country_path(@country.slug),
+      },
+      {
+        title: "Editing #{@country.name}",
+        url: edit_admin_edition_path(@edition),
+      },
+      {
+        title: "Review #{@part.title}",
+      },
+    ]
+  } %>
+<% end %>
+
+<%= content_for :page_title, @part.title %>
+
+<%= render "govuk_publishing_components/components/summary_list", {
+  title: @part.title,
+  heading_size: 'l',
+  items: [
+    {
+      field: "Title",
+      value: @part.title,
+    },
+    {
+      field: "Body",
+      value: @part.body,
+    },
+    {
+      field: "Slug",
+      value: @part.slug,
+    },
+  ]
+} %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :countries, only: %i[index show] do
       resources :editions, only: [:create] do
-        resources :parts, only: %i[new create edit update]
+        resources :parts, only: %i[new create edit update show] do
+          get "review", on: :member
+        end
       end
     end
 

--- a/spec/features/editing_a_part_with_design_system_spec.rb
+++ b/spec/features/editing_a_part_with_design_system_spec.rb
@@ -26,7 +26,7 @@ feature "Editing a part" do
       expect(find("#part_slug").value).to eq @part.slug
     end
 
-    scenario "Parts can be modified from the edit page" do
+    scenario "Parts are prefilled when you visit the edit page" do
       visit edit_admin_edition_path(@edition)
       click_on "Change #{@part.title}"
       fill_in "Title", with: "New title"

--- a/spec/features/editing_a_part_with_design_system_spec.rb
+++ b/spec/features/editing_a_part_with_design_system_spec.rb
@@ -3,7 +3,7 @@ feature "Editing a part" do
     before do
       login_as_stub_user_with_design_system_permission
       @edition = create(
-        :travel_advice_edition_with_parts,
+        :draft_travel_advice_edition,
         country_slug: "aruba",
         summary: "Advice summary",
         version_number: 1,
@@ -26,7 +26,7 @@ feature "Editing a part" do
       expect(find("#part_slug").value).to eq @part.slug
     end
 
-    scenario "Parts are prefilled when you visit the edit page" do
+    scenario "User edits a part" do
       visit edit_admin_edition_path(@edition)
       click_on "Change #{@part.title}"
       fill_in "Title", with: "New title"
@@ -36,6 +36,52 @@ feature "Editing a part" do
       within "#parts" do
         expect(all(".govuk-summary-list__row")[0]).to have_content "New title"
       end
+    end
+  end
+
+  context "Published edition" do
+    before do
+      login_as_stub_user_with_design_system_permission
+      @edition = create(
+        :published_travel_advice_edition,
+        country_slug: "aruba",
+        summary: "Advice summary",
+        version_number: 1,
+      )
+      @part = @edition.parts.create!(
+        title: "Some Part Title!",
+        body: "This is some **version** text.",
+        slug: "part-one",
+        order: 1,
+      )
+    end
+
+    scenario "User manually visits the edit path" do
+      visit edit_admin_country_edition_part_path(@edition.country_slug, @edition, @part)
+      expect(page).to have_current_path(review_admin_country_edition_part_path(@edition.country_slug, @edition, @part))
+    end
+  end
+
+  context "Archived edition" do
+    before do
+      login_as_stub_user_with_design_system_permission
+      @edition = create(
+        :archived_travel_advice_edition,
+        country_slug: "aruba",
+        summary: "Advice summary",
+        version_number: 1,
+      )
+      @part = @edition.parts.create!(
+        title: "Some Part Title!",
+        body: "This is some **version** text.",
+        slug: "part-one",
+        order: 1,
+      )
+    end
+
+    scenario "User visits page and sees summary list table" do
+      visit edit_admin_country_edition_part_path(@edition.country_slug, @edition, @part)
+      expect(page).to have_current_path(review_admin_country_edition_part_path(@edition.country_slug, @edition, @part))
     end
   end
 end

--- a/spec/features/reviewing_a_part_with_design_system_spec.rb
+++ b/spec/features/reviewing_a_part_with_design_system_spec.rb
@@ -1,0 +1,86 @@
+feature "Reviewing a part" do
+  context "Draft edition" do
+    before do
+      login_as_stub_user_with_design_system_permission
+      @edition = create(
+        :draft_travel_advice_edition,
+        country_slug: "aruba",
+        summary: "Advice summary",
+        version_number: 1,
+      )
+      @part = @edition.parts.create!(
+        title: "Some Part Title!",
+        body: "This is some **version** text.",
+        slug: "part-one",
+        order: 1,
+      )
+    end
+
+    scenario "User manually visits the endpoint" do
+      visit review_admin_country_edition_part_path(@edition.country_slug, @edition, @part)
+      expect(page).to have_current_path(edit_admin_country_edition_part_path(@edition.country_slug, @edition, @part))
+    end
+  end
+
+  context "Published edition" do
+    before do
+      login_as_stub_user_with_design_system_permission
+      @edition = create(
+        :published_travel_advice_edition,
+        country_slug: "aruba",
+        summary: "Advice summary",
+        version_number: 1,
+      )
+      @part = @edition.parts.create!(
+        title: "Some Part Title!",
+        body: "This is some **version** text.",
+        slug: "part-one",
+        order: 1,
+      )
+    end
+
+    scenario "User visits page and sees summary list table" do
+      visit edit_admin_edition_path(@edition)
+      click_on "View #{@part.title}"
+
+      expect(page).to have_current_path(review_admin_country_edition_part_path(@edition.country_slug, @edition, @part))
+      expect(all(".govuk-summary-list__key")[0].text).to eq "Title"
+      expect(all(".govuk-summary-list__value")[0].text).to eq @part.title
+      expect(all(".govuk-summary-list__key")[1].text).to eq "Body"
+      expect(all(".govuk-summary-list__value")[1].text).to eq @part.body
+      expect(all(".govuk-summary-list__key")[2].text).to eq "Slug"
+      expect(all(".govuk-summary-list__value")[2].text).to eq @part.slug
+    end
+  end
+
+  context "Archived edition" do
+    before do
+      login_as_stub_user_with_design_system_permission
+      @edition = create(
+        :archived_travel_advice_edition,
+        country_slug: "aruba",
+        summary: "Advice summary",
+        version_number: 1,
+      )
+      @part = @edition.parts.create!(
+        title: "Some Part Title!",
+        body: "This is some **version** text.",
+        slug: "part-one",
+        order: 1,
+      )
+    end
+
+    scenario "User visits page and sees summary list table" do
+      visit edit_admin_edition_path(@edition)
+      click_on "View #{@part.title}"
+
+      expect(page).to have_current_path(review_admin_country_edition_part_path(@edition.country_slug, @edition, @part))
+      expect(all(".govuk-summary-list__key")[0].text).to eq "Title"
+      expect(all(".govuk-summary-list__value")[0].text).to eq @part.title
+      expect(all(".govuk-summary-list__key")[1].text).to eq "Body"
+      expect(all(".govuk-summary-list__value")[1].text).to eq @part.body
+      expect(all(".govuk-summary-list__key")[2].text).to eq "Slug"
+      expect(all(".govuk-summary-list__value")[2].text).to eq @part.slug
+    end
+  end
+end


### PR DESCRIPTION
## Description 

At the moment, there's nothing in place to stop someone from visiting the edit page for a part which belongs to an archived or published edition.

In this case it makes more sense for the user to visit a Part#Review endpoint where they see a summary of the information that was provided.

## Changes made 

- Update the parts section on the edit edition page to link to the review page if the edition is published or archived
- Add a review endpoint
- Enforce the correct behaviour for whether a user should visit the edit/review page in the controller 

The correct behaviour is:

### Draft editions 

1. See change links in the summary list component on the parts section of the edit editions page 
2. See the add new part button
3. Cannot visit the review page for a part - are redirected towards the edit page

### Published and archived editions

1. See view links in the summary list component on the parts section of the edit editions page 
2. Cannot see the add part button
3. cannot visit the edit page - are redirected to the review page

### Screenshots 

**Edit edition page - parts summary list** 

<img width="517" alt="image" src="https://user-images.githubusercontent.com/42515961/162994377-bf650d75-891f-443a-bbb9-ab8d8b6b5743.png">

**Review page** 

<img width="460" alt="image" src="https://user-images.githubusercontent.com/42515961/162994490-ff38f5b3-8da7-48af-ad87-b2d327e83b56.png">

### Trello card 

https://trello.com/c/E48t5WGw/365-travel-advice-move-adding-and-editing-govspeak-parts-to-their-own-flow

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
