### PR TITLE
Clean up redundant repo ref in RSpec action.

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          repository: alphagov/travel-advice-publisher
           ref: ${{ inputs.ref || github.ref }}
 
       - name: Checkout Publishing API (for Content Schemas)


### PR DESCRIPTION
The checkout action checks out the current repo by default, as one would expect. Omitting the repo name therefore slightly helps readability and consistency between similar jobs across our repos.\n\nThis is a bulk change consisting of 20 PRs.