### PR TITLE
Configure hosts for application

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,4 +83,12 @@ Rails.application.configure do
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end
+
+  # Enable DNS rebinding protection and other `Host` header attacks.
+  config.hosts = [
+    /travel-advice-publisher\..*gov.uk?/,
+  ]
+
+  # Skip DNS rebinding protection for the default health check endpoint.
+  config.host_authorization = { exclude: ->(request) { request.path.match?("^\/healthcheck") } }
 end


### PR DESCRIPTION
Note: the healthcheck endpoints are requested by IP, not domain, so we need to specifically exclude them from the protection.<br><br>[Trello card](https://trello.com/c/frqFN7D8)