### PR TITLE
Remove create and show broken links report AJAX behaviour

### DIFF
--- a/app/controllers/link_check_reports_controller.rb
+++ b/app/controllers/link_check_reports_controller.rb
@@ -8,19 +8,13 @@ class LinkCheckReportsController < ApplicationController
 
     @report = service.call
 
-    respond_to do |format|
-      format.js { render "admin/link_check_reports/create" }
-      format.html { redirect_to edit_admin_edition_url(@edition.id) }
-    end
+    redirect_to edit_admin_edition_url(@edition.id)
   end
 
   def show
     @report = @edition.link_check_reports.find_by(id: params[:id])
 
-    respond_to do |format|
-      format.js { render "admin/link_check_reports/show" }
-      format.html { redirect_to edit_admin_edition_url(@edition.id) }
-    end
+    redirect_to edit_admin_edition_url(@edition.id)
   end
 
 private

--- a/app/views/admin/link_check_reports/create.js.erb
+++ b/app/views/admin/link_check_reports/create.js.erb
@@ -1,1 +1,0 @@
-$('.broken-links-report').replaceWith('<%=escape_javascript render("admin/link_check_reports/link_check_report_legacy", report: @report, edition: @edition ) %>');

--- a/app/views/admin/link_check_reports/show.js.erb
+++ b/app/views/admin/link_check_reports/show.js.erb
@@ -1,3 +1,0 @@
-<% if @report.completed? %>
-  $('.broken-links-report').replaceWith('<%=escape_javascript render("admin/link_check_reports/link_check_report_legacy", report: @report, edition: @edition ) %>');
-<% end %>

--- a/spec/controllers/link_check_reports_spec.rb
+++ b/spec/controllers/link_check_reports_spec.rb
@@ -18,23 +18,12 @@ describe LinkCheckReportsController, type: :controller do
     end
 
     context "#create" do
-      it "should create a link report and redirect on a normal request" do
+      it "should create a link report and redirect" do
         subject = post :create, params: { edition_id: travel_advice_edition.id }
         travel_advice_edition.reload
 
         expect(travel_advice_edition.link_check_reports.any?).to eq(true)
         expect(subject).to redirect_to(edit_admin_edition_path(travel_advice_edition.id))
-      end
-
-      it "should create and render the template on AJAX" do
-        subject = post :create, params: { edition_id: travel_advice_edition.id }, xhr: true
-        travel_advice_edition.reload
-
-        expect(response.status).to eq(200)
-        expect(subject).to render_template(:create)
-
-        expect(travel_advice_edition.link_check_reports.any?).to eq(true)
-        expect(travel_advice_edition.latest_link_check_report.batch_id).to eq(5)
       end
     end
 
@@ -52,14 +41,6 @@ describe LinkCheckReportsController, type: :controller do
         get :show, params: { id: link_check_report.id, edition_id: travel_advice_edition_id }
 
         expect(response).to redirect_to(edit_admin_edition_path(travel_advice_edition_id))
-      end
-
-      it "AJAX GET assigns the LinkCheckReport and renders the show template" do
-        get :show, params: { id: link_check_report.id, edition_id: travel_advice_edition_id }, xhr: true
-
-        expect(response).to render_template("admin/link_check_reports/show")
-        expect(assigns(:report)).to eq(link_check_report)
-        expect(assigns(:edition)).to eq(link_check_report.travel_advice_edition)
       end
     end
   end


### PR DESCRIPTION
## Description

We no longer use AJAX to dynamically render the broken links report. This fixes a bug in which legacy views which have been deleted are called returning a 500.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
