### PR TITLE
Apply govuk-link styling to the `preview_edition_link` helper method

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,7 +24,7 @@ module ApplicationHelper
       )
     end
 
-    link_to(name, url, options.merge(target: "_blank"))
+    link_to(name, url, options.merge(target: "_blank", class: "govuk-link"))
   end
 
   def timestamp(time)


### PR DESCRIPTION
At the moment, the correct styling isn't applied and it looks pretty bad next to a correctly styled link

### Before 

<img width="535" alt="image" src="https://user-images.githubusercontent.com/42515961/170673299-c11d8afe-96a9-45ee-8be3-570e5a2ccf7b.png">

### After

<img width="542" alt="image" src="https://user-images.githubusercontent.com/42515961/170673215-bdd9c4a6-8521-403b-a810-4913fbaae194.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
