### PR TITLE
Change rendering app to frontend

### DIFF
--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -26,7 +26,7 @@ class EditionPresenter
       "description" => edition.overview,
       "locale" => "en",
       "publishing_app" => "travel-advice-publisher",
-      "rendering_app" => "government-frontend",
+      "rendering_app" => "frontend",
       "routes" => routes,
       "public_updated_at" => public_updated_at.iso8601,
       "last_edited_by_editor_id" => edition.created_by&.uid,

--- a/docs/further_technical_information.md
+++ b/docs/further_technical_information.md
@@ -4,7 +4,7 @@
 
 The list of countries is defined in [`lib/data/countries.yml`](../lib/data/countries.yml).
 
-Published travel advice is exposed through the [content-store](https://github.com/alphagov/content-store) and presented in [frontend](https://github.com/alphagov/frontend) and [government-frontend](https://github.com/alphagov/government-frontend).
+Published travel advice is exposed through the [content-store](https://github.com/alphagov/content-store) and presented in [frontend](https://github.com/alphagov/frontend).
 
 ### Workflow
 

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -98,7 +98,7 @@ describe EditionPresenter do
         "description" => "Something something",
         "locale" => "en",
         "publishing_app" => "travel-advice-publisher",
-        "rendering_app" => "government-frontend",
+        "rendering_app" => "frontend",
         "public_updated_at" => edition.published_at.iso8601,
         "update_type" => "major",
         "routes" => [


### PR DESCRIPTION
[Trello card](https://trello.com/c/wGMX5KPk)

# What's changed?

Change rendering app for all travel advice country pages to frontend.

# Why?

As part of [RFC 175] many of the document types that were served by government-frontend are being moved to frontend.

This change is dependent on:
https://github.com/alphagov/frontend/pull/4225

Once these changes have been merged, all of the travel advice pages will be republished using the `publishing_api:republish_editions` rake task.

[RFC 175]: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-175-frontend-fewer-apps.md

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
