### PR TITLE
Remove Mailer from the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem "govspeak"
 gem "govuk_app_config"
 gem "govuk_publishing_components"
 gem "govuk_sidekiq"
-gem "mail", "~> 2.8.0"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "mini_magick"
 gem "mongo"
 gem "mongoid"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -511,7 +511,6 @@ DEPENDENCIES
   govuk_sidekiq
   govuk_test
   listen
-  mail (~> 2.8.0)
   mini_magick
   mongo
   mongoid


### PR DESCRIPTION
Previously, there was an issue with the mailer gem in release 2.8.0 mikel/mail#1489.

To circumvent this we added it to the Gemfile and pinned it on the 2.7.0 release. Since this has been fixed we can remove it as a direct dependency.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
