### PR TITLE
Revert "Bump govuk_publishing_components from 35.1.1 to 35.2.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,7 @@ GEM
     govuk_personalisation (0.13.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (35.2.0)
+    govuk_publishing_components (35.1.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -285,7 +285,7 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (5.0.1)
-    puma (6.2.1)
+    puma (6.2.0)
       nio4r (~> 2.0)
     racc (1.6.2)
     rack (2.2.6.4)


### PR DESCRIPTION
## Description

Merged this without thinking during a code freeze. Reverting now and will re-merge after the freeze is over.

Reverts alphagov/travel-advice-publisher#1574