### PR TITLE
Fix reference to tag name in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 name: Deploy
 
-run-name: Deploy ${{ inputs.gitRef || github.ref_name  }} to ${{ inputs.environment || 'integration' }}
+run-name: Deploy ${{ inputs.gitRef || github.event.release.tag_name  }} to ${{ inputs.environment || 'integration' }}
 
 on:
   workflow_dispatch:
@@ -23,11 +23,11 @@ on:
 
 jobs:
   build-and-publish-image:
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref_name, 'v')
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
     name: Build and publish image
     uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@main
     with:
-      gitRef: ${{ inputs.gitRef || github.ref_name }}
+      gitRef: ${{ inputs.gitRef || github.event.release.tag_name }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
There is a known bug in GitHub Actions that `github.ref_name` to not be
populated when the workflow was triggered due to a release tag. This uses an
alternative field to reference the release tag value. This fixes intermittent
failures in running the deploy workflow.
