### PR TITLE
Disable Publishing E2E Tests for this repo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,9 +6,7 @@ node {
   // Run against the MongoDB 3.6 Docker instance on GOV.UK CI
   govuk.setEnvar("TEST_MONGODB_URI", "mongodb://127.0.0.1:27036/travel-advice-publisher-test")
 
-  govuk.setEnvar("PUBLISHING_E2E_TESTS_COMMAND", "test-travel-advice-publisher")
   govuk.buildProject(
-    publishingE2ETests: true,
     brakeman: true
   )
 }


### PR DESCRIPTION
Analysis of the coverage provided by these tests shows they are
redundant and can be safely removed [^1]*. Before we can remove
them, we need to stop trying to run them here.

NOTE: to merge this PR you will need to disable E2E tests as a 
required check, since they aren't going to run.

*The argument is more subtle for this repo as travel advice makes
use of multiple routes to achieve a kind of "anchor" feature on
the page - even though there is only one content item [^2]. This
is not covered by any other E2E test, however:

- Other E2E tests do send an array of routes (with a single item)
[^3], so the relevant data flows are all the same.

- We do have a test for multi-route behaviour in the one place I
would expect this to exist [^4], as well as corresponding tests
for the "anchor" behaviour in the frontend [^5].

While this is makes the argument more subtle, I think it would be
a shame to enforce E2E tests for this repo based on something of
a technicality. I don't see any elevated risk from this subtlety.

WARNING: this is a one-off argument / decision that only applies
to this repo and two others, and should not be repeated. This
change does not set a precedent for removing any other apps or
tests from publishing-e2e-tests until the full condition of the
Continuous Deployment (CD) RFC is met i.e. we have enabled CD
for all of the supported, non-frontend apps [^6].

[^1]: https://docs.google.com/spreadsheets/d/1Rp9afBgwm-QvLgMYKairC5U51HbHbihjS6F6XHtaf_E/edit#gid=0
[^2]: https://github.com/alphagov/travel-advice-publisher/blob/main/app/presenters/edition_presenter.rb#L100
[^3]: https://github.com/alphagov/contacts-admin/blob/a147dae219d22bc85568938990be25efaa379f43/app/presenters/contact_presenter.rb#L24
[^4]: https://github.com/alphagov/content-store/blob/781369cba445d96f7538ce3620c331207657a7d3/spec/models/route_set_spec.rb#L127
[^5]: https://github.com/alphagov/government-frontend/blob/6556691fd35faf9b44a40bb5882f74e758489f67/test/integration/travel_advice_test.rb#L46
[^6]: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-128-continuous-deployment.md#delete-publishing-e2e-tests



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️