### PR TITLE
Rename Micronesia

### DIFF
--- a/app/models/travel_advice_edition.rb
+++ b/app/models/travel_advice_edition.rb
@@ -222,13 +222,13 @@ private
   end
 
   def cannot_edit_published
-    if anything_other_than_state_changed?("reviewed_at", "update_type") && state_was != "draft" && state_was != "scheduled"
+    if anything_other_than_state_changed?("reviewed_at", "update_type", "country_slug") && state_was != "draft" && state_was != "scheduled"
       errors.add(:state, "must be draft to modify")
     end
   end
 
   def cannot_edit_archived
-    if anything_other_than_state_changed?("update_type")
+    if anything_other_than_state_changed?("update_type", "country_slug")
       errors.add(:state, "must be draft to modify")
     end
   end

--- a/lib/data/countries.yml
+++ b/lib/data/countries.yml
@@ -275,6 +275,10 @@
   slug: falkland-islands
   content_id: 61a1542f-d196-42a0-9605-ad667b60504e
   email_signup_content_id: 14d80b15-93f6-49aa-aa44-9dd2ae3626eb
+- name: Federated States of Micronesia
+  slug: federated-states-of-micronesia
+  content_id: d010fd00-bf63-42f0-ba7b-0982f49cb3d4
+  email_signup_content_id: d79f8657-c943-4952-b87d-d968917d4079
 - name: Fiji
   slug: fiji
   content_id: 4b79ee8f-0217-486b-bcc9-5f0ef9c16b54
@@ -527,10 +531,6 @@
   slug: mexico
   content_id: 34dafa2b-24e5-4625-b542-bf5e0bb8cd80
   email_signup_content_id: 5e97d048-633a-4ed5-9244-c94f267d592e
-- name: Micronesia
-  slug: micronesia
-  content_id: d010fd00-bf63-42f0-ba7b-0982f49cb3d4
-  email_signup_content_id: d79f8657-c943-4952-b87d-d968917d4079
 - name: Moldova
   slug: moldova
   content_id: 4064154c-ef7e-4edf-9f98-8f747ce39471


### PR DESCRIPTION
Replace 'Micronesia' with 'Federated States of Micronesia' - content request [Trello](https://trello.com/c/SU6BliYA/2438-replace-micronesia-with-federated-states-of-micronesia-content-request)

The change to the 'cannot_edit_published' and 'cannot_edit_archived' methods are there to allow us to change the country slug. Prior to this change validation would have stopped us from being able to do that, and consequently all the Travel Editions would remain associated with the old slug and not be visable within the travel advice publisher UI

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
