### PR TITLE
Mount /component-guide

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,8 @@ Rails.application.routes.draw do
 
   root to: redirect("/admin")
 
+  mount GovukPublishingComponents::Engine, at: "/component-guide"
+
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
     GovukHealthcheck::SidekiqRedis,


### PR DESCRIPTION
This should be enabled on every app which pulls in govuk_publishing_components.

Trello: https://trello.com/c/ITcz5b1G/3417-enable-component-guide-on-non-dev-environments

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
