### PR TITLE
Revert "Bump mail from 2.7.1 to 2.8.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "govspeak"
 gem "govuk_app_config"
 gem "govuk_publishing_components"
 gem "govuk_sidekiq"
-gem "mail", "~> 2.8.0"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
+gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "mini_magick"
 gem "mongo"
 gem "mongoid"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,11 +205,8 @@ GEM
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.8.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
-      net-imap
-      net-pop
-      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
@@ -511,7 +508,7 @@ DEPENDENCIES
   govuk_sidekiq
   govuk_test
   listen
-  mail (~> 2.8.0)
+  mail (~> 2.7.1)
   mini_magick
   mongo
   mongoid


### PR DESCRIPTION
Reverts alphagov/travel-advice-publisher#1502

This re-applied the bad gem release, see: https://github.com/alphagov/travel-advice-publisher/pull/1498