### PR TITLE
Update GTM `auth` and `preview` in integration [WHIT-3365]

### DIFF
--- a/app/assets/javascripts/domain-config.js
+++ b/app/assets/javascripts/domain-config.js
@@ -19,7 +19,7 @@ window.GOVUK.vars.extraDomains = [
     domains: ['travel-advice-publisher.integration.publishing.service.gov.uk'],
     initialiseGA4: true,
     id: 'GTM-KHZP7S7Q',
-    auth: '8jHx-VNEguw67iX9TBC6_g',
-    preview: 'env-50'
+    auth: 'GoGeIsCL2PK9Dv50tgM6Lg',
+    preview: 'env-172'
   }
 ]


### PR DESCRIPTION
## What

Update `auth` and `preview` of GTM attributes in `domain-config.js` for Integration environment

## Why

Required for analytics to work in Integration

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
