### PR TITLE
Add confirmation step to email alerts trigger rake task [WHIT-1876]

### DIFF
--- a/lib/tasks/email_alerts.rake
+++ b/lib/tasks/email_alerts.rake
@@ -1,3 +1,9 @@
+require "thor"
+
+def shell
+  @shell ||= Thor::Shell::Basic.new
+end
+
 namespace :email_alerts do
   desc "Triggers an email notification for the given edition ID"
   task :trigger, [:edition_id] => :environment do |task, args|
@@ -5,6 +11,10 @@ namespace :email_alerts do
 
     edition = TravelAdviceEdition.find(args[:edition_id])
     puts "Sending an email alert for #{edition.title}"
+    unless shell.yes?("Proceed with sending this email alert? (yes/no)")
+      shell.say_error "Aborted"
+      next
+    end
     EmailAlertApiNotifier.send_alert(edition)
   end
 end

--- a/spec/tasks/email_alerts_rake_spec.rb
+++ b/spec/tasks/email_alerts_rake_spec.rb
@@ -1,4 +1,5 @@
 require "rake"
+require "thor"
 
 describe "Email alert rake tasks", type: :rake_task do
   include GdsApi::TestHelpers::EmailAlertApi
@@ -17,6 +18,7 @@ describe "Email alert rake tasks", type: :rake_task do
     it "triggers an email notification for the given edition ID" do
       edition = create(:published_travel_advice_edition, country_slug:)
 
+      allow_any_instance_of(Thor::Shell::Basic).to receive(:yes?).and_return(true)
       task.invoke(edition.id)
 
       assert_email_alert_api_content_change_created(


### PR DESCRIPTION
I have added a confirmation step, using the Thor gem, to the above mentioned rake task. This is to ensure that the person running this rake task explicitly opts in to sending out this email alert.

I have also added a stub for the prompt in the email_alert_rake_spec file

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
