### PR TITLE
Moving Summary into parts

### DIFF
--- a/app/models/travel_advice_edition.rb
+++ b/app/models/travel_advice_edition.rb
@@ -167,7 +167,7 @@ private
   end
 
   def populate_version_number
-    if version_number.nil? && !country_slug.nil? && !country_slug.empty?
+    if version_number.nil? && country_slug.present?
       latest_edition = self.class.where(country_slug:).order_by(version_number: :desc).first
       self.version_number = if latest_edition
                               latest_edition.version_number + 1

--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -39,9 +39,6 @@ private
 
   def details
     details = {
-      "summary" => [
-        { "content_type" => "text/govspeak", "content" => edition.summary },
-      ],
       "country" => {
         "slug" => country.slug,
         "name" => country.name,
@@ -55,7 +52,7 @@ private
       "alert_status" => edition.alert_status,
       "max_cache_time" => 10,
     }
-
+    details["summary"] = summary if summary
     details["image"] = image if image
     details["document"] = document if document
 
@@ -128,6 +125,14 @@ private
     edition.order_parts.map do |part|
       PartPresenter.present(part)
     end
+  end
+
+  def summary
+    @summary ||= if edition.summary.present?
+                   [
+                     { "content_type" => "text/govspeak", "content" => edition.summary },
+                   ]
+                 end
   end
 
   def image

--- a/app/views/admin/editions/_country_summary.html.erb
+++ b/app/views/admin/editions/_country_summary.html.erb
@@ -31,6 +31,8 @@
   </div>
 <% end %>
 
-<%= render 'govuk_publishing_components/components/govspeak' do %>
-  <%= sanitize(presenter.summary) %>
+<% if @presenter.edition.summary.present? %>
+  <%= render 'govuk_publishing_components/components/govspeak' do %>
+    <%= sanitize(presenter.summary) %>
+  <% end %>
 <% end %>

--- a/app/views/admin/editions/_summary_content.html.erb
+++ b/app/views/admin/editions/_summary_content.html.erb
@@ -1,5 +1,5 @@
 <%= render "govuk_publishing_components/components/fieldset", {
-  legend_text: "Summary content",
+  legend_text: "General information",
   heading_size: "m",
 } do %>
   <%= render "govuk_publishing_components/components/checkboxes", {
@@ -85,20 +85,21 @@
       name: "edition[document]",
       id: "edition_document"
     } %>
-
-    <%= render "govuk_publishing_components/components/textarea", {
-      label: {
-        text: "Summary (govspeak available)",
-        bold: true,
-      },
-      data: {
-        module: "paste-html-to-govspeak",
-      },
-      name: "edition[summary]",
-      id: "edition_summary",
-      rows: 20,
-      value: @edition.summary,
-    } %>
 <% end %>
+    <% if @edition.summary.present? %>
+      <%= render "govuk_publishing_components/components/textarea", {
+        label: {
+          text: "Summary (govspeak available)",
+          bold: true,
+        },
+        data: {
+          module: "paste-html-to-govspeak",
+        },
+        name: "edition[summary]",
+        id: "edition_summary",
+        rows: 20,
+        value: @edition.summary,
+      } %>
+  <% end %>
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">

--- a/app/views/admin/editions/_summary_content_summary.html.erb
+++ b/app/views/admin/editions/_summary_content_summary.html.erb
@@ -7,27 +7,29 @@
   })
 %>
 
+<% general_information_items = [
+  {
+    field: "Alert status",
+    value: alert_statuses.present? ? alert_statuses : "None"
+  },
+  {
+    field: "Map of #{@country.name}",
+    value: @edition.image.present? ? link_to("Map of #{@country.name}", @edition.image["file_url"], { class: "govuk-link" }) : "No Map attached"
+  },
+  {
+    field: "PDF Document",
+    value: @edition.document.present? ?
+             link_to("Download #{@edition.document['name']}", @edition.document["file_url"], { class: "govuk-link" })
+             : "No Document attached"
+  }]
+  general_information_items << {
+   field: "Summary",
+   value: sanitize(@edition.summary.truncate(500, omission: "... (For full content: #{preview_edition_link(@edition, false, { class: "govuk-link" })})"))
+  } if @edition.summary.present?
+%>
+
 <%= render "govuk_publishing_components/components/summary_list", {
-  title: "Summary content",
-  items: [
-    {
-      field: "Alert status",
-      value: alert_statuses.present? ? alert_statuses : "None"
-    },
-    {
-      field: "Map of #{@country.name}",
-      value: @edition.image.present? ? link_to("Map of #{@country.name}", @edition.image["file_url"], {class: "govuk-link"}): "No Map attached"
-    },
-    {
-      field: "PDF Document",
-      value: @edition.document.present? ?
-        link_to("Download #{@edition.document['name']}", @edition.document["file_url"], {class: "govuk-link"})
-        : "No Document attached"
-    },
-    {
-      field: "Summary",
-      value: sanitize(@edition.summary.truncate(500, omission: "... (For full content: #{preview_edition_link(@edition, false, { class: "govuk-link" })})"))
-    }
-  ],
+  title: "General information",
+  items: general_information_items,
   borderless: true
 } %>

--- a/app/views/admin/editions/historical_edition.html.erb
+++ b/app/views/admin/editions/historical_edition.html.erb
@@ -5,6 +5,7 @@
 <div class="content-block" id="summary">
   <%= render partial: "country_summary", locals: {presenter: @presenter}, formats: :html %>
 </div>
+
 <% @presenter.parts.each do |part| %>
   <article class="content-block" id="<%= part.slug %>">
     <header>

--- a/lib/tasks/data_migrations.rake
+++ b/lib/tasks/data_migrations.rake
@@ -1,0 +1,54 @@
+namespace :db do
+  desc "move summary from details into parts for one country"
+  task :migrate_summary, [:country_slug] => :environment do |_task, args|
+    country = Country.find_by_slug(args[:country_slug])
+    raise "Could not find country #{args[:country_slug]}" unless country
+
+    migrate_summary_for(country)
+  end
+
+  desc "move summary from details into parts for one country"
+  task migrate_summary_all_countries: :environment do
+    Country.all.map { |country| migrate_summary_for(country) }
+  end
+end
+
+def migrate_summary_for(country)
+  unless country.has_published_edition?
+    puts "no published editions found for #{country.slug}...skipping"
+    return
+  end
+
+  if country.has_draft_edition?
+    puts "draft edition found for #{country.slug}...skipping"
+    return
+  end
+
+  published_edition = country.last_published_edition
+  new_edition = country.build_new_edition(published_edition)
+  new_edition.save!
+
+  summary = new_edition.summary
+  if summary.nil?
+    puts "no summary found for #{country.slug}...skipping"
+    return
+  end
+
+  new_edition.summary = nil
+  new_edition.parts.map do |part|
+    part.order += 1 if part.order
+  end
+  new_edition.parts.build(
+    order: 1,
+    title: "Summary",
+    slug: "summary",
+    body: summary,
+  )
+
+  new_edition.minor_update = true
+  new_edition.update_type = "minor"
+
+  new_edition.publish
+  new_edition.save!
+  puts "SUCCEED: Summary has moved into parts for country: #{country.slug}"
+end

--- a/spec/features/edition_edit_spec.rb
+++ b/spec/features/edition_edit_spec.rb
@@ -155,13 +155,11 @@ feature "Edit Edition page" do
         expect(page).to have_field("Synonyms")
       end
 
-      within_section "the fieldset labelled Summary content" do
+      within_section "the fieldset labelled General information" do
         expect(page).to have_unchecked_field("The FCO advise against all travel to the whole country")
         expect(page).to have_unchecked_field("The FCO advise against all travel to parts of the country")
         expect(page).to have_unchecked_field("The FCO advise against all but essential travel to the whole country")
         expect(page).to have_unchecked_field("The FCO advise against all but essential travel to parts of the country")
-
-        expect(page).to have_field("Summary")
       end
 
       within_section "the fieldset labelled Parts (govspeak available)" do
@@ -177,8 +175,6 @@ feature "Edit Edition page" do
 
     fill_in "Public change note", with: "Made changes to all the stuff"
 
-    fill_in "Summary", with: "Summary of the situation in Albania"
-
     fill_in "Synonyms", with: "Foo,Bar"
 
     click_on "Save"
@@ -188,7 +184,6 @@ feature "Edit Edition page" do
     @edition.reload
     expect(@edition.title).to eq("Travel advice for Albania")
     expect(@edition.overview).to eq("Read this if you're planning on visiting Albania")
-    expect(@edition.summary).to eq("Summary of the situation in Albania")
     expect(@edition.change_description).to eq("Made changes to all the stuff")
     expect(@edition.synonyms).to eq(%w[Foo Bar])
 
@@ -252,7 +247,6 @@ feature "Edit Edition page" do
       change_description: "Stuff changed",
       update_type: "major",
       overview: "The overview",
-      summary: "## Summary",
     )
 
     now = Time.zone.now.utc
@@ -281,7 +275,6 @@ feature "Edit Edition page" do
       @old_edition = create(
         :published_travel_advice_edition,
         country_slug: "albania",
-        summary: "## The summaryy",
         change_description: "Some things changed",
         update_type: "major",
       )
@@ -296,7 +289,6 @@ feature "Edit Edition page" do
     travel_to(Time.zone.now) do
       visit "/admin/editions/#{@edition.to_param}/edit"
 
-      fill_in "Summary", with: "## The summary"
       choose "A typo, style change or similar"
 
       click_on "Save & Publish"
@@ -595,16 +587,6 @@ feature "Edit Edition page" do
     end
   end
 
-  scenario "disallowing hover text on links in govspeak fields" do
-    @edition = create(:draft_travel_advice_edition, country_slug: "albania")
-    visit "/admin/editions/#{@edition.to_param}/edit"
-
-    fill_in "Summary", with: "Some things changed on [GOV.UK](https://www.gov.uk/ \"GOV.UK\")"
-    click_on "Save"
-
-    expect(page).to have_content("Don't include hover text in links. Delete the text in quotation marks eg \\\"This appears when you hover over the link.")
-  end
-
   scenario "published editions should be read only" do
     @edition = create(:published_travel_advice_edition, country_slug: "albania")
     visit "/admin/editions/#{@edition.to_param}/edit"
@@ -612,7 +594,6 @@ feature "Edit Edition page" do
     expect(page).not_to have_field("Search title")
     expect(page).not_to have_field("Search description (optional)")
     expect(page).not_to have_field("Public change note")
-    expect(page).not_to have_field("Summary (govspeak available)")
     expect(page).not_to have_field("Country Synonyms (optional)")
 
     within :css, ".gem-c-summary-list:nth-of-type(1)" do
@@ -623,11 +604,10 @@ feature "Edit Edition page" do
     end
 
     within :css, ".gem-c-summary-list:nth-of-type(2)" do
-      expect(page).to have_content("Summary content")
+      expect(page).to have_content("General information")
       expect(page).to have_content("Alert status")
       expect(page).to have_content("Map of Albania")
       expect(page).to have_content("PDF Document")
-      expect(page).to have_content("Summary")
     end
 
     within :css, ".gem-c-summary-list:nth-of-type(3)" do
@@ -653,7 +633,6 @@ feature "Edit Edition page" do
     fill_in "Search title", with: "Travel advice for Albania"
     fill_in "Search description (optional)", with: "Read this if you're planning on visiting Albania"
     fill_in "Public change note", with: "Made changes to all the stuff"
-    fill_in "Summary (govspeak available)", with: "Summary of the situation in Albania"
     fill_in "Country Synonyms (optional)", with: "Foo,Bar"
 
     click_on "Add new part"
@@ -679,7 +658,6 @@ feature "Edit Edition page" do
     @edition.reload
     expect(@edition.title).to eq("Travel advice for Albania")
     expect(@edition.overview).to eq("Read this if you're planning on visiting Albania")
-    expect(@edition.summary).to eq("Summary of the situation in Albania")
     expect(@edition.change_description).to eq("Made changes to all the stuff")
     expect(@edition.synonyms).to eq(%w[Foo Bar])
     expect(@edition.parts.size).to eq(2)

--- a/spec/tasks/data_migration_rake_spec.rb
+++ b/spec/tasks/data_migration_rake_spec.rb
@@ -1,0 +1,191 @@
+require "rake"
+
+describe "data migration rake tasks", type: :rake_task do
+  let(:output) { StringIO.new }
+  let(:country_with_ordered_parts) { "azerbaijan" }
+  let(:country_with_unordered_parts) { "austria" }
+  let(:country_with_no_parts) { "aruba" }
+  let(:country_with_no_summary) { "albania" }
+  let(:country_with_unpublished_travel_advice) { "australia" }
+  let(:country_with_published_and_draft_travel_advice) { "anguilla" }
+
+  let!(:travel_advice_with_ordered_parts) { create(:travel_advice_edition_with_parts, country_slug: country_with_ordered_parts, summary: "Summary1") }
+  let!(:travel_advice_with_unordered_parts) { create(:travel_advice_edition_with_parts, country_slug: country_with_unordered_parts, summary: "Summary2") }
+  let!(:travel_advice_with_no_parts) { create(:published_travel_advice_edition, country_slug: country_with_no_parts, summary: "Summary4") }
+  let!(:travel_advice_with_no_summary) { create(:travel_advice_edition_with_parts, country_slug: country_with_no_summary, summary: nil) }
+  let!(:unpublished_travel_advice) { create(:travel_advice_edition_with_parts, country_slug: country_with_unpublished_travel_advice, summary: "Summary3") }
+  let!(:published_with_draft_travel_advice) { create(:travel_advice_edition_with_parts, country_slug: country_with_published_and_draft_travel_advice, summary: "Summary5") }
+
+  before do
+    Rake.application = nil # Reset any previously loaded tasks
+    Rails.application.load_tasks
+    save_and_publish_test_travel_advice_editions
+    $stdout = output
+  end
+
+  def save_and_publish_test_travel_advice_editions
+    test_travel_advices = [
+      travel_advice_with_ordered_parts,
+      travel_advice_with_unordered_parts,
+      travel_advice_with_no_parts,
+      unpublished_travel_advice,
+      travel_advice_with_no_summary,
+      published_with_draft_travel_advice,
+    ]
+
+    test_travel_advices
+      .reject { |travel_advice| travel_advice == unpublished_travel_advice }
+      .map do |travel_advice_edition|
+      travel_advice_edition.published_at ||= Time.zone.now.utc
+      travel_advice_edition.state = "published"
+    end
+
+    travel_advice_with_ordered_parts.order_parts
+
+    test_travel_advices.map(&:save)
+
+    country = Country.find_by_slug(country_with_published_and_draft_travel_advice)
+    published_edition = country.last_published_edition
+    new_edition = country.build_new_edition(published_edition)
+    new_edition.save!
+  end
+
+  after do
+    $stdout = STDOUT
+    Rake.application.clear
+  end
+
+  describe "db:migrate_summary['country-slug']" do
+    let(:task) { Rake::Task["db:migrate_summary"] }
+
+    it "errors if there is no such country" do
+      expect { task.invoke("non-existent") }.to raise_error(/Could not find country non-existent/)
+      existing_country = Country.find_by_slug(country_with_ordered_parts).last_published_edition
+      existing_country2 = Country.find_by_slug(country_with_unordered_parts).last_published_edition
+      expect(existing_country.summary).to eq("Summary1")
+      expect(existing_country.parts.size).to eq(2)
+      expect(existing_country2.summary).to eq("Summary2")
+      expect(existing_country2.parts.size).to eq(2)
+    end
+
+    it "moves summary into parts for specified country and does not affect others" do
+      task.invoke(country_with_ordered_parts)
+
+      migrated_travel_advice = Country.find_by_slug(country_with_ordered_parts).last_published_edition
+      expect(migrated_travel_advice.summary).to be_nil
+      expect(migrated_travel_advice.parts.size).to eq(3)
+      migrated_parts = migrated_travel_advice.parts.order_by(order: :asc)
+      expect(migrated_parts[0].order).to eq(1)
+      expect(migrated_parts[0].title).to eq("Summary")
+      expect(migrated_parts[0].body).to eq("Summary1")
+      expect(migrated_parts[0].slug).to eq("summary")
+      expect(migrated_parts[1].order).to eq(2)
+      expect(migrated_parts[1].title).to eq("Some Part Title!")
+      expect(migrated_parts[2].order).to eq(3)
+      expect(migrated_parts[2].title).to eq("Another Part Title")
+
+      non_migrated_travel_advice = Country.find_by_slug(country_with_unordered_parts).last_published_edition
+      expect(non_migrated_travel_advice.summary).to eq("Summary2")
+      expect(non_migrated_travel_advice.parts.size).to eq(2)
+    end
+
+    it "moves summary into parts for countries with non-ordered parts" do
+      task.invoke(country_with_unordered_parts)
+
+      migrated_travel_advice = Country.find_by_slug(country_with_unordered_parts).last_published_edition
+      expect(migrated_travel_advice.summary).to be_nil
+      expect(migrated_travel_advice.parts.size).to eq(3)
+      migrated_parts = migrated_travel_advice.parts.order_by(order: :asc)
+      expect(migrated_parts[0].order).to eq(1)
+      expect(migrated_parts[0].title).to eq("Summary")
+      expect(migrated_parts[0].body).to eq("Summary2")
+      expect(migrated_parts[0].slug).to eq("summary")
+      expect(migrated_parts[1].order).to be_nil
+      expect(migrated_parts[1].title).to eq("Some Part Title!")
+      expect(migrated_parts[2].order).to be_nil
+      expect(migrated_parts[2].title).to eq("Another Part Title")
+    end
+
+    it "move summary into new part for countries without any existing parts" do
+      task.invoke(country_with_no_parts)
+
+      migrated_travel_advice = Country.find_by_slug(country_with_no_parts).last_published_edition
+      expect(migrated_travel_advice.summary).to be_nil
+      expect(migrated_travel_advice.parts.size).to eq(1)
+      expect(migrated_travel_advice.parts.first.order).to eq(1)
+      expect(migrated_travel_advice.parts.first.title).to eq("Summary")
+      expect(migrated_travel_advice.parts.first.body).to eq("Summary4")
+      expect(migrated_travel_advice.parts.first.slug).to eq("summary")
+    end
+
+    it "doesn't change anything for countries without summaries" do
+      task.invoke(country_with_no_summary)
+
+      migrated_travel_advice = Country.find_by_slug(country_with_no_summary).last_published_edition
+      expect(migrated_travel_advice.summary).to be_nil
+      expect(migrated_travel_advice.parts.size).to eq(2)
+    end
+
+    it "doesn't move summary for countries with no published editions" do
+      task.invoke(country_with_unpublished_travel_advice)
+      published_edition = Country.find_by_slug(country_with_unpublished_travel_advice).last_published_edition
+      expect(published_edition).to be_nil
+
+      last_draft_edition = Country.find_by_slug(country_with_unpublished_travel_advice).editions.first
+      expect(last_draft_edition.state).to eq("draft")
+      expect(last_draft_edition.summary).to eq("Summary3")
+      expect(last_draft_edition.parts.size).to eq(2)
+
+      expect(output.string).to eq("no published editions found for #{country_with_unpublished_travel_advice}...skipping\n")
+    end
+
+    it "doesn't move summary for countries with draft editions" do
+      task.invoke(country_with_published_and_draft_travel_advice)
+      published_edition = Country.find_by_slug(country_with_published_and_draft_travel_advice).last_published_edition
+      expect(published_edition.summary).to eq("Summary5")
+      expect(published_edition.parts.size).to eq(2)
+
+      last_draft_edition = Country.find_by_slug(country_with_published_and_draft_travel_advice).editions.first
+      expect(last_draft_edition.state).to eq("draft")
+      expect(last_draft_edition.summary).to eq("Summary5")
+      expect(last_draft_edition.parts.size).to eq(2)
+
+      expect(output.string).to eq("draft edition found for #{country_with_published_and_draft_travel_advice}...skipping\n")
+    end
+  end
+
+  describe "db:migrate_summary_all_countries" do
+    let(:task) { Rake::Task["db:migrate_summary_all_countries"] }
+
+    it "migrates summary into parts for all countries" do
+      task.invoke
+
+      travel_advice_with_ordered_parts = Country.find_by_slug(country_with_ordered_parts).last_published_edition
+      travel_advice_with_unordered_parts = Country.find_by_slug(country_with_unordered_parts).last_published_edition
+
+      expect(travel_advice_with_ordered_parts.summary).to be_nil
+      expect(travel_advice_with_ordered_parts.parts.size).to eq(3)
+      travel_advice_with_ordered_parts_migrated_parts = travel_advice_with_ordered_parts.parts.order_by(order: :asc)
+      expect(travel_advice_with_ordered_parts_migrated_parts[0].order).to eq(1)
+      expect(travel_advice_with_ordered_parts_migrated_parts[0].title).to eq("Summary")
+      expect(travel_advice_with_ordered_parts_migrated_parts[0].body).to eq("Summary1")
+      expect(travel_advice_with_ordered_parts_migrated_parts[0].slug).to eq("summary")
+      expect(travel_advice_with_ordered_parts_migrated_parts[1].order).to eq(2)
+      expect(travel_advice_with_ordered_parts_migrated_parts[1].title).to eq("Some Part Title!")
+      expect(travel_advice_with_ordered_parts_migrated_parts[2].order).to eq(3)
+      expect(travel_advice_with_ordered_parts_migrated_parts[2].title).to eq("Another Part Title")
+
+      expect(travel_advice_with_unordered_parts.summary).to be_nil
+      expect(travel_advice_with_unordered_parts.parts.size).to eq(3)
+      travel_advice_with_unordered_parts_migrated_parts = travel_advice_with_unordered_parts.parts.order_by(order: :asc)
+      expect(travel_advice_with_unordered_parts_migrated_parts[0].order).to eq(1)
+      expect(travel_advice_with_unordered_parts_migrated_parts[0].title).to eq("Summary")
+      expect(travel_advice_with_unordered_parts_migrated_parts[0].body).to eq("Summary2")
+      expect(travel_advice_with_unordered_parts_migrated_parts[0].slug).to eq("summary")
+      expect(travel_advice_with_unordered_parts_migrated_parts[1].order).to be_nil
+      expect(travel_advice_with_unordered_parts_migrated_parts[1].title).to eq("Some Part Title!")
+      expect(travel_advice_with_unordered_parts_migrated_parts[2].order).to be_nil
+      expect(travel_advice_with_unordered_parts_migrated_parts[2].title).to eq("Another Part Title")
+    end
+  end
+end


### PR DESCRIPTION
# Moving Summary into parts

Summary is moving into parts to enable users to rename the section or re-order it. The publishing
UI will continue to show a summary section for editions that still have it (including historical
editions). For the rest, summary will be another part. These changes include the rake tasks that
migrate the summary section to parts - this will be run on production after the changes have been deployed.

[Trello Ticket](https://trello.com/c/tua0TaRV/1225-remove-summary-from-travel-advice)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
