### PR TITLE
Raise error when there are overdue scheduled editions

### DIFF
--- a/app/models/travel_advice_edition.rb
+++ b/app/models/travel_advice_edition.rb
@@ -53,6 +53,7 @@ class TravelAdviceEdition
                                 reject_if: proc { |attrs| attrs["title"].blank? && attrs["body"].blank? }
 
   scope :published, -> { where(state: "published") }
+  scope :scheduled, -> { where(state: "scheduled").order(scheduled_publication_time: :desc, id: :asc) }
 
   class << self; attr_accessor :fields_to_clone end
   @fields_to_clone = %i[title country_slug overview alert_status summary image_id document_id synonyms]
@@ -146,6 +147,10 @@ class TravelAdviceEdition
     return false unless build_action_as(user, Action::CANCEL_SCHEDULE) && draft
 
     unset(:scheduled_publication_time)
+  end
+
+  def self.due_for_publication
+    scheduled.where({ "scheduled_publication_time" => { "$lte" => Time.zone.now } })
   end
 
   def previous_version

--- a/lib/tasks/publish_scheduled_editions.rake
+++ b/lib/tasks/publish_scheduled_editions.rake
@@ -1,6 +1,17 @@
 desc "Cronjob running daily to catch potentially unpublished editions"
 task publish_scheduled_editions: :environment do
-  TravelAdviceEdition.with_state(:scheduled).pluck(:id).each do |id|
+  TravelAdviceEdition.scheduled.pluck(:id).each do |id|
     ScheduledPublishingWorker.new.perform(id.to_s)
+  rescue StandardError
+    next
+  end
+
+  overdue_editions = TravelAdviceEdition.due_for_publication
+  raise ScheduledEditionsOverdueError, overdue_editions if overdue_editions.any?
+end
+
+class ScheduledEditionsOverdueError < StandardError
+  def initialize(editions)
+    super("The following editions are due for publication: #{editions.map(&:_id).to_sentence}")
   end
 end

--- a/spec/tasks/publish_scheduled_editions_rake_spec.rb
+++ b/spec/tasks/publish_scheduled_editions_rake_spec.rb
@@ -27,4 +27,35 @@ describe "publish_scheduled_editions", type: :rake_task do
     expect(PublishingApiWorker.jobs.size).to eq(0)
     expect(edition.reload.state).to eq("scheduled")
   end
+
+  it "raises custom error if there are overdue editions" do
+    edition = create(:scheduled_travel_advice_edition, country_slug: country.slug, scheduled_publication_time: 1.hour.from_now)
+    allow_any_instance_of(ScheduledPublishingWorker).to receive(:perform).and_return(true)
+    travel_to(1.hour.from_now)
+
+    expect { task.invoke }.to raise_error(ScheduledEditionsOverdueError, "The following editions are due for publication: #{edition._id}")
+    expect(PublishingApiWorker.jobs.size).to eq(0)
+    expect(edition.reload.state).to eq("scheduled")
+  end
+
+  it "finishes loop execution and raises custom overdue error if edition publication fails" do
+    failed_edition = create(:scheduled_travel_advice_edition, country_slug: "spain", scheduled_publication_time: 1.hour.from_now)
+    success_edition = create(:scheduled_travel_advice_edition, country_slug: country.slug, scheduled_publication_time: 1.hour.from_now)
+    allow_any_instance_of(ScheduledPublishingWorker).to receive(:perform).with(failed_edition._id).and_raise(StandardError)
+    allow_any_instance_of(ScheduledPublishingWorker).to receive(:perform).with(success_edition._id).and_call_original
+    travel_to(2.hours.from_now)
+
+    expect { task.invoke }.to raise_error(ScheduledEditionsOverdueError, "The following editions are due for publication: #{failed_edition._id}")
+    expect(failed_edition.reload.state).to eq("scheduled")
+    expect(success_edition.reload.state).to eq("published")
+  end
+
+  it "composes the overdue error message as a sentence" do
+    first_edition = create(:scheduled_travel_advice_edition, country_slug: "aruba", scheduled_publication_time: 1.hour.from_now)
+    second_edition = create(:scheduled_travel_advice_edition, country_slug: "spain", scheduled_publication_time: 1.hour.from_now)
+    third_edition = create(:scheduled_travel_advice_edition, country_slug: "italy", scheduled_publication_time: 1.hour.from_now)
+    editions = [first_edition, second_edition, third_edition]
+
+    expect(ScheduledEditionsOverdueError.new(editions).message).to eq "The following editions are due for publication: #{first_edition._id}, #{second_edition._id}, and #{third_edition._id}"
+  end
 end


### PR DESCRIPTION
We want to publish any scheduled editions left unpublished. If the scheduling has somehow failed, we address that by running a  cronjob every morning, which attempts to publish the editions by executing the worker synchronously.

If any editions are still left unpublished after running the worker, we raise a an error to ensure the team has visibility. The intention is to observe this and gauge whether we should enable pager duty and/or increase the frequency of the cronjob.

 [Trello card](https://trello.com/c/ESWx6uYN/2447-missed-scheduling-jobs-log-and-alert)
