### PR TITLE
Update dependabot merger config

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -19,7 +19,6 @@ auto_merge:
   - dependency: govuk_publishing_components
     allowed_semver_bumps:
       - patch
-      - minor
   - dependency: govuk_schemas
     allowed_semver_bumps:
       - patch


### PR DESCRIPTION
Temporarily reduce auto-merging of gem bumps to patch versions only

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
