### PR TITLE
Adding a daily task to catch any potentially unpublished editions.

### DIFF
--- a/lib/tasks/publish_scheduled_editions.rake
+++ b/lib/tasks/publish_scheduled_editions.rake
@@ -1,0 +1,6 @@
+desc "Cronjob running daily to catch potentially unpublished editions"
+task publish_scheduled_editions: :environment do
+  TravelAdviceEdition.with_state(:scheduled).pluck(:id).each do |id|
+    ScheduledPublishingWorker.new.perform(id.to_s)
+  end
+end

--- a/spec/tasks/publish_scheduled_editions_rake_spec.rb
+++ b/spec/tasks/publish_scheduled_editions_rake_spec.rb
@@ -1,0 +1,30 @@
+require "rake"
+describe "publish_scheduled_editions", type: :rake_task do
+  let(:country) { Country.find_by_slug("aruba") }
+  let(:task) { Rake::Task["publish_scheduled_editions"] }
+  let!(:robot) { create(:scheduled_publishing_robot) }
+
+  before do
+    Rake.application = nil
+    Rails.application.load_tasks
+    Sidekiq::Worker.clear_all
+  end
+
+  it "runs to publish scheduled editions that might have been left unpublished" do
+    edition = create(:scheduled_travel_advice_edition, country_slug: country.slug)
+    travel_to(2.hours.from_now)
+    task.invoke
+
+    expect(PublishingApiWorker.jobs.size).to eq(1)
+    expect(edition.reload.state).to eq("published")
+  end
+
+  it "does not publish editions scheduled for future publication" do
+    edition = create(:scheduled_travel_advice_edition, country_slug: country.slug, scheduled_publication_time: 5.hours.from_now)
+    travel_to(2.hours.from_now)
+    task.invoke
+
+    expect(PublishingApiWorker.jobs.size).to eq(0)
+    expect(edition.reload.state).to eq("scheduled")
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/UX0jNZC5/2419-cronjob-for-scheduling)

Cronjob is set up in govuk-helm-charts. https://github.com/alphagov/govuk-helm-charts/pull/1926

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
