### PR TITLE
Allow cancellation of scheduling for overdue edition

### DIFF
--- a/app/models/travel_advice_edition.rb
+++ b/app/models/travel_advice_edition.rb
@@ -260,7 +260,7 @@ private
   end
 
   def validate_scheduled_publication_time
-    errors.add(:scheduled_publication_time, "can't be in the past") if scheduled_publication_time && scheduled_publication_time <= Time.zone.now
+    errors.add(:scheduled_publication_time, "can't be in the past") if scheduled_publication_time && scheduled_publication_time <= Time.zone.now && state_was != "scheduled"
   end
 
   def extract_part_errors

--- a/spec/controllers/admin/schedulings_controller_spec.rb
+++ b/spec/controllers/admin/schedulings_controller_spec.rb
@@ -169,6 +169,17 @@ describe Admin::SchedulingsController do
       expect(flash[:alert]).to include("We had some problems cancelling")
       expect(response).to redirect_to edit_admin_edition_path(@edition)
     end
+
+    it "cancels an overdue scheduled edition (failed to publish)" do
+      scheduled_publication_time = 1.hour.from_now
+      edition = create(:scheduled_travel_advice_edition, country_slug: "albania", scheduled_publication_time:)
+
+      travel_to 2.hours.from_now
+      delete :destroy, params: { edition_id: edition.id }
+
+      expect(edition.reload.scheduled_publication_time).to be_nil
+      expect(edition.reload.state).to eq("draft")
+    end
   end
 
   def generate_scheduling_params(date_time)

--- a/spec/models/travel_advice_edition_spec.rb
+++ b/spec/models/travel_advice_edition_spec.rb
@@ -477,13 +477,23 @@ describe TravelAdviceEdition do
 
     context "cancel schedule for publication" do
       let(:user) { create(:user) }
-      let(:country) { Country.find_by_slug("afghanistan") }
+      let!(:country) { Country.find_by_slug("afghanistan") }
 
       it "sends a cancel schedule action" do
         scheduled = create(:scheduled_travel_advice_edition, country_slug: country.slug)
         scheduled.cancel_schedule_for_publication(user)
 
         expect(scheduled.actions.first.request_type).to eq "cancel_schedule"
+      end
+
+      it "allows cancelling a failed scheduled edition (failed to publish)" do
+        scheduled_overdue = create(:scheduled_travel_advice_edition, country_slug: country.slug)
+        travel_to(2.hours.from_now)
+
+        scheduled_overdue.cancel_schedule_for_publication(user)
+
+        expect(scheduled_overdue.reload.scheduled_publication_time).to be_nil
+        expect(scheduled_overdue.reload.state).to eq "draft"
       end
     end
   end


### PR DESCRIPTION
If something goes wrong within the scheduled publishing worker, be it a state transition or a downstream error coming from publishing-api, it will return without changing the edition state (remains scheduled) and will retry.

Nonetheless, if the worker cannot fix itself, we want to allow the users to cancel the current schedule and re-schedule.

Due to a validation restriction on the edition model, we were blocking this. The publication time would in this case be in the past which was not allowed on the draft state. We are now allowing it if the previous state was "scheduled".

[Trello card](https://trello.com/c/3MZPtaWs/2530-bug-tap-allow-cancel-when-edition-overdue)


Previous error seen when trying to cancel overdue edition:
![Screenshot 2024-04-20 at 15 39 26](https://github.com/alphagov/travel-advice-publisher/assets/91544378/10b90337-b541-4bda-aeb9-7309beb9dbfc)


With the current fix in place:
![Screenshot 2024-04-20 at 15 39 50](https://github.com/alphagov/travel-advice-publisher/assets/91544378/705031b9-792c-4637-aa70-97fe1099a381)

