### PR TITLE
Add Paste HTML to Govspeak

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM ruby:2.7.6
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential nodejs && apt-get clean
+
+# Add yarn to apt sources
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential nodejs yarn && apt-get clean
 RUN gem install foreman
 
 # This image is only intended to be able to run this app in a production RAILS_ENV
@@ -17,6 +22,7 @@ ADD Gemfile* $APP_HOME/
 RUN bundle config set deployment 'true'
 RUN bundle config set without 'development test'
 RUN bundle install --jobs 4
+RUN yarn install --production --frozen-lockfile
 ADD . $APP_HOME
 
 RUN GOVUK_APP_DOMAIN=www.gov.uk \

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,3 +4,4 @@
 //= require analytics
 //= require ./modules/parts
 //= require ./modules/broken_links
+//= require ./modules/paste_html_to_govspeak

--- a/app/assets/javascripts/modules/paste_html_to_govspeak.js
+++ b/app/assets/javascripts/modules/paste_html_to_govspeak.js
@@ -1,0 +1,16 @@
+//= require paste-html-to-govspeak/dist/paste-html-to-markdown.js
+
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function PasteHtmlToGovspeak (module) {
+    this.module = module
+  }
+
+  PasteHtmlToGovspeak.prototype.init = function () {
+    this.module.addEventListener('paste', window.pasteHtmlToGovspeak.pasteListener)
+  }
+
+  Modules.PasteHtmlToGovspeak = PasteHtmlToGovspeak
+})(window.GOVUK.Modules)

--- a/app/views/admin/editions/_part.html.erb
+++ b/app/views/admin/editions/_part.html.erb
@@ -19,6 +19,9 @@
         text: "Body",
         bold: true,
       },
+      data: {
+        module: "paste-html-to-govspeak",
+      },
       name: "edition[parts_attributes][#{index}][body]",
       rows: 15,
       value: part[:body],

--- a/app/views/admin/editions/_summary_content.html.erb
+++ b/app/views/admin/editions/_summary_content.html.erb
@@ -91,6 +91,9 @@
         text: "Summary (govspeak available)",
         bold: true,
       },
+      data: {
+        module: "paste-html-to-govspeak",
+      },
       name: "edition[summary]",
       id: "edition_summary",
       rows: 20,

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -4,7 +4,7 @@
 Rails.application.config.assets.version = "1.0"
 
 # Add additional assets to the asset load path.
-# Rails.application.config.assets.paths << Emoji.images_path
+Rails.application.config.assets.paths << Rails.root.join("node_modules")
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,0 +1,1 @@
+Rake::Task["assets:precompile"].enhance(["yarn:install"])

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "standardx": "^7.0.0",
     "stylelint": "^14.8.2",
     "stylelint-config-gds": "^0.2.0"
+  },
+  "dependencies": {
+    "paste-html-to-govspeak": "^0.2.6"
   }
 }

--- a/spec/javascripts/spec/paste_html_to_govspeak.spec.js
+++ b/spec/javascripts/spec/paste_html_to_govspeak.spec.js
@@ -1,0 +1,31 @@
+/* global GOVUK */
+
+describe('GOVUK.Modules.PasteHtmlToGovspeak', function () {
+  var textarea
+
+  function createHtmlPasteEvent (html = null) {
+    var event = new window.Event('paste')
+    event.clipboardData = {
+      getData: (type) => {
+        if (type === 'text/html') {
+          return html
+        }
+      }
+    }
+
+    return event
+  }
+
+  beforeEach(function () {
+    textarea = document.createElement('textarea')
+
+    var pasteHtmlToGovspeak = new GOVUK.Modules.PasteHtmlToGovspeak(textarea)
+    pasteHtmlToGovspeak.init()
+  })
+
+  it('responds to a paste event by converting the HTML to Govspeak', function () {
+    textarea.dispatchEvent(createHtmlPasteEvent('<h2>This is a h2</h2>'))
+
+    expect(textarea.value).toEqual('## This is a h2')
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1846,6 +1846,11 @@ parseurl@~1.3.3:
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
+paste-html-to-govspeak@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/paste-html-to-govspeak/-/paste-html-to-govspeak-0.2.6.tgz#a7bbb5e2b7ce4b38a0fec68febf67001d4764163"
+  integrity sha512-vRF4DbxgVqaI5bCFWrNAxRHSPY1NYNAwKR9M1v0YB928kvrh0TOvPGY9R67nzRm44L8Fn/+TdILA/NldeN2RjQ==
+
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"


### PR DESCRIPTION
## What
Converts pasted formatted content to GovSpeak

## Why
This work will reduce the effort and time for publishers to create new content.

## How to test

1. Create a draft edition in any country
2. Go to any HTML page on the internet and copy the content
3. Paste into "Summary" textarea
4. Check if it converts the pasted content into markdown
5. Create a new part and paste into the "body" textarea
6. Check if it converts the pasted content into markdown

https://trello.com/c/67fZL71E/437-add-paste-html-to-govspeak-to-travel-advice

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
