### PR TITLE
Install imagemagick in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ COPY . .
 RUN bootsnap precompile --gemfile .
 RUN rails assets:precompile && rm -fr log node_modules
 
-
 FROM $base_image
+RUN install_packages imagemagick
 
 ENV GOVUK_APP_NAME=travel-advice-publisher
 


### PR DESCRIPTION
This dependency is required for the ImageValidator class. Without it we see an error of:

```
MiniMagick::Invalid
You must have ImageMagick or GraphicsMagick installed
```

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
