### PR TITLE
Update Dockerfile to use yarn 4 configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,9 @@ FROM $builder_image AS builder
 WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./
 RUN bundle install
-COPY package.json yarn.lock ./
-RUN yarn install --production --frozen-lockfile --non-interactive --link-duplicates
+COPY package.json yarn.lock .yarnrc.yml ./
+COPY .yarn/releases ./.yarn/releases
+RUN yarn workspaces focus --all --production
 COPY . .
 RUN bootsnap precompile --gemfile .
 RUN rails assets:precompile && rm -fr log node_modules


### PR DESCRIPTION
## Description

How you require/copy the yarn config that now sits in the yarn dir has changed between yarn 1 and yarn 4. We now need to copy the release from the yarn/* directory before calling yarn install.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
