### PR TITLE
Add country content_id to healthcheck URL

### DIFF
--- a/app/controllers/healthcheck_controller.rb
+++ b/app/controllers/healthcheck_controller.rb
@@ -12,6 +12,7 @@ class HealthcheckController < ApplicationController
       {
         title: edition.title,
         published_at: edition.published_at,
+        content_id: Country.find_by_slug(edition.country_slug).content_id,
       }
     end
 

--- a/spec/controllers/healthcheck_spec.rb
+++ b/spec/controllers/healthcheck_spec.rb
@@ -2,7 +2,7 @@ describe HealthcheckController, type: :controller do
   include Rails.application.routes.url_helpers
 
   describe "#recently_published_editions" do
-    let!(:travel_advice_edition) { create(:published_travel_advice_edition, published_at: 160.minutes.ago) }
+    let!(:travel_advice_edition) { create(:published_travel_advice_edition, published_at: 160.minutes.ago, country_slug: "albania") }
 
     it "should return the title and published_at of recently published editions" do
       get :recently_published_editions
@@ -11,6 +11,7 @@ describe HealthcheckController, type: :controller do
           {
             title: travel_advice_edition.title,
             published_at: travel_advice_edition.published_at,
+            content_id: "2a3938e1-d588-45fc-8c8f-0f51814d5409",
           },
         ],
       }.to_json


### PR DESCRIPTION
https://trello.com/c/Z5yzNTIo/2247-add-content-id-information-to-travel-alerts-healthcheck-url

Add content_id to items on the healthcheck URL so that it can be used for matching in email-alert-api's monitoring system.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
