### PR TITLE
Send last_edited_by_editor_id to publishing api

### DIFF
--- a/app/models/travel_advice_edition.rb
+++ b/app/models/travel_advice_edition.rb
@@ -197,6 +197,13 @@ class TravelAdviceEdition
     false
   end
 
+  def created_by
+    creation = actions.detect do |a|
+      a.request_type == Action::CREATE || a.request_type == Action::NEW_VERSION
+    end
+    creation.requester if creation
+  end
+
 private
 
   def state_for_slug_unique

--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -29,10 +29,11 @@ class EditionPresenter
       "rendering_app" => "government-frontend",
       "routes" => routes,
       "public_updated_at" => public_updated_at.iso8601,
+      "last_edited_by_editor_id" => edition.created_by&.uid,
       "update_type" => update_type,
       "details" => details,
       "change_note" => change_description,
-    }
+    }.compact
   end
 
 private

--- a/spec/models/travel_advice_edition_spec.rb
+++ b/spec/models/travel_advice_edition_spec.rb
@@ -861,4 +861,23 @@ describe TravelAdviceEdition do
       end
     end
   end
+
+  describe "#created_by" do
+    let!(:user) { create(:user) }
+    let!(:edition) { create(:draft_travel_advice_edition, country_slug: "foo") }
+
+    it "returns nil by default" do
+      expect(edition.created_by).to eq(nil)
+    end
+
+    it "returns the requester of the first CREATE action when present" do
+      edition.build_action_as(user, Action::CREATE)
+      expect(edition.created_by).to eq(user)
+    end
+
+    it "returns the requester of the first NEW_VERSION action when present" do
+      edition.build_action_as(user, Action::NEW_VERSION, "a comment for the new version")
+      expect(edition.created_by).to eq(user)
+    end
+  end
 end

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -186,5 +186,33 @@ describe EditionPresenter do
         expect(presented_data["update_type"]).to eq("republish")
       end
     end
+
+    describe "when there is an associated CREATE action" do
+      before do
+        edition.actions.build(
+          request_type: Action::CREATE,
+          requester: user,
+          comment: "Some comment",
+        )
+      end
+
+      it "includes the requester's uid" do
+        expect(presented_data["last_edited_by_editor_id"]).to eq(user.uid)
+      end
+    end
+
+    describe "when there is an associated NEW_VERSION action" do
+      before do
+        edition.actions.build(
+          request_type: Action::NEW_VERSION,
+          requester: user,
+          comment: "Some comment",
+        )
+      end
+
+      it "includes the requester's uid" do
+        expect(presented_data["last_edited_by_editor_id"]).to eq(user.uid)
+      end
+    end
   end
 end


### PR DESCRIPTION
This is a new field that will allow us to identify the last person who has edited an Edition within the Publishing API.

I've added a new `last_edited_by` method to the `TravelAdviceEdition` model, which uses a similar approach to the one used in Mainstream.