### PR TITLE
This sets the asset path to include the application name.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,10 @@ module TravelAdvicePublisher
     # https://github.com/alphagov/govuk-frontend/issues/1350
     config.assets.css_compressor = nil
 
+    # Set asset path to be application specific so that we can put all GOV.UK
+    # assets into an S3 bucket and distinguish app by path.
+    config.assets.prefix = "/assets/travel-advice-publisher"
+
     config.slimmer.use_cache = true
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")

--- a/spec/support/jasmine-browser.json
+++ b/spec/support/jasmine-browser.json
@@ -1,5 +1,5 @@
 {
-  "srcDir": "public/assets",
+  "srcDir": "public/assets/travel-advice-publisher",
   "srcFiles": [
     "govuk-admin-template-*.js",
     "legacy-*.js",


### PR DESCRIPTION
Background to this change can be found here:
https://github.com/alphagov/manuals-publisher/pull/2004

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
