### PR TITLE
Update copy for downloading map for historical editions

### DIFF
--- a/app/views/admin/editions/_country_summary.html.erb
+++ b/app/views/admin/editions/_country_summary.html.erb
@@ -26,7 +26,7 @@
 <% if presenter.document %>
   <div class="form-download">
   <p>
-    <a href="<%= presenter.document['file_url'] %>">Download map (PDF)</a>
+    <a href="<%= presenter.document['file_url'] %>">Download a more detailed map (PDF)</a>
   </p>
   </div>
 <% end %>


### PR DESCRIPTION
## Description

Travel advice publisher allows you to download & print superseded (archived) editions.

There's a link within this document where a user can access a more detailed version of the map (jpg) provided in the pdf.

<img width="931" alt="image" src="https://github.com/alphagov/travel-advice-publisher/assets/42515961/1bd9ad7b-f028-4eb8-8f38-3fee59987fd7">

This links off to asset manager which handles providing them with pdf containing a more detailed map 

FCDO would like the copy of this link updated to be more specific.

## Trello card

https://trello.com/c/1LEVvxq0/2285-create-farming-grant-specialist-finder


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
