### PR TITLE
Fix Jasmine specs in govuk-docker

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "paste-html-to-govspeak": "^0.4.0"
   },
   "resolutions": {
+    "selenium-webdriver": "4.17.0",
     "stylelint/string-width": "4.2.3"
   },
   "packageManager": "yarn@4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2931,14 +2931,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"selenium-webdriver@npm:^4.12.0":
-  version: 4.12.0
-  resolution: "selenium-webdriver@npm:4.12.0"
+"selenium-webdriver@npm:4.17.0":
+  version: 4.17.0
+  resolution: "selenium-webdriver@npm:4.17.0"
   dependencies:
     jszip: "npm:^3.10.1"
     tmp: "npm:^0.2.1"
-    ws: "npm:>=8.13.0"
-  checksum: d7e1d692017c13a20efbc4496ddb46a4c7bb1530fcdbd58a4f4d9818029acbcb4e11a42fbdc421387a607b9099c9cdede24d8ccd28f70fa294a79e86d235b414
+    ws: "npm:>=8.14.2"
+  checksum: 7a33bc50212efb702041cab4e0a0c1cbe1c8b06a5349d8c987994c53abdb3ec4e87274042779344cdfc704198fc4058a857202a2a028fd4dad148a67ca329e04
   languageName: node
   linkType: hard
 
@@ -3714,9 +3714,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:>=8.13.0":
-  version: 8.13.0
-  resolution: "ws@npm:8.13.0"
+"ws@npm:>=8.14.2":
+  version: 8.16.0
+  resolution: "ws@npm:8.16.0"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -3725,7 +3725,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 579817dbbab3ee46669129c220cfd81ba6cdb9ab5c3e9a105702dd045743c4ab72e33bb384573827c0c481213417cc880e41bc097e0fc541a0b79fa3eb38207d
+  checksum: a7783bb421c648b1e622b423409cb2a58ac5839521d2f689e84bc9dc41d59379c692dd405b15a997ea1d4c0c2e5314ad707332d0c558f15232d2bc07c0b4618a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
To resolve this issue: `SessionNotCreatedError: session not created: This version of ChromeDriver only supports Chrome version 120`

This solution is now being applied across our applications, for full investigation see https://github.com/alphagov/govuk-docker/pull/724

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
