### PR TITLE
Add dependabot cooldown and open pr limit [WHIT-3369]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,15 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
   
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
 
   # Ruby needs to be upgraded manually in multiple places, so cannot
   # be upgraded by Dependabot. That effectively makes the below
@@ -21,8 +25,12 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: daily
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25
   
   - package-ecosystem: npm
     directory: /
@@ -13,6 +14,7 @@ updates:
       interval: daily
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25
 
   # Ruby needs to be upgraded manually in multiple places, so cannot
   # be upgraded by Dependabot. That effectively makes the below
@@ -27,6 +29,7 @@ updates:
       interval: weekly
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25
 
   - package-ecosystem: github-actions
     directory: /
@@ -34,3 +37,4 @@ updates:
       interval: daily
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25


### PR DESCRIPTION
Adds a dependabot cooldown of 3 days and increases the upper limit on dependabot PRs to 25, as agreed in https://gov-uk.atlassian.net/browse/WHIT-3369

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
