### PR TITLE
test using publishing api for schemas

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,12 +1,24 @@
 #!/usr/bin/env groovy
 
-library("govuk")
+library("govuk@add-publishing-api-clone")
 
 node {
   // Run against the MongoDB 3.6 Docker instance on GOV.UK CI
   govuk.setEnvar("TEST_MONGODB_URI", "mongodb://127.0.0.1:27036/travel-advice-publisher-test")
 
   govuk.buildProject(
-    brakeman: true
+    brakeman: true,
+    extraParameters: [
+            booleanParam(
+            name: "USE_PUBLISHING_API_FOR_SCHEMAS",
+            defaultValue: true,
+            description: "whether to use publishing api for schemas"
+          ),
+          stringParam(
+            name: "PUBLISHING_API_BRANCH",
+            defaultValue: "add-content-schemas",
+            description: "The branch of publishing api to test against"
+          ),
+        ],
   )
 }


### PR DESCRIPTION
This demonstrates that we can use the [proposed changes to jenkinslib](https://github.com/alphagov/govuk-jenkinslib/pull/126), without an issue.

This branch demonstrates the new behaviour of using publishing api for content schemas. It uses [this branch of publishing api](https://github.com/alphagov/publishing-api/pull/2184) (soon to be merged into main) as the branch of publishing api to clone, and uses the schemas defined in there to run the tests against. Therefore this is a proof of concept both of the jenkinslib changes and the publishing api changes. It can serve as the basis for the swapover of dependent apps to using publishing api as the source of content schemas.

You can tell that publishing api is being used for schemas since the logging will include "using publishing api for content schemas", and you can see the cloning being done in the logging.

It's also possible to configure these variables via the jenkins UI: you can see this when you 'build with parameters' here.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
