### PR TITLE
Rename button from Create scheduling to Schedule to publish

### DIFF
--- a/app/views/admin/schedulings/new.html.erb
+++ b/app/views/admin/schedulings/new.html.erb
@@ -60,9 +60,9 @@
   } %>
   <div class="govuk-button-group govuk-!-margin-top-8">
     <%= render "govuk_publishing_components/components/button", {
-      text: "Create scheduling",
-      name: "Create scheduling",
-      value: "Create scheduling",
+      text: "Schedule to publish",
+      name: "Schedule to publish",
+      value: "Schedule to publish",
       type: "submit",
       primary: true,
     } %>

--- a/spec/features/schedule_edition_spec.rb
+++ b/spec/features/schedule_edition_spec.rb
@@ -25,7 +25,7 @@ feature "Edit Edition page" do
     fill_in "Day", with: "12"
     fill_in "Month", with: "12"
     fill_in "Year", with: "2999"
-    click_on "Create scheduling"
+    click_on "Schedule to publish"
 
     expect(current_path).to eq("/admin/countries/#{country_slug}")
     expect(page).to have_text "Albania travel advice is scheduled to publish on December 12, 2999 00:00 UTC."


### PR DESCRIPTION
Following FCDO suggestion to make wording more intuitive.

[trello card](https://trello.com/c/232UKPZt/2561-update-travel-advice-publisher-button-and-release-to-tap)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
