### PR TITLE
Fix for edition diff comparison not working when both summaries are nil

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,6 +37,6 @@ module ApplicationHelper
   end
 
   def diff_html(version1, version2)
-    Diffy::Diff.new(version1, version2, allow_empty_diff: false).to_s(:html).html_safe
+    Diffy::Diff.new(version1.to_s, version2.to_s, allow_empty_diff: false).to_s(:html).html_safe
   end
 end

--- a/app/views/admin/editions/diff.html.erb
+++ b/app/views/admin/editions/diff.html.erb
@@ -28,17 +28,18 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
+    <% unless @comparison.summary.nil? && @edition.summary.nil? %>
+      <div class="govuk-!-margin-bottom-5">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Summary",
+          margin_bottom: 3
+        } %>
 
-    <div class="govuk-!-margin-bottom-5">
-      <%= render "govuk_publishing_components/components/heading", {
-        text: "Summary",
-        margin_bottom: 3
-      } %>
-
-      <div class="govuk-body">
-        <%= diff_html(@comparison.summary, @edition.summary) %>
+        <div class="govuk-body">
+          <%= diff_html(@comparison.summary, @edition.summary) %>
+        </div>
       </div>
-    </div>
+    <% end %>
 
     <% @edition.parts.each_with_index do |part, index| %>
       <div class="govuk-!-margin-bottom-5">

--- a/spec/features/edition_comparison_spec.rb
+++ b/spec/features/edition_comparison_spec.rb
@@ -1,24 +1,43 @@
 feature "Comparing two editions", js: true do
   before :each do
     login_as stub_user
-    @edition1 = create(
+  end
+
+  scenario "comparing an edition with the previous version" do
+    edition1 = create(
       :published_travel_advice_edition,
       country_slug: "aruba",
       summary: "Advice summray",
       version_number: 1,
     )
-    @edition2 = @edition1.build_clone
-    @edition2.summary = "Advice summary"
-    @edition2.change_description = "Corrected typo in the summary"
-    @edition2.save!
-  end
+    edition2 = edition1.build_clone
+    edition2.summary = "Advice summary"
+    edition2.change_description = "Corrected typo in the summary"
+    edition2.save!
 
-  scenario "comparing an edition with the previous version" do
-    visit edit_admin_edition_path(@edition2)
+    visit edit_admin_edition_path(edition2)
     click_on "History & Notes"
     click_on "Compare with version 1"
 
     expect(page).to have_css("del", text: "Advice summray")
     expect(page).to have_css("ins", text: "Advice summary")
+  end
+
+  scenario "comparing 2 editions with no summaries" do
+    edition1 = create(
+      :published_travel_advice_edition,
+      country_slug: "albania",
+      summary: nil,
+      version_number: 1,
+    )
+    edition2 = edition1.build_clone
+    edition2.change_description = "Corrected typo in the summary"
+    edition2.save!
+
+    visit edit_admin_edition_path(edition2)
+    click_on "History & Notes"
+    click_on "Compare with version 1"
+
+    expect(page).to_not have_text("Summary")
   end
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,52 @@
+require "spec_helper"
+
+describe ApplicationHelper do
+  describe "#diff_html" do
+    it "Shows insertion diff" do
+      result = diff_html("abcd", "abc123d")
+      expect(result).to include('<li class="del"><del>abcd</del></li>')
+      expect(result).to include('<li class="ins"><ins>abc<strong>123</strong>d</ins></li>')
+    end
+
+    it "Shows insertion diff from empty" do
+      result = diff_html("", "abc123d")
+      expect(result).to include('<li class="ins"><ins>abc123d</ins></li>')
+    end
+
+    it "Shows insertion diff from nil" do
+      result = diff_html(nil, "abc123d")
+      expect(result).to include('<li class="ins"><ins>abc123d</ins></li>')
+    end
+
+    it "Shows removal diff" do
+      result = diff_html("abcd", "abd")
+      expect(result).to include('<li class="del"><del>ab<strong>c</strong>d</del></li>')
+      expect(result).to include('<li class="ins"><ins>abd</ins></li>')
+    end
+
+    it "Shows removal diff to empty" do
+      result = diff_html("abcd", "")
+      expect(result).to include('<li class="del"><del>abcd</del></li>')
+    end
+
+    it "Shows removal diff to nil" do
+      result = diff_html("abcd", nil)
+      expect(result).to include('<li class="del"><del>abcd</del></li>')
+    end
+
+    it "Shows unchanged diff" do
+      result = diff_html("abc", "abc")
+      expect(result).to include('<li class="unchanged"><span>abc</span></li>')
+    end
+
+    it "Shows unchanged empty diff" do
+      result = diff_html("", "")
+      expect(result).to include('<li class="unchanged"><span></span></li>')
+    end
+
+    it "Shows unchanged nil diff" do
+      result = diff_html(nil, nil)
+      expect(result).to include('<li class="unchanged"><span></span></li>')
+    end
+  end
+end


### PR DESCRIPTION
Previously, all editions have summaries - even in cases where nothing is entered, it will be empty string. 

Since summary has always been required and defaulted to empty string, edition comparison always worked. 
However, since we have migrated summaries into parts, summary has become nil for all new published editions. 

When we compare older versions with summaries it was fine, however comparing newest versions where both summaries are nil presented an error. This fix makes sure that diffs work for nil fields, and also the comparison section for Summary will not show if neither compared versions have a summary.

How to recreate problem before fix: 
1. Run migration task for <country A> to move summary into parts
2. Create a new edition and publish for <country A>
3. Compare the diff between these two versions, both summaries will be nil

After fix: 
1. Diff for edition where Summary section is moved into Parts will show 2 empty summary sections if the Travel Advice had no summary before nor after the migration. If there were text, then it would show the diff of removal and addition.
<img width="1038" alt="Screenshot 2023-05-16 at 17 10 11" src="https://github.com/alphagov/travel-advice-publisher/assets/568730/5061c847-223a-4c4a-9185-bc2e59bc0170">

2. For subsequent versions it will no longer show Summary as a section in the diff if neither versions have existing summaries
<img width="569" alt="Screenshot 2023-05-16 at 17 12 06" src="https://github.com/alphagov/travel-advice-publisher/assets/568730/2a369959-8dbd-4f63-9a82-7434824bb156">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
