### PR TITLE
Add a confirmation step to rename_country rake task [WHIT-1876]

### DIFF
--- a/lib/tasks/rename_country.rake
+++ b/lib/tasks/rename_country.rake
@@ -1,3 +1,9 @@
+require "thor"
+
+def shell
+  @shell ||= Thor::Shell::Basic.new
+end
+
 namespace :country do
   desc "Rename a country"
   task :rename, %i[old_country_slug new_country_slug] => :environment do |_task, args|
@@ -6,6 +12,10 @@ namespace :country do
     end
 
     puts "Renaming #{args.old_country_slug} to #{args.new_country_slug}..."
+    unless shell.yes?("Proceed with renaming country? (yes/no)")
+      shell.say_error "Aborted"
+      next
+    end
     TravelAdviceEdition.where(country_slug: args.old_country_slug).update_all(country_slug: args.new_country_slug)
   end
 end


### PR DESCRIPTION
I have added a confirmation step, using the Thor gem, to the above mentioned rake task. This is to ensure that the person runnning this rake task explicitly opts in to making these changes.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
