### PR TITLE
Check if robot user exists before creating it in tests and seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,8 +7,10 @@ if User.where(name: "Test user").blank?
     organisation_content_id: gds_organisation_id,
   )
 
-  User.create!(
-    name: "Scheduled Publishing Robot",
-    uid: "scheduled_publishing_robot",
-  )
+  if User.where(name: "Scheduled Publishing Robot", uid: "scheduled_publishing_robot").blank?
+    User.create!(
+      name: "Scheduled Publishing Robot",
+      uid: "scheduled_publishing_robot",
+    )
+  end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -7,11 +7,6 @@ FactoryBot.define do
     permissions { %w[signin] } if defined?(GDS::SSO::Config)
   end
 
-  factory :scheduled_publishing_robot, parent: :user do
-    uid { "scheduled_publishing_robot" }
-    name { "Scheduled Publishing Robot" }
-  end
-
   factory :travel_advice_edition do
     sequence(:country_slug) { |n| "test-country-#{n}" }
     sequence(:title) { |n| "Test Country #{n}" }

--- a/spec/features/schedule_edition_spec.rb
+++ b/spec/features/schedule_edition_spec.rb
@@ -57,7 +57,7 @@ feature "Edit Edition page" do
   end
 
   scenario "publishes a scheduled edition, archives previously published editions, and shows version history" do
-    User.create!(name: "Scheduled Publishing Robot", uid: "scheduled_publishing_robot")
+    User.where(name: "Scheduled Publishing Robot", uid: "scheduled_publishing_robot").first_or_create!
 
     country_slug = "albania"
     scheduled_publication_time = 2.hours.from_now

--- a/spec/tasks/publish_scheduled_editions_rake_spec.rb
+++ b/spec/tasks/publish_scheduled_editions_rake_spec.rb
@@ -2,7 +2,7 @@ require "rake"
 describe "publish_scheduled_editions", type: :rake_task do
   let(:country) { Country.find_by_slug("aruba") }
   let(:task) { Rake::Task["publish_scheduled_editions"] }
-  let!(:robot) { create(:scheduled_publishing_robot) }
+  let!(:robot) { User.where(name: "Scheduled Publishing Robot", uid: "scheduled_publishing_robot").first_or_create }
 
   before do
     Rake.application = nil

--- a/spec/workers/scheduled_publishing_worker_spec.rb
+++ b/spec/workers/scheduled_publishing_worker_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe ScheduledPublishingWorker, type: :worker do
     let(:country) { Country.find_by_slug("afghanistan") }
     let(:edition) { create(:scheduled_travel_advice_edition, country_slug: country.slug) }
     let(:user) { create(:user) }
-    let!(:robot) { create(:scheduled_publishing_robot) }
+    let!(:robot) { User.where(name: "Scheduled Publishing Robot", uid: "scheduled_publishing_robot").first_or_create }
 
     before do
       Sidekiq::Worker.clear_all


### PR DESCRIPTION
To ensure we do not get any errors when running tests in parallel, we are checking that the robot user exists before attempting to create it, both in tests and seeds. Noticed some flaky tests in the pipeline, where an user of uuid `scheduled_publishing_robot` already existed.


