### PR TITLE
Change summary text for the Foreign travel advice entry page (A-Z) 

### DIFF
--- a/app/presenters/index_presenter.rb
+++ b/app/presenters/index_presenter.rb
@@ -13,7 +13,7 @@ class IndexPresenter
       "document_type" => TravelAdvicePublisher::INDEX_FORMAT,
       "schema_name" => TravelAdvicePublisher::INDEX_FORMAT,
       "title" => "Foreign travel advice",
-      "description" => "Get advice about travelling abroad, including the latest information on coronavirus, safety and security, entry requirements and travel warnings.",
+      "description" => "Get advice and warnings about travel abroad, including entry requirements, safety and security, health risks and legal differences.",
       "locale" => "en",
       "publishing_app" => "travel-advice-publisher",
       "rendering_app" => "frontend",

--- a/spec/presenters/index_presenter_spec.rb
+++ b/spec/presenters/index_presenter_spec.rb
@@ -32,7 +32,7 @@ describe IndexPresenter do
           "document_type" => "travel_advice_index",
           "schema_name" => "travel_advice_index",
           "title" => "Foreign travel advice",
-          "description" => "Get advice about travelling abroad, including the latest information on coronavirus, safety and security, entry requirements and travel warnings.",
+          "description" => "Get advice and warnings about travel abroad, including entry requirements, safety and security, health risks and legal differences.",
           "locale" => "en",
           "publishing_app" => "travel-advice-publisher",
           "rendering_app" => "frontend",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Update the summary text to make it clearer for users what information is included in the country travel advice pages, including removing the reference to coronavirus.

https://govuk.zendesk.com/agent/tickets/5887594
