### PR TITLE
Fix Part validation behaviour after upgrading Mongo version

### DIFF
--- a/app/models/travel_advice_edition.rb
+++ b/app/models/travel_advice_edition.rb
@@ -43,6 +43,7 @@ class TravelAdviceEdition
   validates :version_number, presence: true, uniqueness: { scope: :country_slug }
   validate :alert_status_contains_valid_values
   validate :first_version_cant_be_minor_update
+  validate :parts_valid?
   validates_with SafeHtml
   validates_with LinkValidator
 
@@ -247,6 +248,10 @@ private
     if is_minor_update? && first_version?
       errors.add(:update_type, "can't be minor for first version")
     end
+  end
+
+  def parts_valid?
+    parts.map(&:valid?).all?
   end
 
   def validate_scheduled_publication_time


### PR DESCRIPTION
The validations for parts weren't being triggered when parent model (edition) is validated. To get around this we added an explicit custom validation method to enforce the association validation. The issue that was happening was that only the first part validation message was being shown on the front end instead of everything whenever Parts were created in the old way outlined above. Quick fix of tests where slugs had `_` in them which are not allowed and failing validation quietly...

[Trello card](https://trello.com/c/kTkE9TUh/2418-investigate-problem-with-upgrading-travel-advice-publisher-mongoid-version)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
