### PR TITLE
Add Licence reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-do
 ### Further documentation
 
 Detailed technical information can be found in [`docs/`](docs/).
+
+## Licence
+
+[MIT License](LICENCE)


### PR DESCRIPTION
We want to make the reference to the licence in the README consistent with the GDS Way.

Trello card: https://trello.com/c/P0DpFcwW/260-standardise-all-license-files-names-to-licence