### PR TITLE
Add Google Tag Manager snippet

### DIFF
--- a/app/views/layouts/_google_tag_manager.html.erb
+++ b/app/views/layouts/_google_tag_manager.html.erb
@@ -1,0 +1,9 @@
+<% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
+  <% content_for :head do %>
+    <%= render "govuk_publishing_components/components/google_tag_manager_script", {
+      gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],
+      gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],
+      gtm_preview: ENV["GOOGLE_TAG_MANAGER_PREVIEW"],
+    } %>
+  <% end %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,3 +1,4 @@
+<% render "layouts/google_tag_manager" %>
 <%= render 'govuk_publishing_components/components/layout_for_admin',
   product_name: "Travel Advice Publisher",
   environment: GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment,

--- a/app/views/layouts/historical_edition.html.erb
+++ b/app/views/layouts/historical_edition.html.erb
@@ -1,3 +1,4 @@
+<% render "layouts/google_tag_manager" %>
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -8,6 +9,7 @@
   <% end %>
   <%= stylesheet_link_tag "historical-edition", media: "all" %>
   <%= yield :extra_headers %>
+  <%= yield :head %>
 </head>
 <body>
   <div id="wrapper" class="travel-advice-guide">


### PR DESCRIPTION
Google Tag Manager (GTM) can be included on all pages of the app by configuring the following environment variables:

- GOOGLE_TAG_MANAGER_ID
- GOOGLE_TAG_MANAGER_AUTH
- GOOGLE_TAG_MANAGER_PREVIEW

All three variables are optional.

If none are set, GTM will not be included on the page.

If only GOOGLE_TAG_MANAGER_ID is set, the default environment of the GTM container will be used.

If GOOGLE_TAG_MANAGER_AUTH and GOOGLE_TAG_MANAGER_PREVIEW are set, the specified GTM container environment will be used. This is used for managing the rollout of changes to integration so they can be tested before rolling out to production.

Trello: https://trello.com/c/Wcuq3R1S/2167-add-ga4-page-view-tracking-to-apps-that-we-own

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
