### PR TITLE
Remove default gitRef for deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,6 @@ on:
         description: 'Commit, tag or branch name to deploy'
         required: true
         type: string
-        default: 'main'
       environment:
         description: 'Environment to deploy to'
         required: true


### PR DESCRIPTION
This removes the default value of 'main' as to encourage people to deploy a
specific version tag, rather than assuming the intended release it still the
HEAD of main.
