### PR TITLE
test out latest jenkins lib

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library("govuk")
+library("govuk@add-publishing-api-clone")
 
 node {
   // Run against the MongoDB 3.6 Docker instance on GOV.UK CI


### PR DESCRIPTION
This demonstrates that we can use the [proposed changes to jenkinslib](https://github.com/alphagov/govuk-jenkinslib/pull/126) without an issue.

This branch maintains the behaviour of cloning schemas from govuk-content-schemas, rather than publishing api, so demonstrates that the change to jenkinslib is safe to merge and will not cause repos that are currently configured to get schemas from govuk-content-schemas to fail, while we do the work to switch over.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
