### PR TITLE
Move historical editions to design system

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -1,6 +1,6 @@
 class Admin::EditionsController < ApplicationController
   include Slimmer::Headers
-  layout "legacy"
+  layout :get_layout
 
   before_action :skip_slimmer, except: :historical_edition
   before_action :load_country, only: [:create]
@@ -68,6 +68,16 @@ class Admin::EditionsController < ApplicationController
   end
 
 private
+
+  def is_legacy_layout?
+    !preview_design_system_user? || !["historical_edition"].include?(action_name)
+  end
+
+  def get_layout
+    return "legacy" if is_legacy_layout?
+
+    "design_system"
+  end
 
   def permitted_edition_attributes
     params.fetch(:edition, {}).permit(


### PR DESCRIPTION
## What
Migrate the Historical editions to the GOVUK design system

## Why
Migrating to DS will make it easier for users to use, consistent with the rest of GOVUK, and more accessible

## Other notes
Ignore the print page

https://trello.com/c/hCLCz4cl/356-travel-advice-historical-editions-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
