### PR TITLE
Alert statuses now returning a list of items

### DIFF
--- a/app/views/admin/editions/_summary_content_summary.html.erb
+++ b/app/views/admin/editions/_summary_content_summary.html.erb
@@ -1,9 +1,18 @@
+<%
+  alert_statuses = render("govuk_publishing_components/components/list", {
+    visible_counters: true,
+    items: alert_statuses_with_labels(@edition.alert_status).map do |option|
+      option.first
+    end
+  })
+%>
+
 <%= render "govuk_publishing_components/components/summary_list", {
   title: "Summary content",
   items: [
     {
       field: "Alert status",
-      value: @edition.alert_status
+      value: alert_statuses.present? ? alert_statuses : "None"
     },
     {
       field: "Map of #{@country.name}",


### PR DESCRIPTION
Previously it would return an array of items but this isn't very nice or accessible.

This change fixes this.

<img width="617" alt="Screenshot 2022-05-10 at 10 38 47 am" src="https://user-images.githubusercontent.com/4599889/167598975-0c67150c-9dc2-4ac2-ba40-c1ecb29208ce.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
