### PR TITLE
Adding the required GitHub actions needed for CI.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,45 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      gitRef:
+        description: 'Commit, tag or branch name to deploy'
+        required: true
+        type: string
+        default: 'main'
+      environment:
+        description: 'Environment to deploy to'
+        required: true
+        type: choice
+        options:
+        - integration
+        - staging
+        - production
+        default: 'integration'
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+
+jobs:
+  build-and-publish-image:
+    name: Build and publish image
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    uses: alphagov/govuk-infrastructure/.github/workflows/ci-ecr.yaml@main
+    with:
+      gitRef: ${{ github.event.inputs.gitRef || github.ref }}
+    secrets:
+      AWS_GOVUK_ECR_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
+      AWS_GOVUK_ECR_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}
+  trigger-deploy:
+    name: Trigger deploy to ${{ github.event.inputs.environment }}
+    needs: build-and-publish-image
+    uses: alphagov/govuk-infrastructure/.github/workflows/deploy.yaml@main
+    with:
+      imageTag: ${{ needs.build-and-publish-image.outputs.imageTag }}
+      environment: ${{ github.event.inputs.environment }}
+    secrets:
+      WEBHOOK_TOKEN: ${{ secrets.GOVUK_INTEGRATION_ARGO_EVENTS_WEBHOOK_TOKEN }}
+      WEBHOOK_URL: ${{ secrets.GOVUK_INTEGRATION_ARGO_EVENTS_WEBHOOK_URL }}
+      GOVUK_CI_GITHUB_API_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}

--- a/.github/workflows/set-automatic-deploys-enabled.yaml
+++ b/.github/workflows/set-automatic-deploys-enabled.yaml
@@ -1,0 +1,37 @@
+name: Set automatic_deploys
+
+on:
+  workflow_dispatch:
+    inputs:
+      resetImageTag:
+        description: 'Reset image tag to main'
+        required: false
+        default: false
+        type: boolean
+      automaticDeploysEnabled:
+        description: 'Activate automatic deploys'
+        required: false
+        default: true
+        type: boolean
+      environment:
+        description: 'Environment to deploy to'
+        required: true
+        type: choice
+        options:
+        - integration
+        - staging
+        - production
+        default: 'integration'
+
+jobs:
+  set_automatic_deploys_enabled:
+    name: Set automatic_deploys_enabled to ${{ github.event.inputs.environment }}
+    uses: alphagov/govuk-infrastructure/.github/workflows/set-automatic-deploys-enabled.yaml@main
+    with:
+      resetImageTag: ${{ github.event.inputs.resetImageTag == 'true' }}
+      automaticDeploysEnabled: ${{ github.event.inputs.automaticDeploysEnabled == 'true' }}
+      environment: ${{ github.event.inputs.environment }}
+    secrets:
+      WEBHOOK_TOKEN: ${{ secrets.GOVUK_INTEGRATION_ARGO_EVENTS_WEBHOOK_TOKEN }}
+      WEBHOOK_URL: ${{ secrets.GOVUK_INTEGRATION_ARGO_EVENTS_WEBHOOK_URL }}
+      GOVUK_CI_GITHUB_API_TOKEN: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}


### PR DESCRIPTION
The following Workflows are necessary for Pushing images to AWS ECR, triggering deployment to AWS EKS.

https://trello.com/c/WwdA4FxT/721-package-travel-advice-publisher-for-migration

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
