### PR TITLE
Upgrade to GOV.UK Frontend V5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "slimmer"
 gem "sprockets"
 gem "state_machines"
 gem "state_machines-mongoid"
-gem "uglifier"
+gem "terser"
 
 group :development do
   gem "listen"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
     domain_name (0.6.20240107)
     drb (2.2.1)
     erubi (1.13.0)
-    execjs (2.8.1)
+    execjs (2.9.1)
     factory_bot (6.4.5)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.4.3)
@@ -720,14 +720,14 @@ GEM
       state_machines-activemodel (>= 0.5.0)
     statsd-ruby (1.5.0)
     stringio (3.1.1)
+    terser (1.2.3)
+      execjs (>= 0.3.0, < 3)
     thor (1.3.2)
     timecop (0.9.10)
     timeout (0.4.1)
     ttfunk (1.7.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (2.5.0)
     uri (0.13.0)
     version_gem (1.1.4)
@@ -786,8 +786,8 @@ DEPENDENCIES
   sprockets
   state_machines
   state_machines-mongoid
+  terser
   timecop
-  uglifier
   webmock
 
 BUNDLED WITH

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,4 @@
 //= link_tree ../images
 //= link_tree ../builds
 //= link application.js
+//= link es6-components.js

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,8 @@
 //= require govuk_publishing_components/dependencies
-//= require govuk_publishing_components/all_components
+//= require govuk_publishing_components/components/govspeak
+//= require govuk_publishing_components/components/image-card
+//= require govuk_publishing_components/components/metadata
+//= require govuk_publishing_components/components/table
 //= require ./modules/parts
 //= require ./modules/broken_links
 //= require ./modules/paste_html_to_govspeak

--- a/app/assets/javascripts/es6-components.js
+++ b/app/assets/javascripts/es6-components.js
@@ -1,0 +1,18 @@
+// These modules from govuk_publishing_components
+// depend on govuk-frontend modules. govuk-frontend
+// now targets browsers that support `type="module"`.
+//
+// To gracefully prevent execution of these scripts
+// on browsers that don't support ES6, this script
+// should be included in a `type="module"` script tag
+// which will ensure they are never loaded.
+
+//= require govuk_publishing_components/components/accordion
+//= require govuk_publishing_components/components/button
+//= require govuk_publishing_components/components/checkboxes
+//= require govuk_publishing_components/components/character-count
+//= require govuk_publishing_components/components/error-summary
+//= require govuk_publishing_components/components/layout-header
+//= require govuk_publishing_components/components/radio
+//= require govuk_publishing_components/components/skip-link
+//= require govuk_publishing_components/components/tabs

--- a/app/assets/javascripts/es6-components.js
+++ b/app/assets/javascripts/es6-components.js
@@ -10,9 +10,6 @@
 //= require govuk_publishing_components/components/accordion
 //= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/checkboxes
-//= require govuk_publishing_components/components/character-count
-//= require govuk_publishing_components/components/error-summary
 //= require govuk_publishing_components/components/layout-header
 //= require govuk_publishing_components/components/radio
 //= require govuk_publishing_components/components/skip-link
-//= require govuk_publishing_components/components/tabs

--- a/config/initializers/govuk_publishing_components.rb
+++ b/config/initializers/govuk_publishing_components.rb
@@ -1,0 +1,3 @@
+GovukPublishingComponents.configure do |config|
+  config.use_es6_components = true
+end


### PR DESCRIPTION
Components that contain code from GOV.UK Frontend have been moved to a separate file, es6-components.js. This approach is used to prevent Grade X Browsers evaluating JavaScript that isn't supported by adding the type=”module” attribute to the script tag.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

[Trello](https://trello.com/c/vbqszQXq/2762-update-publishing-apps-to-govukpublishingcomponents-v4000)