### PR TITLE
Add manage ordering for parts

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -4,7 +4,7 @@ class Admin::EditionsController < ApplicationController
 
   before_action :skip_slimmer, except: :historical_edition
   before_action :load_country, only: [:create]
-  before_action :load_country_and_edition, only: %i[edit update destroy diff]
+  before_action :load_country_and_edition, only: %i[edit update destroy diff manage_part_ordering update_part_ordering]
   before_action :strip_empty_alert_statuses, only: :update
 
   def create
@@ -69,6 +69,24 @@ class Admin::EditionsController < ApplicationController
     render layout: "historical_edition"
   end
 
+  def manage_part_ordering
+    redirect_to edit_admin_edition_path(@edition) unless @edition.draft?
+  end
+
+  def update_part_ordering
+    redirect_to edit_admin_edition_path(@edition) unless @edition.draft?
+
+    if @edition.update(part_ordering_params)
+      notifier.put_content(@edition)
+      notifier.enqueue
+      flash["notice"] = "Parts reordered successfully"
+
+      redirect_to edit_admin_edition_path(@edition)
+    else
+      render :manage_part_ordering
+    end
+  end
+
 private
 
   def permitted_edition_attributes
@@ -107,6 +125,24 @@ private
         alert_status: params.dig("edition", "alert_status") || [],
       )
     end
+  end
+
+  def part_ordering_params
+    part_attributes_hash = {}
+
+    params[:ordering].each do |input|
+      part_id, order = input
+      part = @edition.parts.find(part_id)
+      part_attributes_hash[order] = {
+        "order" => order,
+        "id" => part_id,
+        "title" => part.title,
+        "body" => part.body,
+        "slug" => part.slug,
+      }
+    end
+
+    { parts_attributes: part_attributes_hash }
   end
 
   def load_country_and_edition

--- a/app/views/admin/editions/_parts.html.erb
+++ b/app/views/admin/editions/_parts.html.erb
@@ -5,6 +5,10 @@
     <%= render "govuk_publishing_components/components/summary_list", {
       title: "Parts (govspeak available)",
       borderless: true,
+      edit: ({
+        href: manage_part_ordering_admin_edition_path(@edition),
+        link_text: "Reorder",
+      } if @edition.draft? && @edition.parts.count > 1),
       items: @edition.parts.in_order.map do |part|
         {
           field: part.title,
@@ -15,7 +19,7 @@
           }
         }
       end
-    } %>
+    }.compact %>
   <% end %>
 
   <% if @edition.draft? %>

--- a/app/views/admin/editions/manage_part_ordering.html.erb
+++ b/app/views/admin/editions/manage_part_ordering.html.erb
@@ -1,0 +1,47 @@
+<% content_for :breadcrumbs do %>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    breadcrumbs: [
+      {
+        title: 'All countries',
+        url: admin_countries_path,
+      },
+      {
+        title: @country.name,
+        url: admin_country_path(@country.slug),
+      },
+      {
+        title: "Editing #{@country.name}",
+        url: edit_admin_edition_path(@edition),
+      },
+      {
+        title: "Reorder parts",
+      },
+    ]
+  } %>
+<% end %>
+
+
+<% content_for :title, "Reorder parts" %>
+
+<%= render 'shared/error_summary', object: @edition %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @edition, url: update_part_ordering_admin_edition_path, method: :patch do |f| %>
+      <div class="govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/reorderable_list", {
+          items: @edition.parts.in_order.map do |part|
+            {
+              id: part.id,
+              title: part.title,
+            }
+          end
+        } %>
+
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save",
+        } %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,8 @@ Rails.application.routes.draw do
     resources :editions, only: %i[edit update destroy] do
       get "diff/:compare_id", action: :diff, as: :diff, on: :member
       get "historical_edition"
+      get "manage_part_ordering", on: :member
+      patch "update_part_ordering", on: :member
     end
 
     root to: "countries#index"

--- a/spec/controllers/admin/editions_controller_spec.rb
+++ b/spec/controllers/admin/editions_controller_spec.rb
@@ -288,4 +288,29 @@ describe Admin::EditionsController do
       expect(assigns(:presenter).country).to eq(@country)
     end
   end
+
+  describe "manage_part_ordering" do
+    before do
+      login_as_stub_user
+      @country = Country.find_by_slug("aruba")
+    end
+
+    context "published edition" do
+      it "redirects to the edit edition page" do
+        @edition = create(:published_travel_advice_edition, country_slug: @country.slug)
+        get :manage_part_ordering, params: { id: @edition.id }
+
+        expect(response).to redirect_to(edit_admin_edition_path(@edition))
+      end
+    end
+
+    context "archived edition" do
+      it "redirects to the edit edition page" do
+        @edition = create(:archived_travel_advice_edition, country_slug: @country.slug)
+        get :manage_part_ordering, params: { id: @edition.id }
+
+        expect(response).to redirect_to(edit_admin_edition_path(@edition))
+      end
+    end
+  end
 end

--- a/spec/features/edition_manage_ordering_of_parts_with_design_system_spec.rb
+++ b/spec/features/edition_manage_ordering_of_parts_with_design_system_spec.rb
@@ -1,0 +1,69 @@
+feature "Edition manage part ordering" do
+  before do
+    login_as_stub_user_with_design_system_permission
+  end
+
+  scenario "Draft edition with multiple parts" do
+    @edition = create(
+      :travel_advice_edition_with_parts,
+      country_slug: "aruba",
+    )
+    @edition.save!
+
+    visit edit_admin_edition_path(@edition)
+    click_on "Reorder"
+
+    fill_in @edition.parts.first.title, with: "2"
+    fill_in @edition.parts.second.title, with: "1"
+    click_on "Save"
+
+    expect(page).to have_current_path(edit_admin_edition_path(@edition))
+    within "#parts" do
+      expect(all(".govuk-summary-list__key")[0].text).to eq @edition.parts.second.title
+      expect(all(".govuk-summary-list__key")[1].text).to eq @edition.parts.first.title
+    end
+  end
+
+  scenario "Draft edition with one part" do
+    @edition = create(
+      :travel_advice_edition,
+      country_slug: "aruba",
+    )
+
+    @edition.parts.create!(
+      title: "Title 1",
+      body: "Body 1",
+      slug: "title-one",
+      order: 1,
+    )
+
+    visit edit_admin_edition_path(@edition)
+
+    expect(page).not_to have_link("Reorder")
+  end
+
+  scenario "Publshed edition with with parts" do
+    @edition = create(
+      :travel_advice_edition_with_parts,
+      country_slug: "aruba",
+    )
+    @edition.publish!
+
+    visit edit_admin_edition_path(@edition)
+
+    expect(page).not_to have_link("Reorder")
+  end
+
+  scenario "Archived edition with with parts" do
+    @edition = create(
+      :travel_advice_edition_with_parts,
+      country_slug: "aruba",
+    )
+    @edition.publish!
+    @edition.archive!
+
+    visit edit_admin_edition_path(@edition)
+
+    expect(page).not_to have_link("Reorder")
+  end
+end


### PR DESCRIPTION
### Description 

This follows on from the work done in #1304 #1310 & #1311 which add functionality to add, edit and review parts. 

This PR adds the ability to reorder parts for a draft edition.

The current implementation uses drag and drop Javascript for the reordering of parts. With JS off, a user cannot reorder parts. It's also inaccessible for screen readers.

This page should only be accessible for draft editions as parts cannot be reordered for archived or published editions.

### Changes made 

- Add a `Reorder` link to the parts section of the edit edition page

<img width="479" alt="image" src="https://user-images.githubusercontent.com/42515961/163155727-51d18ad4-3b16-4d07-b678-2e2dbf9913b3.png">

- Add reorder page

<img width="546" alt="image" src="https://user-images.githubusercontent.com/42515961/163155788-db7c0f9d-e049-4daf-a1a3-b7d330ad9c23.png">


### Trello card 

https://trello.com/c/vhnuShqt/367-travel-advice-reordering-a-part

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
