### PR TITLE
Fix invalid date behaviour

### DIFF
--- a/app/controllers/admin/schedulings_controller.rb
+++ b/app/controllers/admin/schedulings_controller.rb
@@ -37,10 +37,11 @@ private
     raise StandardError, "cannot be blank" if scheduling_params.values.any?(&:blank?)
 
     begin
-      year, month, day, hour, minute = scheduling_params.to_h.sort.map { |_, v| Integer(v) }
-      raise ArgumentError unless year.to_s.match?(/^\d{4}$/) && Date.valid_date?(year, month, day)
+      year, month, day, hour, minute = scheduling_params.to_h.sort.map { |_, v| v }
+      raise ArgumentError unless year.to_s.match?(/^\d{4}$/) && month.match?(/^\d{1,2}$/) && day.match?(/^\d{1,2}$/) \
+        && hour.match?(/^\d{1,2}$/) && minute.match?(/^\d{1,2}$/) && Date.valid_date?(year.to_i, month.to_i, day.to_i)
 
-      Time.zone.local(year, month, day, hour, minute)
+      Time.zone.local(year.to_i, month.to_i, day.to_i, hour.to_i, minute.to_i)
     rescue ArgumentError
       raise StandardError, "is not in the correct format"
     end


### PR DESCRIPTION
During testing it was discovered that the generic date incorrect error was showing for seemingly correct dates.

The previous implementation made use of an Integer conversion to ascertain whether the input is a correct date/time value. Nonetheless, Integer() will interpret input such as "0_" as octal rather than decimal, so values like "08" or "09" will not be allowed. This was introduced during refactoring and not caught by tests.

We replaced the Integer conversion with `.to_i` and added some additional tests (valid date input rather than covering invalid scenarios). We also brought back the digit number regex checks, to restrict day, month, hour and minute input to 2 digits, so that a month like "0010" is invalid.

[Trello card](https://trello.com/c/ttLGDysr/2519-invalid-date-behaviour-in-tap)

![error](https://github.com/alphagov/travel-advice-publisher/assets/91544378/cd857813-4657-4ef3-9932-67080d907257)
