### PR TITLE
Make ruby tests a reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,45 +39,5 @@ jobs:
 
   test-ruby:
     name: Test Ruby
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup MongoDB
-        uses: alphagov/govuk-infrastructure/.github/actions/setup-mongodb@main
-        with:
-          version: 3.6
-
-      - name: Setup Redis
-        uses: alphagov/govuk-infrastructure/.github/actions/setup-redis@main
-
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Checkout Publishing API (for Content Schemas)
-        uses: actions/checkout@v3
-        with:
-          repository: alphagov/publishing-api
-          ref: deployed-to-production
-          path: vendor/publishing-api
-
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-
-      - name: Setup Node
-        uses: alphagov/govuk-infrastructure/.github/actions/setup-node@main
-
-      - name: Precompile assets
-        uses: alphagov/govuk-infrastructure/.github/actions/precompile-rails-assets@main
-
-      - name: Initialize database
-        env:
-          RAILS_ENV: test
-        run: bundle exec rails db:setup
-
-      - name: Run RSpec
-        env:
-          RAILS_ENV: test
-          GOVUK_CONTENT_SCHEMAS_PATH: vendor/publishing-api/content_schemas
-        run: bundle exec rake spec
+    uses: ./.github/workflows/rspec.yml
 

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,0 +1,62 @@
+name: Run RSpec
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'The branch, tag or SHA to checkout'
+        required: false
+        type: string
+      publishingApiRef:
+        description: 'The branch, tag or SHA to checkout Publishing API'
+        required: false
+        default: 'deployed-to-production'
+        type: string
+
+jobs:
+  run-rspec:
+    name: Run RSpec
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup MongoDB
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-mongodb@main
+        with:
+          version: 3.6
+
+      - name: Setup Redis
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-redis@main
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          repository: alphagov/travel-advice-publisher
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Checkout Publishing API (for Content Schemas)
+        uses: actions/checkout@v3
+        with:
+          repository: alphagov/publishing-api
+          ref: ${{ inputs.publishingApiRef }}
+          path: vendor/publishing-api
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Setup Node
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-node@main
+
+      - name: Precompile assets
+        uses: alphagov/govuk-infrastructure/.github/actions/precompile-rails-assets@main
+
+      - name: Initialize database
+        env:
+          RAILS_ENV: test
+        run: bundle exec rails db:setup
+
+      - name: Run RSpec
+        env:
+          RAILS_ENV: test
+          GOVUK_CONTENT_SCHEMAS_PATH: vendor/publishing-api/content_schemas
+        run: bundle exec rake spec


### PR DESCRIPTION
This application depends on the Content Schemas. Making the tests
reusable allows Publishing API to run the tests when the Content Schemas
are updated.
