### PR TITLE
Small fixes for Travel Advice

### DIFF
--- a/app/views/admin/editions/_govspeak_guidance_design_system.html.erb
+++ b/app/views/admin/editions/_govspeak_guidance_design_system.html.erb
@@ -1,7 +1,7 @@
 <h3 class="govuk-heading-m govuk-!-margin-top-3">Govspeak help</h3>
 
 <div class="app-c-markdown-guidance">
-  <p>For full examples see <%= link_to "the Govspeak Wiki", "https://sites.google.com/a/digital.cabinet-office.gov.uk/wiki/projects-and-processes/processes/editorial/govspeak", target:"_blank", rel: "external", class: "govuk-link" %></p>
+  <p>For full examples see <%= link_to "the Govspeak Wiki", "https://govspeak-preview.publishing.service.gov.uk/guide", target:"_blank", rel: "external", class: "govuk-link" %></p>
 
   <%= render "govuk_publishing_components/components/details", {
     title: "Headers",

--- a/app/views/admin/editions/_tab_edit.html.erb
+++ b/app/views/admin/editions/_tab_edit.html.erb
@@ -46,7 +46,7 @@
             <% end %>
           <% end %>
           <%= preview_edition_link(@edition, false, { class: "govuk-link", style_as_button: true }) %>
-          <% if !@edition.draft? %>
+          <% if @edition.draft? %>
             <%= form_with url: admin_edition_path(@edition), method: :delete, classes: "govuk-!-margin-bottom-0" do |f| %>
               <%= render "govuk_publishing_components/components/button", {
                 text: "Delete edition",

--- a/app/views/admin/editions/_tab_edit.html.erb
+++ b/app/views/admin/editions/_tab_edit.html.erb
@@ -28,6 +28,13 @@
     <div class="app-side-wrapper">
       <div class="app-side">
         <div class="app-side__actions">
+          <% if !@country.has_draft_edition? %>
+            <%= form_with url: admin_country_editions_path(@country.slug), method: :post do |f| %>
+              <%= render "govuk_publishing_components/components/button", {
+                text: "Create new edition"
+              } %>
+            <% end %>
+          <% end %>
           <% if @edition.published? %>
             <%= form_for @edition, url: admin_edition_path(@edition), as: :edition, html: { multipart: true } do |f| %>
               <%= render "govuk_publishing_components/components/button", {
@@ -38,23 +45,15 @@
               } %>
             <% end %>
           <% end %>
-          <% if !@country.has_draft_edition? %>
-            <%= form_with url: admin_country_editions_path(@country.slug), method: :post do |f| %>
-              <%= render "govuk_publishing_components/components/button", {
-                text: "Create new edition"
-              } %>
-            <% end %>
-          <% end %>
+          <%= preview_edition_link(@edition, false, { class: "govuk-link", style_as_button: true }) %>
           <% if !@edition.draft? %>
             <%= form_with url: admin_edition_path(@edition), method: :delete, classes: "govuk-!-margin-bottom-0" do |f| %>
               <%= render "govuk_publishing_components/components/button", {
-                text: "Delete",
+                text: "Delete edition",
                 destructive: true,
               } %>
             <% end %>
           <% end %>
-
-          <%= preview_edition_link(@edition, false, { class: "govuk-link", style_as_button: true }) %>
         </div>
       </div>
       <div class="app-side">

--- a/app/views/admin/editions/_tab_edit.html.erb
+++ b/app/views/admin/editions/_tab_edit.html.erb
@@ -62,11 +62,13 @@
           <%= render "admin/link_check_reports/link_check_report", edition: @edition, report: @edition.latest_link_check_report %>
         </div>
       </div>
-      <div class="app-side">
-        <div class="app-side__actions">
-          <%= render "govspeak_guidance_design_system" %>
+      <% if @edition.draft? %>
+        <div class="app-side">
+          <div class="app-side__actions">
+            <%= render "govspeak_guidance_design_system" %>
+          </div>
         </div>
-      </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/admin/editions/_tab_history.html.erb
+++ b/app/views/admin/editions/_tab_history.html.erb
@@ -1,6 +1,6 @@
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <div>
+<% if @edition.draft? %>
+  <div class="govuk-grid-row govuk-!-margin-bottom-9">
+    <div class="govuk-grid-column-two-thirds">
       <%= form_for @edition, url: admin_edition_path(@edition) do |f| %>
         <%= render "govuk_publishing_components/components/textarea", {
           label: {
@@ -19,36 +19,42 @@
         } %>
       <% end %>
     </div>
-    <div class="govuk-!-margin-top-6">
-      <h2 class="govuk-heading-m">Version history</h2>
-      <%
-        items = []
-        @country.editions.each do | edition |
-          content = ""
-          edition.actions.reverse.each do |action|
-            content += render("edition_action", action: action)
-          end
+  </div>
+<% end %>
 
-          items.push({
-            heading: {
-              text: "Version #{edition.version_number}"
-            },
-            summary: {
-              text: (link_to(
-                "Compare with version #{edition.version_number - 1}",
-                diff_admin_edition_path(edition.to_param, compare_id: edition.previous_version.to_param),
-                class: "govuk-link govuk-body compare-version-link"
-              ) if edition.version_number > 1),
-            }.compact,
-            content: {
-              html: sanitize(content)
-            }
-          })
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Version history",
+      margin_bottom: 6
+    } %>
+    <%
+      items = []
+      @country.editions.each do | edition |
+        content = ""
+        edition.actions.reverse.each do |action|
+          content += render("edition_action", action: action)
         end
-      %>
-      <%= render "govuk_publishing_components/components/accordion", {
-        items: items
-      } %>
-    </div>
+
+        items.push({
+          heading: {
+            text: "Version #{edition.version_number}"
+          },
+          summary: {
+            text: (link_to(
+              "Compare with version #{edition.version_number - 1}",
+              diff_admin_edition_path(edition.to_param, compare_id: edition.previous_version.to_param),
+              class: "govuk-link govuk-body compare-version-link"
+            ) if edition.version_number > 1),
+          }.compact,
+          content: {
+            html: sanitize(content)
+          }
+        })
+      end
+    %>
+    <%= render "govuk_publishing_components/components/accordion", {
+      items: items
+    } %>
   </div>
 </div>


### PR DESCRIPTION
Small fixes found during testing, see commit messages or issue doc for further information:
- [Only show GovSpeak help on draft editions](https://github.com/alphagov/travel-advice-publisher/pull/1339/commits/52348424ded4bd1414a862949ff722acc25233d6)
- [Reorder buttons so primary buttons are first](https://github.com/alphagov/travel-advice-publisher/pull/1339/commits/d89d8db7d508c4071d04c1e530e8dd0a91fa8f69)
- [only show delete button on draft mode](https://github.com/alphagov/travel-advice-publisher/pull/1339/commits/a43199dc04bc57e6a2572b12a5f17df61cef934b)
- [update govspeak wiki links](https://github.com/alphagov/travel-advice-publisher/pull/1339/commits/4e7d855e099f75c5938ecaa29cd7e871337e7501)
- [change history tab layout and only show notes input in draft mode](https://github.com/alphagov/travel-advice-publisher/pull/1339/commits/18b75bd68d1769e0315cd739e90814fc9df49cc5)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
