### PR TITLE
All of our logs need to go to stdout/stderr when running on k8s.

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,8 @@
 ---
 :verbose: true
 :concurrency:  2
-:logfile: ./log/sidekiq.json.log
+<% if ENV.key?('SIDEKIQ_LOGFILE') %>
+:logfile: <%= ENV['SIDEKIQ_LOGFILE'] %>
+<% end %>
 :queues:
   - default


### PR DESCRIPTION
As of Sidekiq 6.0, the logfile directive and -L option are being removed and logs will always go to stdout anyway:
https://github.com/mperham/sidekiq/wiki/Logging#log-redirection

This is essentially the same change as: https://github.com/alphagov/publisher/commit/5547a1a

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
