### PR TITLE
Use rails 7.1 cache formatter

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -23,10 +23,7 @@ module TravelAdvicePublisher
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.1
 
-    # Once this application is fully deployed to Rails 7.1 and you have no plans to rollback
-    # replace the line below with config.active_support.cache_format_version = 7.1
-    # This will mean that we can revert back to rails 7.0 if there is an issue
-    config.active_support.cache_format_version = 7.0
+    config.active_support.cache_format_version = 7.1
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.


### PR DESCRIPTION
Now travel advice publisher has been running on rails 7.1 happily for a while we should be confident we won't have to roll back and so can update our cache formatter.

Trello card: https://trello.com/c/xycIPxuB/2203-use-rails-71-cache-formatter-in-travel-advice