### PR TITLE
Migrate Diff / Compare page to Design system

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,3 +5,4 @@
 @import "govspeak";
 @import "side";
 @import "broken_links_report";
+@import "diff";

--- a/app/assets/stylesheets/diff.scss
+++ b/app/assets/stylesheets/diff.scss
@@ -6,6 +6,9 @@ $added-color: #ddffdd;
 $strong-added-color: #77f177;
 $removed-color: #ffdddd;
 $strong-removed-color: #ffaaaa;
+$gray-lighter: govuk-colour("light-grey");
+$state-danger-text: govuk-colour("red");
+$state-success-text: govuk-colour("green");
 
 .diff {
   border: 1px solid $gray-lighter;

--- a/app/assets/stylesheets/diff_legacy.scss
+++ b/app/assets/stylesheets/diff_legacy.scss
@@ -1,0 +1,80 @@
+// stylelint-disable max-nesting-depth
+
+// Diff of two editions
+
+$added-color: #ddffdd;
+$strong-added-color: #77f177;
+$removed-color: #ffdddd;
+$strong-removed-color: #ffaaaa;
+
+.diff {
+  border: 1px solid $gray-lighter;
+  border-left: 40px solid $gray-lighter;
+  border-radius: 3px;
+  padding: 15px;
+
+  ul {
+    padding-left: 0;
+
+    li {
+      min-height: 24px;
+      margin: 0 -15px;
+      padding: 0 15px;
+      word-wrap: break-word;
+      list-style: none;
+      position: relative;
+
+      del,
+      ins {
+        text-decoration: none;
+      }
+    }
+
+    .del,
+    .ins {
+      padding-top: 2px;
+    }
+
+    .del {
+      background-color: $removed-color;
+
+      strong {
+        font-weight: normal;
+        background-color: $strong-removed-color;
+      }
+    }
+
+    .ins {
+      background-color: $added-color;
+
+      strong {
+        font-weight: normal;
+        background-color: $strong-added-color;
+      }
+    }
+
+    .del:before,
+    .ins:before {
+      position: absolute;
+      font-weight: bold;
+      margin-left: -55px;
+      width: 40px;
+      text-align: center;
+      min-height: 24px;
+      top: 0;
+      bottom: 0;
+    }
+
+    .del:before {
+      color: $state-danger-text;
+      background-color: $removed-color;
+      content: "-";
+    }
+
+    .ins:before {
+      color: $state-success-text;
+      background-color: $added-color;
+      content: "+";
+    }
+  }
+}

--- a/app/assets/stylesheets/legacy.scss
+++ b/app/assets/stylesheets/legacy.scss
@@ -1,7 +1,7 @@
 @import "govuk_admin_template";
 @import "scaffold";
 @import "sortable_accordion";
-@import "diff";
+@import "diff_legacy";
 @import "broken_links_report";
 
 .js-hidden {

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -27,6 +27,12 @@ class Admin::EditionsController < ApplicationController
 
   def diff
     @comparison = @country.editions.find(params[:compare_id])
+
+    if is_legacy_layout?
+      render "diff_legacy"
+    else
+      render "diff"
+    end
   end
 
   def edit

--- a/app/views/admin/editions/diff.html.erb
+++ b/app/views/admin/editions/diff.html.erb
@@ -1,23 +1,56 @@
-<ul class="breadcrumb">
-  <li>
-    <%= link_to "All countries", admin_countries_path %>
-  </li>
-  <li><%= link_to @country.name, admin_country_path(@country.slug) %></li>
-  <li class="active">Editing <%= @country.name %></li>
-</ul>
-
-<div class="page-title">
-  <h1><%= @country.name %> <small>Comparing Version <%= @edition.version_number %> with <%= @comparison.version_number %></small></h1>
-</div>
-
-<p>
-  <%= link_to "Back to version #{@edition.version_number}", edit_admin_edition_path(@edition), :class => "btn btn-default" %>
-</p>
-
-<h2>Summary</h2>
-<%= diff_html(@comparison.summary, @edition.summary) %>
-
-<% @edition.parts.each_with_index do |part, index| %>
-  <h2><%= part.title.present? ? part.title : 'Untitled part' %></h2>
-  <%= diff_html(@comparison.parts[index].try(:body), part.body) %>
+<% content_for :breadcrumbs do %>
+  <%= render "govuk_publishing_components/components/breadcrumbs", {
+    breadcrumbs: [
+      {
+        title: 'All countries',
+        url: admin_countries_path,
+      },
+      {
+        title: @country.name,
+        url: admin_country_path(@country.slug),
+      },
+      {
+        title: "Editing #{@country.name}",
+      }
+    ]
+  } %>
 <% end %>
+
+<%= content_for :title, @country.name %>
+<%= content_for :context, "Comparing Version #{@edition.version_number} with #{@comparison.version_number}" %>
+
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    text: "Back to version #{@edition.version_number}",
+    href: edit_admin_edition_path(@edition)
+  } %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+
+    <div class="govuk-!-margin-bottom-5">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Summary",
+        margin_bottom: 3
+      } %>
+
+      <div class="govuk-body">
+        <%= diff_html(@comparison.summary, @edition.summary) %>
+      </div>
+    </div>
+
+    <% @edition.parts.each_with_index do |part, index| %>
+      <div class="govuk-!-margin-bottom-5">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: part.title.present? ? part.title : "Untitled part",
+          margin_bottom: 3
+        } %>
+
+        <div class="govuk-body">
+          <%= diff_html(@comparison.parts[index].try(:body), part.body) %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/editions/diff_legacy.html.erb
+++ b/app/views/admin/editions/diff_legacy.html.erb
@@ -1,0 +1,23 @@
+<ul class="breadcrumb">
+  <li>
+    <%= link_to "All countries", admin_countries_path %>
+  </li>
+  <li><%= link_to @country.name, admin_country_path(@country.slug) %></li>
+  <li class="active">Editing <%= @country.name %></li>
+</ul>
+
+<div class="page-title">
+  <h1><%= @country.name %> <small>Comparing Version <%= @edition.version_number %> with <%= @comparison.version_number %></small></h1>
+</div>
+
+<p>
+  <%= link_to "Back to version #{@edition.version_number}", edit_admin_edition_path(@edition), :class => "btn btn-default" %>
+</p>
+
+<h2>Summary</h2>
+<%= diff_html(@comparison.summary, @edition.summary) %>
+
+<% @edition.parts.each_with_index do |part, index| %>
+  <h2><%= part.title.present? ? part.title : 'Untitled part' %></h2>
+  <%= diff_html(@comparison.parts[index].try(:body), part.body) %>
+<% end %>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -18,8 +18,8 @@
     ].delete_if{ |item| item[:user_has_permission_to_see] == false },
   }%>
   <div class="govuk-width-container">
-    <%= yield(:back_link) %>
     <%= yield(:breadcrumbs) %>
+    <%= yield(:back_link) %>
 
     <main class="govuk-main-wrapper<%= " govuk-main-wrapper--l" if yield(:back_link).blank? && yield(:breadcrumbs).blank?%>" id="main-content" role="main">
       <% if flash["notice"].present? %>


### PR DESCRIPTION
## What
Migrate the Diff / Compare page to the GOVUK design system

## Why
Migrating to DS will make it easier for users to use, consistent with the rest of GOVUK, and more accessible

## Before
![old-version](https://user-images.githubusercontent.com/4599889/165771855-fd5a8ad1-1c2a-432f-911c-68fd06164360.png)

## After
![new-version](https://user-images.githubusercontent.com/4599889/165771902-ada2bb53-7966-436d-b9dd-09bca84c5a1f.png)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

https://trello.com/c/tTchBk7C/355-travel-advice-diff-compare-page