### PR TITLE
Adds ajax request for broken links

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -3,3 +3,4 @@
 //= require govuk_publishing_components/analytics
 //= require analytics
 //= require ./modules/parts
+//= require ./modules/broken_links

--- a/app/assets/javascripts/modules/broken_links.js
+++ b/app/assets/javascripts/modules/broken_links.js
@@ -26,7 +26,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
             .querySelector('.js-broken-links__content')
             .innerHTML = '<p class="govuk-body"><strong>Error occured when checking for broken links.</strong></p>' +
               '<p class="govuk-body">Status code ' + res.currentTarget.status + ': ' + res.currentTarget.statusText + '</p>' +
-              '<p class="govuk-body">Please refresh the page and try again.</p>'
+              '<p class="govuk-body">Please refresh the page and try again (please save any changes before refreshing).</p>'
         }
       }.bind(this)
       request.send()
@@ -34,7 +34,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       this.module
         .querySelector('.js-broken-links__content')
         .innerHTML = '<p class="govuk-body"><strong>Please wait. Broken link report in progress.</strong></p>' +
-          '<p class="govuk-body">Refresh the page to view to see the result.</p>'
+          '<p class="govuk-body">Refresh the page to view to see the result (please save any changes before refreshing).</p>'
       e.currentTarget.remove()
     }.bind(this))
   }

--- a/app/assets/javascripts/modules/broken_links.js
+++ b/app/assets/javascripts/modules/broken_links.js
@@ -23,18 +23,19 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       request.onreadystatechange = function (res) {
         if (res.currentTarget.readyState === 4 && res.currentTarget.status !== 200) {
           this.module
-            .querySelector('.js-broken-links__text')
-            .innerHTML = '<strong>Error occured when checking for broken links.</strong><br/><br/>' +
-              'Status code ' + res.currentTarget.status + ': ' + res.currentTarget.statusText + '<br/><br/>' +
-              'Please refresh the page and try again.'
+            .querySelector('.js-broken-links__content')
+            .innerHTML = '<p class="govuk-body"><strong>Error occured when checking for broken links.</strong></p>' +
+              '<p class="govuk-body">Status code ' + res.currentTarget.status + ': ' + res.currentTarget.statusText + '</p>' +
+              '<p class="govuk-body">Please refresh the page and try again.</p>'
         }
       }.bind(this)
       request.send()
 
-      e.currentTarget.remove()
       this.module
-        .querySelector('.js-broken-links__text')
-        .innerHTML = '<strong>Please wait. Broken link report in progress.</strong><br/><br/>Refresh the page to view to see the result.'
+        .querySelector('.js-broken-links__content')
+        .innerHTML = '<p class="govuk-body"><strong>Please wait. Broken link report in progress.</strong></p>' +
+          '<p class="govuk-body">Refresh the page to view to see the result.</p>'
+      e.currentTarget.remove()
     }.bind(this))
   }
 

--- a/app/assets/javascripts/modules/broken_links.js
+++ b/app/assets/javascripts/modules/broken_links.js
@@ -1,0 +1,42 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function BrokenLinks (module) {
+    this.module = module
+  }
+
+  BrokenLinks.prototype.init = function () {
+    this.initFormListener()
+  }
+
+  BrokenLinks.prototype.initFormListener = function () {
+    var form = this.module.querySelector('.js-broken-links__form')
+    if (!form) return
+
+    form.addEventListener('submit', function (e) {
+      e.preventDefault()
+
+      var request = new XMLHttpRequest()
+      request.open('POST', e.currentTarget.action, true)
+      request.setRequestHeader('x-csrf-token', document.querySelector('meta[name=csrf-token]').content)
+      request.onreadystatechange = function (res) {
+        if (res.currentTarget.readyState === 4 && res.currentTarget.status !== 200) {
+          this.module
+            .querySelector('.js-broken-links__text')
+            .innerHTML = '<strong>Error occured when checking for broken links.</strong><br/><br/>' +
+              'Status code ' + res.currentTarget.status + ': ' + res.currentTarget.statusText + '<br/><br/>' +
+              'Please refresh the page and try again.'
+        }
+      }.bind(this)
+      request.send()
+
+      e.currentTarget.remove()
+      this.module
+        .querySelector('.js-broken-links__text')
+        .innerHTML = '<strong>Please wait. Broken link report in progress.</strong><br/><br/>Refresh the page to view to see the result.'
+    }.bind(this))
+  }
+
+  Modules.BrokenLinks = BrokenLinks
+})(window.GOVUK.Modules)

--- a/app/assets/stylesheets/broken_links_report.scss
+++ b/app/assets/stylesheets/broken_links_report.scss
@@ -1,52 +1,13 @@
-.link-check-report {
-  float: right;
-  margin-top: 25px;
-}
-
 .broken-links-report {
   word-break: break-word;
+}
 
-  .issue-summary {
-    font-weight: normal;
-  }
+// overrides
 
-  .issue-list {
-    list-style: none;
-    padding-left: 0;
+.broken-links-report__link.govuk-link {
+  @include govuk-font(16);
+}
 
-    li {
-      margin-top: govuk-spacing(1);
-    }
-  }
-
-  .issue-status-description {
-    margin-top: govuk-spacing(2);
-  }
-
-  .issue-list + .issue-status-description {
-    margin: govuk-spacing(3) 0;
-  }
-
-  .display-issue-details {
-    display: block;
-    font-weight: bold;
-    padding-top: govuk-spacing(1);
-  }
-
-  .display-issue-details::-webkit-details-marker {
-    display: none;
-  }
-
-  .display-issue-details:before {
-    content: "\25B6";
-    padding-right: 3px;
-  }
-
-  details[open] > .display-issue-details:before {
-    content: "\25BC";
-  }
-
-  .issues-link-design-system {
-    word-wrap: break-word;
-  }  /* TODO: clean this file up once we're only using the design system */
+.broken-links-report__link-details .gem-c-details {
+  @include govuk-font(16);
 }

--- a/app/assets/stylesheets/broken_links_report.scss
+++ b/app/assets/stylesheets/broken_links_report.scss
@@ -4,6 +4,8 @@
 }
 
 .broken-links-report {
+  word-break: break-word;
+
   .issue-summary {
     font-weight: normal;
   }
@@ -13,22 +15,22 @@
     padding-left: 0;
 
     li {
-      margin-top: 5px;
+      margin-top: govuk-spacing(1);
     }
   }
 
   .issue-status-description {
-    margin-top: 10px;
+    margin-top: govuk-spacing(2);
   }
 
   .issue-list + .issue-status-description {
-    margin: 15px 0;
+    margin: govuk-spacing(3) 0;
   }
 
   .display-issue-details {
     display: block;
     font-weight: bold;
-    padding-top: 5px;
+    padding-top: govuk-spacing(1);
   }
 
   .display-issue-details::-webkit-details-marker {

--- a/app/assets/stylesheets/broken_links_report_legacy.scss
+++ b/app/assets/stylesheets/broken_links_report_legacy.scss
@@ -1,0 +1,48 @@
+.link-check-report {
+  float: right;
+  margin-top: 25px;
+}
+
+.broken-links-report {
+  word-break: break-word;
+
+  .issue-summary {
+    font-weight: normal;
+  }
+
+  .issue-list {
+    list-style: none;
+    padding-left: 0;
+
+    li {
+      margin-top: 5px;
+    }
+  }
+
+  .issue-status-description {
+    margin-top: 10px;
+  }
+
+  .issue-list + .issue-status-description {
+    margin: 15px 0;
+  }
+
+  .display-issue-details {
+    display: block;
+    font-weight: bold;
+    padding-top: 5px;
+  }
+
+  .display-issue-details::-webkit-details-marker {
+    display: none;
+  }
+
+  .display-issue-details:before {
+    content: "\25B6";
+    padding-right: 3px;
+  }
+
+  details[open] > .display-issue-details:before {
+    content: "\25BC";
+  }
+}

--- a/app/assets/stylesheets/legacy.scss
+++ b/app/assets/stylesheets/legacy.scss
@@ -2,7 +2,7 @@
 @import "scaffold";
 @import "sortable_accordion";
 @import "diff_legacy";
-@import "broken_links_report";
+@import "broken_links_report_legacy";
 
 .js-hidden {
   .js & {

--- a/app/views/admin/link_check_reports/_form.html.erb
+++ b/app/views/admin/link_check_reports/_form.html.erb
@@ -1,5 +1,5 @@
-<form action="<%= link_check_reports_path(edition_id: edition.id) %>" method="post" ata-remote="true" rel="nofollow">
-    <%= render "govuk_publishing_components/components/button", {
+<form action="<%= link_check_reports_path(edition_id: edition.id) %>" method="post" class="js-broken-links__form">
+  <%= render "govuk_publishing_components/components/button", {
     text: button_text,
     secondary: true,
   } %>

--- a/app/views/admin/link_check_reports/_link_check_report.html.erb
+++ b/app/views/admin/link_check_reports/_link_check_report.html.erb
@@ -3,7 +3,6 @@
     <p class="govuk-body js-broken-links__text">Check this edition for broken links. The report will take a few moments to complete. It only runs against GovSpeak fields.</p>
     <%= render "admin/link_check_reports/form", edition: edition, button_text: "Check for broken links" %>
   <% elsif report.in_progress? %>
-    <% #TODO: see if this works once the JS is fixed %>
     <%= image_tag("ajax_loader_blue_32.gif", width: 24, height: 24, class: "pull-left add-right-margin") %>
     <p class="govuk-body">Broken link report in progress.</p>
     <p class="govuk-body">Please wait. Refresh the page to view to see the result.</p>
@@ -12,19 +11,21 @@
     <% report.links.sort_by(&:status).group_by(&:status).each do |status, links| %>
       <% next unless %w(broken caution).include? status %>
       <h4 class="govuk-heading-s govuk-!-margin-top-2"><%= status.capitalize %></h4>
-      <ul class="issue-list">
+      <ul class="issue-list govuk-list">
         <% links.each do |link| %>
           <li class="govuk-!-margin-top-1">
-            <%= link_to link.uri.truncate(50), link.uri, title: link.uri, class: "issues-link-design-system govuk-link govuk-!-margin-bottom-2" %>
+            <%= link_to link.uri.truncate(50), link.uri, title: link.uri, class: "issues-link-design-system govuk-link" %>
 
-            <%= render "govuk_publishing_components/components/details", {
-              title: "See more details about this link"
-            } do %>
-              <p class="govuk-body"><%= link.problem_summary %></p>
-              <% if link.suggested_fix %>
-                <p class="govuk-body">Suggested fix: <%= link.suggested_fix %></p>
+            <div class="govuk-!-margin-top-3">
+              <%= render "govuk_publishing_components/components/details", {
+                title: "See more details about this link"
+              } do %>
+                <p class="govuk-body-s"><%= link.problem_summary %></p>
+                <% if link.suggested_fix %>
+                  <p class="govuk-body-s"><strong>Suggested fix:</strong> <%= link.suggested_fix %></p>
+                <% end %>
               <% end %>
-            <% end %>
+            </div>
           </li>
         <% end %>
       </ul>

--- a/app/views/admin/link_check_reports/_link_check_report.html.erb
+++ b/app/views/admin/link_check_reports/_link_check_report.html.erb
@@ -2,21 +2,30 @@
   <% if !report.present? %>
     <p class="govuk-body js-broken-links__text">Check this edition for broken links. The report will take a few moments to complete. It only runs against GovSpeak fields.</p>
     <%= render "admin/link_check_reports/form", edition: edition, button_text: "Check for broken links" %>
-  <% elsif report.in_progress? %>
-    <%= image_tag("ajax_loader_blue_32.gif", width: 24, height: 24, class: "pull-left add-right-margin") %>
-    <p class="govuk-body">Broken link report in progress.</p>
-    <p class="govuk-body">Please wait. Refresh the page to view to see the result.</p>
   <% elsif report.broken_links.any? || report.caution_links.any? %>
-    <h3 class="govuk-heading-m">Links</h3>
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Links",
+      heading_level: 3,
+      font_size: "m",
+      margin_bottom: 2,
+    } %>
+
     <% report.links.sort_by(&:status).group_by(&:status).each do |status, links| %>
       <% next unless %w(broken caution).include? status %>
-      <h4 class="govuk-heading-s govuk-!-margin-top-2"><%= status.capitalize %></h4>
-      <ul class="issue-list govuk-list">
-        <% links.each do |link| %>
-          <li class="govuk-!-margin-top-1">
-            <%= link_to link.uri.truncate(50), link.uri, title: link.uri, class: "issues-link-design-system govuk-link" %>
 
-            <div class="govuk-!-margin-top-3">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: status.capitalize,
+        heading_level: 4,
+        font_size: "s",
+        margin_bottom: 2,
+      } %>
+
+      <ul class="govuk-list">
+        <% links.each do |link| %>
+          <li>
+            <%= link_to link.uri.truncate(50), link.uri, title: link.uri, class: "govuk-link broken-links-report__link" %>
+
+            <div class="govuk-!-margin-top-3 broken-links-report__link-details">
               <%= render "govuk_publishing_components/components/details", {
                 title: "See more details about this link"
               } do %>
@@ -30,6 +39,7 @@
         <% end %>
       </ul>
     <% end %>
+
     <%= render "admin/link_check_reports/form", edition: edition, button_text: "Check again" %>
   <% else %>
     <p class="govuk-body js-broken-links__text">This edition contains no broken links.</p>

--- a/app/views/admin/link_check_reports/_link_check_report.html.erb
+++ b/app/views/admin/link_check_reports/_link_check_report.html.erb
@@ -1,6 +1,6 @@
-<div class="broken-links-report">
+<div class="broken-links-report" data-module="broken-links">
   <% if !report.present? %>
-    <p class="govuk-body">Check this edition for broken links. The report will take a few moments to complete. It only runs against GovSpeak fields.</p>
+    <p class="govuk-body js-broken-links__text">Check this edition for broken links. The report will take a few moments to complete. It only runs against GovSpeak fields.</p>
     <%= render "admin/link_check_reports/form", edition: edition, button_text: "Check for broken links" %>
   <% elsif report.in_progress? %>
     <% #TODO: see if this works once the JS is fixed %>
@@ -31,7 +31,7 @@
     <% end %>
     <%= render "admin/link_check_reports/form", edition: edition, button_text: "Check again" %>
   <% else %>
-    <p class="govuk-body">This edition contains no broken links.</p>
+    <p class="govuk-body js-broken-links__text">This edition contains no broken links.</p>
     <%= render "admin/link_check_reports/form", edition: edition, button_text: "Check again" %>
   <% end %>
 </div>

--- a/app/views/admin/link_check_reports/_link_check_report.html.erb
+++ b/app/views/admin/link_check_reports/_link_check_report.html.erb
@@ -1,7 +1,14 @@
 <div class="broken-links-report" data-module="broken-links">
   <% if !report.present? %>
-    <p class="govuk-body js-broken-links__text">Check this edition for broken links. The report will take a few moments to complete. It only runs against GovSpeak fields.</p>
+    <div class="js-broken-links__content">
+      <p class="govuk-body">Check this edition for broken links. The report will take a few moments to complete. It only runs against GovSpeak fields.</p>
+    </div>
     <%= render "admin/link_check_reports/form", edition: edition, button_text: "Check for broken links" %>
+  <% elsif report.in_progress? %>
+    <div class="js-broken-links__content">
+      <p class="govuk-body"><strong>Please wait. Broken link report in progress.</strong></p>
+      <p class="govuk-body">Refresh the page to view to see the result.</p>
+    </div>
   <% elsif report.broken_links.any? || report.caution_links.any? %>
     <%= render "govuk_publishing_components/components/heading", {
       text: "Links",
@@ -10,39 +17,43 @@
       margin_bottom: 2,
     } %>
 
-    <% report.links.sort_by(&:status).group_by(&:status).each do |status, links| %>
-      <% next unless %w(broken caution).include? status %>
+    <div class="js-broken-links__content">
+      <% report.links.sort_by(&:status).group_by(&:status).each do |status, links| %>
+        <% next unless %w(broken caution).include? status %>
 
-      <%= render "govuk_publishing_components/components/heading", {
-        text: status.capitalize,
-        heading_level: 4,
-        font_size: "s",
-        margin_bottom: 2,
-      } %>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: status.capitalize,
+          heading_level: 4,
+          font_size: "s",
+          margin_bottom: 2,
+        } %>
 
-      <ul class="govuk-list">
-        <% links.each do |link| %>
-          <li>
-            <%= link_to link.uri.truncate(50), link.uri, title: link.uri, class: "govuk-link broken-links-report__link" %>
+        <ul class="govuk-list">
+          <% links.each do |link| %>
+            <li>
+              <%= link_to link.uri.truncate(50), link.uri, title: link.uri, class: "govuk-link broken-links-report__link" %>
 
-            <div class="govuk-!-margin-top-3 broken-links-report__link-details">
-              <%= render "govuk_publishing_components/components/details", {
-                title: "See more details about this link"
-              } do %>
-                <p class="govuk-body-s"><%= link.problem_summary %></p>
-                <% if link.suggested_fix %>
-                  <p class="govuk-body-s"><strong>Suggested fix:</strong> <%= link.suggested_fix %></p>
+              <div class="govuk-!-margin-top-3 broken-links-report__link-details">
+                <%= render "govuk_publishing_components/components/details", {
+                  title: "See more details about this link"
+                } do %>
+                  <p class="govuk-body-s"><%= link.problem_summary %></p>
+                  <% if link.suggested_fix %>
+                    <p class="govuk-body-s"><strong>Suggested fix:</strong> <%= link.suggested_fix %></p>
+                  <% end %>
                 <% end %>
-              <% end %>
-            </div>
-          </li>
-        <% end %>
-      </ul>
-    <% end %>
+              </div>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+    </div>
 
     <%= render "admin/link_check_reports/form", edition: edition, button_text: "Check again" %>
   <% else %>
-    <p class="govuk-body js-broken-links__text">This edition contains no broken links.</p>
+    <div class="js-broken-links__content">
+      <p class="govuk-body">This edition contains no broken links.</p>
+    </div>
     <%= render "admin/link_check_reports/form", edition: edition, button_text: "Check again" %>
   <% end %>
 </div>


### PR DESCRIPTION
This is currently just a placeholder until we have redesigned the view to not be one form.

This is done to prevent the form from refreshing without the user saving their changes

<img width="311" alt="Screenshot 2022-05-11 at 3 03 54 pm" src="https://user-images.githubusercontent.com/4599889/167869951-3afffbd9-a2d2-465e-b98c-8c902cb7775a.png">

<img width="312" alt="Screenshot 2022-05-11 at 3 04 22 pm" src="https://user-images.githubusercontent.com/4599889/167869956-15aea94b-c37f-45f3-9f3b-6af6230f31a9.png">

https://trello.com/c/e7v57JL5/436-add-ajax-to-broken-links


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
