### PR TITLE
Replace govuk content schema test helpers with govuk schemas gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ group :test do
   gem "ci_reporter_rspec"
   gem "database_cleaner-mongoid"
   gem "factory_bot_rails"
-  gem "govuk-content-schema-test-helpers"
+  gem "govuk_schemas"
   gem "rails-controller-testing"
   gem "rubocop-govuk"
   gem "simplecov"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,8 +145,6 @@ GEM
       nokogiri (~> 1.12)
       rinku (~> 2.0)
       sanitize (~> 6)
-    govuk-content-schema-test-helpers (1.6.1)
-      json-schema (~> 2.8.0)
     govuk_app_config (4.6.3)
       logstasher (~> 2.1)
       prometheus_exporter (~> 2.0)
@@ -166,6 +164,8 @@ GEM
       rails (>= 6)
       rouge
       sprockets (>= 3)
+    govuk_schemas (4.3.0)
+      json-schema (~> 2.8.0)
     govuk_sidekiq (5.0.0)
       gds-api-adapters (>= 19.1.0)
       govuk_app_config (>= 1.1)
@@ -501,9 +501,9 @@ DEPENDENCIES
   gds-api-adapters
   gds-sso
   govspeak
-  govuk-content-schema-test-helpers
   govuk_app_config
   govuk_publishing_components
+  govuk_schemas
   govuk_sidekiq
   govuk_test
   listen

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -81,7 +81,7 @@ describe EditionPresenter do
 
     it "is valid against the content schemas" do
       expect(presented_data["schema_name"]).to eq("travel_advice")
-      expect(presented_data).to be_valid_against_schema("travel_advice")
+      expect(presented_data).to be_valid_against_publisher_schema("travel_advice")
     end
 
     it "returns a travel_advice item" do

--- a/spec/presenters/email_alert_signup/edition_presenter_spec.rb
+++ b/spec/presenters/email_alert_signup/edition_presenter_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe EmailAlertSignup::EditionPresenter do
 
   it "validates against the email alert signup schema" do
     presenter = described_class.new(edition)
-    expect(presenter.content_payload.as_json).to be_valid_against_schema("email_alert_signup")
+    expect(presenter.content_payload.as_json).to be_valid_against_publisher_schema("email_alert_signup")
   end
 
   it "presents the email signup content item for the edition" do

--- a/spec/presenters/email_alert_signup/index_presenter_spec.rb
+++ b/spec/presenters/email_alert_signup/index_presenter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe EmailAlertSignup::IndexPresenter do
   subject(:presenter) { described_class.new }
 
   it "validates against the email alert signup schema" do
-    expect(presenter.content_payload.as_json).to be_valid_against_schema("email_alert_signup")
+    expect(presenter.content_payload.as_json).to be_valid_against_publisher_schema("email_alert_signup")
   end
 
   it "presents the email signup content item for the edition" do

--- a/spec/presenters/index_presenter_spec.rb
+++ b/spec/presenters/index_presenter_spec.rb
@@ -20,7 +20,7 @@ describe IndexPresenter do
 
     it "is valid against the content schemas" do
       expect(presented_data["schema_name"]).to eq("travel_advice_index")
-      expect(presented_data).to be_valid_against_schema("travel_advice_index")
+      expect(presented_data).to be_valid_against_publisher_schema("travel_advice_index")
     end
 
     it "returns a presented index item" do

--- a/spec/support/govuk_content_schemas.rb
+++ b/spec/support/govuk_content_schemas.rb
@@ -1,10 +1,3 @@
-require "govuk-content-schema-test-helpers"
+require "govuk_schemas/rspec_matchers"
 
-GovukContentSchemaTestHelpers.configure do |config|
-  config.schema_type = "publisher_v2"
-  config.project_root = Rails.root
-end
-
-require "govuk-content-schema-test-helpers/rspec_matchers"
-
-RSpec.configuration.include GovukContentSchemaTestHelpers::RSpecMatchers
+RSpec.configuration.include GovukSchemas::RSpecMatchers


### PR DESCRIPTION
## Description 

This PR replaces the govuk-content-schema-test-helpers gem with the govuk_schemas gem to validate content item schemas.

[govuk-content-schema-test-helpers] has been archived and there is a concern that it no longer receives any security updates. The advice in the govuk-content-schema-test-helpers repo is to replace it with the govuk_schemas gem.

[govuk-content-schema-test-helpers]: https://github.com/alphagov/govuk-content-schema-test-helpers

## Trello card

https://trello.com/c/Q9O5rXnz/550-stop-using-the-deprecated-govuk-content-schema-test-helpers-gem

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance]
(https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️