### PR TITLE
Add missing service-navigation import

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,6 +2,7 @@
 //= require govuk_publishing_components/components/govspeak
 //= require govuk_publishing_components/components/image-card
 //= require govuk_publishing_components/components/metadata
+//= require govuk_publishing_components/components/service-navigation
 //= require govuk_publishing_components/components/table
 //= require ./modules/parts
 //= require ./modules/broken_links


### PR DESCRIPTION
Follows from https://github.com/alphagov/travel-advice-publisher/pull/2312 where it was missed.
This is based on the instructions on https://github.com/alphagov/govuk_publishing_components/pull/4934 - Deployment steps.
No need to add the `scss` import as we have `@import "govuk_publishing_components/all_components"`.


<img width="525" height="251" alt="Screenshot 2025-08-06 at 20 19 57" src="https://github.com/user-attachments/assets/9fd2ac25-5c1f-4b55-9de6-2cf1f905c88d" />
<img width="715" height="223" alt="Screenshot 2025-08-06 at 20 20 07" src="https://github.com/user-attachments/assets/4fa149a1-c21b-4cb4-8287-7bf8d1ee9ce1" />
